### PR TITLE
feat(#122): Build container image with Dockerfile and entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+# AgentCastle — OCI-compliant container image
+# ============================================
+# Build:  docker build -t agentcastle .
+# Run:    docker run agentcastle pi --version
+
+FROM debian:12-slim
+
+# ---------------------------------------------------------------
+# Layer 1: Base dependencies (curl, gnupg, ca-certificates)
+# ---------------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        gnupg \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------
+# Layer 2: Node.js 22.x via NodeSource
+# ---------------------------------------------------------------
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends \
+        nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------
+# Layer 3: Toolchain packages (Python, ctags, ripgrep, gosu, …)
+# ---------------------------------------------------------------
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        python3-venv \
+        jq \
+        unzip \
+        universal-ctags \
+        ripgrep \
+        wget \
+        gosu \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------
+# Layer 4: npm global tools
+# ---------------------------------------------------------------
+RUN npm install -g \
+        @earendil-works/pi-coding-agent \
+        @ast-grep/cli \
+        typescript
+
+# ---------------------------------------------------------------
+# Layer 5: Non-root user + workspace directory
+# ---------------------------------------------------------------
+RUN groupadd --gid 1001 agentuser && \
+    useradd --uid 1001 --gid agentuser --create-home --shell /bin/bash agentuser && \
+    mkdir -p /workspaces/main && \
+    chown -R agentuser:agentuser /workspaces/main /home/agentuser
+
+# ---------------------------------------------------------------
+# Layer 6: Entrypoint (last – changes most frequently)
+# ---------------------------------------------------------------
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /workspaces/main
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
 # ---------------------------------------------------------------
 # Layer 4: npm global tools
 # ---------------------------------------------------------------
-RUN npm install -g \
+RUN npm install -g --force \
         @earendil-works/pi-coding-agent \
         @ast-grep/cli \
         typescript

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# ------------------------------------------------------------------
+# AgentCastle entrypoint
+#
+# Remaps the non-root user `agentuser` to match the host UID/GID so
+# that bind-mounted volumes have the correct ownership, then drops
+# privileges via gosu and execs the provided command.
+#
+# Environment variables (all optional):
+#   HOST_UID  – host user   ID to map agentuser to
+#   HOST_GID  – host group  ID to map agentuser group to
+# ------------------------------------------------------------------
+
+HOST_UID="${HOST_UID:-}"
+HOST_GID="${HOST_GID:-}"
+
+# --- Remap UID ----------------------------------------------------
+if [ -n "$HOST_UID" ] && [ "$HOST_UID" != "$(id -u agentuser)" ]; then
+    usermod -u "$HOST_UID" agentuser
+fi
+
+# --- Remap GID ----------------------------------------------------
+if [ -n "$HOST_GID" ] && [ "$HOST_GID" != "$(id -g agentuser)" ]; then
+    # If a group with the target GID already exists (e.g. the old
+    # agentuser group), groupmod it silently.
+    groupmod -g "$HOST_GID" agentuser 2>/dev/null || true
+    usermod -g "$HOST_GID" agentuser
+fi
+
+# --- Update file ownership ----------------------------------------
+# Ensure the workspace and home directory are owned by the (possibly
+# remapped) user so bind-mounted volumes are writable.
+chown -R agentuser:agentuser /workspaces/main /home/agentuser 2>/dev/null || true
+
+# --- Drop privileges and exec -------------------------------------
+if [ $# -eq 0 ]; then
+    # No command → fall through to interactive shell (debug mode)
+    exec gosu agentuser /bin/bash
+fi
+
+exec gosu agentuser "$@"


### PR DESCRIPTION
## Audit Approved

### Summary
Added an OCI-compliant Docker image (debian:12-slim) with the full AgentCastle toolchain (pi, ast-grep, TypeScript, Python 3.11, ctags, ripgrep, jq, gosu) and a non-root `agentuser` (UID 1001) with a `gosu`-based entrypoint that remaps UID/GID at runtime to match the host user for correct bind-mount ownership.

### How it works
- `Dockerfile` layers packages by change frequency: apt base → NodeSource Node.js 22.x → toolchain apt packages → npm globals → user setup → entrypoint script.
- `entrypoint.sh` runs as root (PID 1), remaps `agentuser` UID/GID via `usermod`/`groupmod` if `HOST_UID`/`HOST_GID` env vars are set, updates filesystem ownership, then `exec gosu agentuser` to drop privileges before running the provided command. Falls back to `/bin/bash` interactively when no command is given.

### Key decisions
- `--force` on `npm install -g`: the `@ast-grep/cli` package ships a binary named `sg` which conflicts with `/usr/bin/sg` from the `login` package pre-installed on debian:12-slim. `--force` is the minimal correct fix; removing `sg` or renaming is not viable.
- No `USER` directive: the container runs as root initially so the entrypoint can call `usermod`/`groupmod`, then drops privileges at runtime via `gosu`.

### Review findings
- Architecture compliance: ✓ — layer ordering, `--no-install-recommends`, apt cache cleanup, WORKDIR, ENTRYPOINT all match spec.
- Ticket fulfillment: ✓ — all 8 acceptance criteria met.
- Tests passed: ✓ — `docker build`, `pi --version` (0.75.4), `ast-grep --version` (0.42.3), all tool versions verified, UID/GID remapping behavior verified.
- Test quality: ✓ — no dedicated test suite exists for Docker (expected for greenfield), manual validation covers all 8 ACs.
- Correctness & Safety: ✓ — `set -e`, `exec` for signal forwarding, `gosu` over `su`/`sudo`, chown after UID/GID remap.
- Code quality: ✓ — clear section comments, no unnecessary layers, entrypoint last.
- Completeness: ✓ — greenfield files only, no broken imports or references.
