### PR TITLE
feat(#156): session-logger: metadata.json and sessions.md overwritten every session (no session ID in filename)

### DIFF
--- a/.pi/extensions/session-logger/files.ts
+++ b/.pi/extensions/session-logger/files.ts
@@ -5,8 +5,8 @@ import type { Metadata } from "./types.js";
 export interface FileOps {
 	ensureSymlink(sessionFile: string, sessionsDir: string): Promise<void>;
 	ensureMdSymlink(sessionDir: string, mdFile: string): Promise<void>;
-	writeMetadata(sessionDir: string, metadata: Metadata): Promise<void>;
-	writeSessionReport(sessionDir: string, markdown: string): Promise<void>;
+	writeMetadata(sessionDir: string, sessionId: string, metadata: Metadata): Promise<void>;
+	writeSessionReport(sessionDir: string, sessionId: string, markdown: string): Promise<void>;
 }
 
 export function createFileOps(): FileOps {
@@ -47,13 +47,19 @@ export function createFileOps(): FileOps {
 			}
 		},
 
-		async writeMetadata(sessionDir: string, metadata: Metadata): Promise<void> {
-			await fs.writeFile(path.join(sessionDir, "metadata.json"), JSON.stringify(metadata, null, 2));
+		async writeMetadata(sessionDir: string, sessionId: string, metadata: Metadata): Promise<void> {
+			await fs.writeFile(
+				path.join(sessionDir, `${sessionId}.metadata.json`),
+				JSON.stringify(metadata, null, 2),
+			);
 		},
 
-		async writeSessionReport(sessionDir: string, markdown: string): Promise<void> {
-			const mdName = path.basename(sessionDir) + ".md";
-			const mdPath = path.join(sessionDir, mdName);
+		async writeSessionReport(
+			sessionDir: string,
+			sessionId: string,
+			markdown: string,
+		): Promise<void> {
+			const mdPath = path.join(sessionDir, `${sessionId}.md`);
 			await fs.writeFile(mdPath, markdown, "utf-8");
 		},
 	};

--- a/.pi/extensions/session-logger/index.ts
+++ b/.pi/extensions/session-logger/index.ts
@@ -80,12 +80,12 @@ export default function (pi: ExtensionAPI): void {
 		};
 
 		const sessionDir = path.dirname(sessionFile);
-		await files.writeMetadata(sessionDir, meta);
+		await files.writeMetadata(sessionDir, meta.sessionId, meta);
 
 		// Generate .md report
 		try {
 			const md = renderSessionToMarkdown(sessionFile);
-			await files.writeSessionReport(sessionDir, md);
+			await files.writeSessionReport(sessionDir, meta.sessionId, md);
 		} catch (err) {
 			console.error(`[session-logger] Failed to generate report: ${(err as Error).message}`);
 		}

--- a/README.md
+++ b/README.md
@@ -359,16 +359,20 @@ Switch the project to **Board** layout in the browser and change **Group by** to
 
 Commands: `/session-logger`, `/session-logger on`, `/session-logger off`
 
-Output format (JSONL): `.pi/sessions/<datetime>_<uuid>.jsonl`
+Output formats:
 
-Each line is a JSON event: messages, thinking blocks, tool calls, compactions.
+- **JSONL log**: `.pi/sessions/<datetime>_<uuid>.jsonl` — event stream per session
+- **Markdown report**: `.pi/sessions/<sessionId>.md` — human-readable session summary
+- **Metadata**: `.pi/sessions/<sessionId>.metadata.json` — structured session metadata
+
+Each session produces uniquely-named `.md` and `.metadata.json` files (keyed by `sessionId`), so no data is overwritten between sessions.
+
+The JSONL log is a newline-delimited JSON event stream: messages, thinking blocks, tool calls, compactions.
 
 ```bash
 ./scripts/session-query.sh 'select(.role == "user")'
 cat .pi/sessions/latest.jsonl | ./scripts/session-query.sh 'select(.tool == "bash")'
 ```
-
-Metadata stored in `.pi/sessions/metadata.json`.
 
 #### 7.4 Context & Templates
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "---",
 	"main": "index.js",
 	"scripts": {
-		"test": "node --experimental-strip-types --test test/session-logger.test.mts test/session-query.test.mts test/context-info.test.mts test/context-status-bar.test.mts test/supervisor-extensions.test.mts test/supervisor-process-context-info.test.mts test/lsp-auditor.test.mts test/lsp-auditor-settings.test.mts test/format-on-save.test.mts test/tsc-checkpoint.test.mts test/tsc-decisions.test.mts",
+		"test": "node --experimental-strip-types --test test/session-logger-files.test.mts test/session-logger-stats.test.mts test/session-logger.test.mts test/session-query.test.mts test/context-info.test.mts test/context-status-bar.test.mts test/supervisor-extensions.test.mts test/supervisor-process-context-info.test.mts test/lsp-auditor.test.mts test/lsp-auditor-settings.test.mts test/format-on-save.test.mts test/tsc-checkpoint.test.mts test/tsc-decisions.test.mts",
 		"postinstall": "bash scripts/postinstall.sh"
 	},
 	"keywords": [],

--- a/test/session-logger-files.test.mts
+++ b/test/session-logger-files.test.mts
@@ -75,12 +75,13 @@ describe("createFileOps", () => {
 		assert.ok(fs.lstatSync(latestLink).isSymbolicLink());
 	});
 
-	it("writeMetadata creates metadata.json with correct content", async () => {
-		const sessionDir = path.join(tmpDir, ".pi", "sessions", "test-session");
+	it("writeMetadata writes <sessionId>.metadata.json with correct content", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
 		fs.mkdirSync(sessionDir, { recursive: true });
+		const sessionId = "test-session-123";
 
 		const meta: Metadata = {
-			sessionId: "test-session",
+			sessionId,
 			name: "Test Session",
 			messages: 5,
 			tokens: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5, total: 165 },
@@ -91,13 +92,13 @@ describe("createFileOps", () => {
 		};
 
 		const files = createFileOps();
-		await files.writeMetadata(sessionDir, meta);
+		await files.writeMetadata(sessionDir, sessionId, meta);
 
-		const metaPath = path.join(sessionDir, "metadata.json");
-		assert.ok(fs.existsSync(metaPath));
+		const metaPath = path.join(sessionDir, `${sessionId}.metadata.json`);
+		assert.ok(fs.existsSync(metaPath), `Expected ${metaPath} to exist`);
 
 		const loaded: Metadata = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
-		assert.strictEqual(loaded.sessionId, "test-session");
+		assert.strictEqual(loaded.sessionId, sessionId);
 		assert.strictEqual(loaded.name, "Test Session");
 		assert.strictEqual(loaded.messages, 5);
 		assert.strictEqual(loaded.tokens.total, 165);
@@ -108,11 +109,12 @@ describe("createFileOps", () => {
 	});
 
 	it("writeMetadata works without optional name", async () => {
-		const sessionDir = path.join(tmpDir, ".pi", "sessions", "test-session-2");
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
 		fs.mkdirSync(sessionDir, { recursive: true });
+		const sessionId = "test-session-2";
 
 		const meta: Metadata = {
-			sessionId: "test-session-2",
+			sessionId,
 			messages: 0,
 			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			cost: 0,
@@ -122,20 +124,21 @@ describe("createFileOps", () => {
 		};
 
 		const files = createFileOps();
-		await files.writeMetadata(sessionDir, meta);
+		await files.writeMetadata(sessionDir, sessionId, meta);
 
-		const metaPath = path.join(sessionDir, "metadata.json");
+		const metaPath = path.join(sessionDir, `${sessionId}.metadata.json`);
 		const loaded: Metadata = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
-		assert.strictEqual(loaded.sessionId, "test-session-2");
+		assert.strictEqual(loaded.sessionId, sessionId);
 		assert.strictEqual(loaded.name, undefined);
 	});
 
 	it("writeMetadata formats JSON with indentation", async () => {
-		const sessionDir = path.join(tmpDir, ".pi", "sessions", "fmt-test");
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
 		fs.mkdirSync(sessionDir, { recursive: true });
+		const sessionId = "fmt-test";
 
 		const meta: Metadata = {
-			sessionId: "fmt-test",
+			sessionId,
 			messages: 1,
 			tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
 			cost: 0.0001,
@@ -145,9 +148,9 @@ describe("createFileOps", () => {
 		};
 
 		const files = createFileOps();
-		await files.writeMetadata(sessionDir, meta);
+		await files.writeMetadata(sessionDir, sessionId, meta);
 
-		const metaPath = path.join(sessionDir, "metadata.json");
+		const metaPath = path.join(sessionDir, `${sessionId}.metadata.json`);
 		const content = fs.readFileSync(metaPath, "utf-8");
 		// Verify pretty-printed: first line should be `{`, last `}`
 		const lines = content.trim().split("\n");
@@ -155,5 +158,185 @@ describe("createFileOps", () => {
 		assert.strictEqual(lines[lines.length - 1], "}");
 		// Should have indentation (leading space on non-first/last lines)
 		assert.ok(lines.length > 2, "JSON should span multiple lines with indentation");
+	});
+
+	// ---------------------------------------------------------------------------
+	// writeSessionReport tests
+	// ---------------------------------------------------------------------------
+
+	it("writeSessionReport writes <sessionId>.md with correct content", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+		const sessionId = "test-session-md-456";
+		const markdown = "# Session Report\n\nHello world";
+
+		const files = createFileOps();
+		await files.writeSessionReport(sessionDir, sessionId, markdown);
+
+		const mdPath = path.join(sessionDir, `${sessionId}.md`);
+		assert.ok(fs.existsSync(mdPath), `Expected ${mdPath} to exist`);
+		const content = fs.readFileSync(mdPath, "utf-8");
+		assert.strictEqual(content, markdown);
+	});
+
+	it("writeSessionReport with different sessionIds produces separate .md files", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+
+		const files = createFileOps();
+		await files.writeSessionReport(sessionDir, "sid-1", "md1");
+		await files.writeSessionReport(sessionDir, "sid-2", "md2");
+
+		const md1Path = path.join(sessionDir, "sid-1.md");
+		const md2Path = path.join(sessionDir, "sid-2.md");
+		assert.ok(fs.existsSync(md1Path), "First .md should exist");
+		assert.ok(fs.existsSync(md2Path), "Second .md should exist");
+		assert.strictEqual(fs.readFileSync(md1Path, "utf-8"), "md1");
+		assert.strictEqual(fs.readFileSync(md2Path, "utf-8"), "md2");
+	});
+
+	it("writeMetadata with different sessionIds produces separate .metadata.json files", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+
+		const files = createFileOps();
+		const meta1: Metadata = {
+			sessionId: "sid-a",
+			messages: 1,
+			tokens: { input: 10, output: 5, cacheRead: 0, cacheWrite: 0, total: 15 },
+			cost: 0,
+			compactions: 0,
+			modelChanges: [],
+			thinkingChanges: [],
+		};
+		const meta2: Metadata = {
+			sessionId: "sid-b",
+			messages: 2,
+			tokens: { input: 20, output: 10, cacheRead: 0, cacheWrite: 0, total: 30 },
+			cost: 0.001,
+			compactions: 1,
+			modelChanges: [],
+			thinkingChanges: [],
+		};
+
+		await files.writeMetadata(sessionDir, "sid-a", meta1);
+		await files.writeMetadata(sessionDir, "sid-b", meta2);
+
+		const meta1Path = path.join(sessionDir, "sid-a.metadata.json");
+		const meta2Path = path.join(sessionDir, "sid-b.metadata.json");
+		assert.ok(fs.existsSync(meta1Path), "First metadata should exist");
+		assert.ok(fs.existsSync(meta2Path), "Second metadata should exist");
+		const loaded1: Metadata = JSON.parse(fs.readFileSync(meta1Path, "utf-8"));
+		const loaded2: Metadata = JSON.parse(fs.readFileSync(meta2Path, "utf-8"));
+		assert.strictEqual(loaded1.messages, 1);
+		assert.strictEqual(loaded2.messages, 2);
+	});
+
+	it("old stale metadata.json (no sessionId prefix) is NOT created", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+
+		const meta: Metadata = {
+			sessionId: "sid-c",
+			messages: 0,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: 0,
+			compactions: 0,
+			modelChanges: [],
+			thinkingChanges: [],
+		};
+
+		const files = createFileOps();
+		await files.writeMetadata(sessionDir, "sid-c", meta);
+
+		const stalePath = path.join(sessionDir, "metadata.json");
+		assert.ok(!fs.existsSync(stalePath), "metadata.json without sessionId prefix should NOT exist");
+	});
+
+	it("old stale sessions.md (derived from dir basename) is NOT created", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+		// sessionDir basename is "sessions" — old code would create "sessions.md"
+
+		const files = createFileOps();
+		await files.writeSessionReport(sessionDir, "sid-d", "markdown content");
+
+		const stalePath = path.join(sessionDir, "sessions.md");
+		assert.ok(!fs.existsSync(stalePath), "sessions.md (from dir basename) should NOT exist");
+	});
+
+	it("writeMetadata with empty-string sessionId produces .metadata.json", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+
+		const meta: Metadata = {
+			sessionId: "",
+			messages: 0,
+			tokens: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			cost: 0,
+			compactions: 0,
+			modelChanges: [],
+			thinkingChanges: [],
+		};
+
+		const files = createFileOps();
+		await files.writeMetadata(sessionDir, "", meta);
+
+		const metaPath = path.join(sessionDir, ".metadata.json");
+		assert.ok(fs.existsSync(metaPath), "Empty sessionId should produce .metadata.json");
+	});
+
+	it("writeSessionReport with empty-string sessionId produces .md", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+
+		const files = createFileOps();
+		await files.writeSessionReport(sessionDir, "", "empty-id");
+
+		const mdPath = path.join(sessionDir, ".md");
+		assert.ok(fs.existsSync(mdPath), "Empty sessionId should produce .md");
+		assert.strictEqual(fs.readFileSync(mdPath, "utf-8"), "empty-id");
+	});
+
+	it("writeMetadata JSON roundtrips with full Metadata object", async () => {
+		const sessionDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionDir, { recursive: true });
+		const sessionId = "roundtrip-test";
+
+		const meta: Metadata = {
+			sessionId,
+			name: "Round Trip",
+			messages: 42,
+			tokens: { input: 1000, output: 500, cacheRead: 100, cacheWrite: 50, total: 1650 },
+			cost: 0.025,
+			compactions: 3,
+			modelChanges: [
+				{ time: "2025-01-01T00:00:00Z", model: "openai/gpt-4" },
+				{ time: "2025-01-01T01:00:00Z", model: "anthropic/claude-3" },
+			],
+			thinkingChanges: [
+				{ time: "2025-01-01T00:00:00Z", level: "low" },
+				{ time: "2025-01-01T01:00:00Z", level: "high" },
+			],
+			perTurnTokens: [
+				{ turnIndex: 0, tokens: 500, cost: 0.005, toolCount: 2, errorCount: 0 },
+				{ turnIndex: 1, tokens: 1000, cost: 0.015, toolCount: 3, errorCount: 1 },
+			],
+			toolStats: {
+				read: { calls: 5, errors: 0, totalDurationMs: 1200 },
+				write: { calls: 3, errors: 1, totalDurationMs: 800 },
+			},
+			fileModifications: [
+				{ action: "read", path: "/file1", timestamp: "2025-01-01T00:00:00Z" },
+				{ action: "write", path: "/file2", timestamp: "2025-01-01T00:01:00Z", size: 500 },
+			],
+		};
+
+		const files = createFileOps();
+		await files.writeMetadata(sessionDir, sessionId, meta);
+
+		const metaPath = path.join(sessionDir, `${sessionId}.metadata.json`);
+		const loaded: Metadata = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+		assert.deepStrictEqual(loaded, meta);
 	});
 });

--- a/test/session-logger.test.mts
+++ b/test/session-logger.test.mts
@@ -807,11 +807,14 @@ describe("Session init / filesystem", () => {
 		assert.ok(fs.readlinkSync(latestLink).includes("session2.jsonl"));
 	});
 
-	it("metadata.json written on shutdown", () => {
-		const sessionDir = path.join(tmpDir, ".pi", "sessions", "abc123");
-		fs.mkdirSync(sessionDir, { recursive: true });
-		const meta = {
-			sessionId: "abc123",
+	it("two sessions — both <sessionId>.metadata.json and .md files coexist", () => {
+		const sessionsDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionsDir, { recursive: true });
+
+		// Session 1
+		const sid1 = "session-111";
+		const meta1 = {
+			sessionId: sid1,
 			messages: 5,
 			tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
 			cost: 0.0015,
@@ -819,8 +822,68 @@ describe("Session init / filesystem", () => {
 			modelChanges: [],
 			thinkingChanges: [],
 		};
-		fs.writeFileSync(path.join(sessionDir, "metadata.json"), JSON.stringify(meta, null, 2));
-		const loaded = JSON.parse(fs.readFileSync(path.join(sessionDir, "metadata.json"), "utf-8"));
+		fs.writeFileSync(
+			path.join(sessionsDir, `${sid1}.metadata.json`),
+			JSON.stringify(meta1, null, 2),
+		);
+		fs.writeFileSync(path.join(sessionsDir, `${sid1}.md`), "# Session 1");
+
+		// Session 2
+		const sid2 = "session-222";
+		const meta2 = {
+			sessionId: sid2,
+			messages: 10,
+			tokens: { input: 200, output: 100, cacheRead: 0, cacheWrite: 0, total: 300 },
+			cost: 0.003,
+			compactions: 1,
+			modelChanges: [],
+			thinkingChanges: [],
+		};
+		fs.writeFileSync(
+			path.join(sessionsDir, `${sid2}.metadata.json`),
+			JSON.stringify(meta2, null, 2),
+		);
+		fs.writeFileSync(path.join(sessionsDir, `${sid2}.md`), "# Session 2");
+
+		// Assert all 4 files coexist
+		assert.ok(fs.existsSync(path.join(sessionsDir, `${sid1}.metadata.json`)), "Session1 metadata");
+		assert.ok(fs.existsSync(path.join(sessionsDir, `${sid1}.md`)), "Session1 md");
+		assert.ok(fs.existsSync(path.join(sessionsDir, `${sid2}.metadata.json`)), "Session2 metadata");
+		assert.ok(fs.existsSync(path.join(sessionsDir, `${sid2}.md`)), "Session2 md");
+
+		// Assert no stale files
+		assert.ok(!fs.existsSync(path.join(sessionsDir, "metadata.json")), "No stale metadata.json");
+		assert.ok(!fs.existsSync(path.join(sessionsDir, "sessions.md")), "No stale sessions.md");
+
+		// Verify content preserved
+		assert.strictEqual(
+			JSON.parse(fs.readFileSync(path.join(sessionsDir, `${sid1}.metadata.json`), "utf-8"))
+				.messages,
+			5,
+		);
+		assert.strictEqual(
+			JSON.parse(fs.readFileSync(path.join(sessionsDir, `${sid2}.metadata.json`), "utf-8"))
+				.messages,
+			10,
+		);
+	});
+
+	it("<sessionId>.metadata.json written on shutdown", () => {
+		const sessionsDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionsDir, { recursive: true });
+		const sessionId = "abc123";
+		const meta = {
+			sessionId,
+			messages: 5,
+			tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, total: 150 },
+			cost: 0.0015,
+			compactions: 0,
+			modelChanges: [],
+			thinkingChanges: [],
+		};
+		const metaPath = path.join(sessionsDir, `${sessionId}.metadata.json`);
+		fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+		const loaded = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
 		assert.strictEqual(loaded.messages, 5);
 	});
 });


### PR DESCRIPTION
## Audit Approved

### Summary
Added `sessionId` parameter to `writeMetadata` and `writeSessionReport` in `files.ts`. Both functions now write `<sessionId>.metadata.json` and `<sessionId>.md` respectively instead of static filenames. Call sites in `index.ts` pass `meta.sessionId` from the session shutdown handler.

### How it works
- `FileOps` interface: `writeMetadata(sessionDir, sessionId, metadata)` → writes ``path.join(sessionDir, `${sessionId}.metadata.json`)``
- `FileOps` interface: `writeSessionReport(sessionDir, sessionId, markdown)` → writes ``path.join(sessionDir, `${sessionId}.md`)``
- `index.ts`: both calls updated to pass `meta.sessionId` as second argument

### Key decisions
- Rejected per-session subdirectory approach — flat naming matches Pi's own `.jsonl` convention and avoids directory lifecycle complexity
- `ensureMdSymlink` in `files.ts` remains uncalled — pre-existing defect out of scope for this fix

### Review findings
- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (64/64, ran: `node --experimental-strip-types --test test/session-logger-files.test.mts test/session-logger-stats.test.mts test/session-logger.test.mts`)
- Test quality: ✓ — 8 new tests added covering filenames, coexistence, stale-file absence, edge cases, JSON roundtrip
- Correctness & Safety: ✓ — no secrets, no error swallowing, boundary logic unchanged
- Code quality: ✓ — no duplication, clear naming, focused functions
- Completeness: ✓ — all edge cases (empty sessionId), stale file assertions, two-session coexistence verified
