### PR TITLE
feat(#175): Merge ranked_map and map_codebase into one unified tool

### DIFF
--- a/.pi/agents/architect.md
+++ b/.pi/agents/architect.md
@@ -4,12 +4,12 @@ description: Proposes target architecture/implementation approach via a GitHub i
 tools: read, bash, structural_search, ripgrep_search
 model: opencode-go/deepseek-v4-pro
 thinking: high
-extensions: "caveman,codebase-mapper,crawl4ai,piignore,ripgrep-search,structural-analyzer"
+extensions: "caveman,crawl4ai,piignore,ripgrep-search,structural-analyzer"
 ---
 
 🛠 Tool Discipline — Architect
 - **Explore code structure:** Use `structural_search` for AST-aware discovery (function defs, class declarations, method calls, try/catch) — NOT `bash | grep`. AST queries find patterns across files without noise from comments/strings.
-- **Find symbols:** Use `map_codebase` for file/symbol overview — NOT `bash | grep` for class/function names
+- **Find symbols:** Use `ranked_map` (omit query for full dump) for file/symbol overview — NOT `bash | grep` for class/function names
 - **Search codebase:** Use `ripgrep_search` for text patterns — NOT `bash | grep`, `bash | rg`
 - **Read files:** Use `read(path, offset?, limit?)` — NOT `bash cat`, `bash head`
 - **Error means rethink:** If tool errors, change approach — different args, different tool, or ask user. Do NOT retry same tool+args.

--- a/.pi/agents/auditor.md
+++ b/.pi/agents/auditor.md
@@ -4,7 +4,7 @@ description: Reviews implementation, creates PR if approved, rejects back to Imp
 tools: read, bash, structural_search, ripgrep_search
 model: opencode-go/minimax-m2.7
 thinking: high
-extensions: "caveman,codebase-mapper,crawl4ai,piignore,ripgrep-search,structural-analyzer"
+extensions: "caveman,crawl4ai,piignore,ripgrep-search,structural-analyzer"
 ---
 
 🛠 Tool Discipline — Auditor

--- a/.pi/agents/developer.md
+++ b/.pi/agents/developer.md
@@ -4,7 +4,7 @@ description: Implements a GitHub issue in an isolated git worktree based on arch
 tools: read, bash, write, edit, structural_search, ripgrep_search
 model: opencode-go/deepseek-v4-flash
 thinking: medium
-extensions: "caveman,codebase-mapper,crawl4ai,format-on-save,piignore,ripgrep-search,tsc-checkpoint,structural-analyzer"
+extensions: "caveman,crawl4ai,format-on-save,piignore,ripgrep-search,tsc-checkpoint,structural-analyzer"
 ---
 
 🛠 Tool Discipline — Developer

--- a/.pi/agents/researcher.md
+++ b/.pi/agents/researcher.md
@@ -4,7 +4,7 @@ description: Searches the public web for best practices, recent library versions
 tools: read, bash, structural_search, ripgrep_search
 model: opencode-go/deepseek-v4-flash
 thinking: medium
-extensions: "caveman,codebase-mapper,crawl4ai,piignore,ripgrep-search,structural-analyzer"
+extensions: "caveman,crawl4ai,piignore,ripgrep-search,structural-analyzer"
 ---
 
 🛠 Tool Discipline — Researcher

--- a/.pi/agents/test-designer.md
+++ b/.pi/agents/test-designer.md
@@ -4,7 +4,7 @@ description: Reads a GitHub issue (including architecture comment) and writes a 
 tools: read, bash, structural_search, ripgrep_search
 model: opencode-go/deepseek-v4-flash
 thinking: medium
-extensions: "caveman,codebase-mapper,crawl4ai,piignore,ripgrep-search,structural-analyzer"
+extensions: "caveman,crawl4ai,piignore,ripgrep-search,structural-analyzer"
 ---
 
 🛠 Tool Discipline — TestDesigner

--- a/.pi/extensions/codebase-mapper.ts
+++ b/.pi/extensions/codebase-mapper.ts
@@ -1,12 +1,10 @@
 /**
- * codebase-mapper — Scans codebase structure with ctags and returns symbol hierarchy
+ * codebase-mapper — Library layer: ctags parsing, grouping, command building.
  *
- * Provides the map_codebase tool. Discovers all symbols (classes, functions,
- * methods, variables) grouped by file. Returns metadata only — never file contents.
+ * This module exports library functions consumed by ranked-map.ts.
+ * Tool registration has been migrated to ranked-map.ts (ranked_map tool).
+ * No tool is registered from this module.
  */
-
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { Type } from "typebox";
 
 // ═══════════════════════════════════════════════════════════════════════
 // Types
@@ -135,7 +133,16 @@ export function buildCtagsArgs(
 	targetDir: string,
 	maxDepth: number,
 ): { command: string; args: string[] } {
-	const args = ["-R", "--output-format=json", "--exclude=node_modules", "--exclude=.git", "--exclude=*.json", "--exclude=*.min.js", "--exclude=*.css", "--exclude=static"];
+	const args = [
+		"-R",
+		"--output-format=json",
+		"--exclude=node_modules",
+		"--exclude=.git",
+		"--exclude=*.json",
+		"--exclude=*.min.js",
+		"--exclude=*.css",
+		"--exclude=static",
+	];
 
 	if (maxDepth > 0) {
 		args.push(`--maxdepth=${maxDepth}`);
@@ -144,142 +151,4 @@ export function buildCtagsArgs(
 	args.push(targetDir);
 
 	return { command: "ctags", args };
-}
-
-// ═══════════════════════════════════════════════════════════════════════
-// Extension
-// ═══════════════════════════════════════════════════════════════════════
-
-export default function codebaseMapper(pi: ExtensionAPI): void {
-	pi.registerTool({
-		name: "map_codebase",
-		label: "Map Codebase",
-		description:
-			"Run ctags (Universal Ctags) on a target directory and return a compressed, " +
-			"hierarchical tree of symbols (classes, functions, methods, variables) grouped by file. " +
-			"Output: JSON object where keys are file paths and values are arrays of " +
-			'{ "type": string, "name": string, "line": number } entries. ' +
-			"Use this to answer 'What files and functions exist?' before reading any files. " +
-			"This tool is strictly read-only and metadata-focused. " +
-			"It never returns file contents or function bodies. " +
-			"Requires universal-ctags compiled with JSON output support.",
-		promptSnippet: "Map a codebase directory by running ctags and returning symbol hierarchy",
-		promptGuidelines: [
-			"Use map_codebase at the start of a task to get a macro-level skeleton of the repository. This answers 'What files and functions exist?' without reading individual files.",
-			"Default target_directory is project root, default max_depth is 3. Pass max_depth=0 for unlimited depth, or max_depth=1-3 for a top-level overview.",
-			"Combine map_codebase results with read to inspect specific functions by file path and line number.",
-			"Run map_codebase once and reuse the result — re-running is expensive for large codebases.",
-		],
-		parameters: Type.Object({
-			target_directory: Type.Optional(
-				Type.String({
-					default: ".",
-					description: "Path to the directory to map (default: current working directory)",
-				}),
-			),
-			max_depth: Type.Optional(
-				Type.Number({
-					default: 3,
-					description:
-						"Maximum directory recursion depth (default: 3 for a top-level overview, 0 for unlimited). " +
-						"Use small values (1-3) for a top-level overview to avoid overloading context.",
-				}),
-			),
-		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const targetDir = params.target_directory || ".";
-			const maxDepth = params.max_depth ?? 3;
-			const cwd = ctx.cwd;
-
-			// Build and run ctags command
-			const { command, args } = buildCtagsArgs(targetDir, maxDepth);
-
-			const result = await pi.exec(command, args, {
-				cwd,
-				timeout: 30_000,
-			});
-
-			if (result.code !== 0) {
-				// ctags may produce stderr warnings about skipped files
-				// but still output valid JSONL to stdout — only fail if stdout is empty
-				if (!result.stdout || result.stdout.trim().length === 0) {
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text:
-									`ctags failed (exit code ${result.code}): ` +
-									(result.stderr || "unknown error") +
-									"\n\nEnsure universal-ctags is installed with JSON output support (`ctags --list-output-formats`).",
-							},
-						],
-						details: { success: false, exitCode: result.code, stderr: result.stderr } as Record<
-							string,
-							unknown
-						>,
-					};
-				}
-			}
-
-			// Parse and group
-			const map = buildCodebaseMap(result.stdout);
-
-			// Apply output size cap (~50 KB / ~750 symbols)
-			const MAX_OUTPUT_SYMBOLS = 750;
-			const allEntries = Object.entries(map);
-			let includedEntries: [string, SymbolEntry[]][] = allEntries;
-			let truncated = false;
-
-			const totalSymbols = allEntries.reduce((sum, [, entries]) => sum + entries.length, 0);
-			if (totalSymbols > MAX_OUTPUT_SYMBOLS) {
-				// Sort by symbol count descending, keep the most symbol-dense files
-				allEntries.sort((a, b) => b[1].length - a[1].length);
-				let count = 0;
-				const cutoff = allEntries.findIndex(([, entries]) => {
-					count += entries.length;
-					return count > MAX_OUTPUT_SYMBOLS;
-				});
-				includedEntries = allEntries.slice(0, cutoff === -1 ? allEntries.length : cutoff);
-				truncated = true;
-			}
-
-			const truncatedMap: CodebaseMap = Object.fromEntries(includedEntries);
-
-			// Format as pretty JSON for LLM consumption
-			const json = JSON.stringify(truncatedMap, null, 2);
-
-			const symbolCount = totalSymbols;
-			const fileCount = allEntries.length;
-			const includedSymbolCount = truncated
-				? Object.values(truncatedMap).flat().length
-				: symbolCount;
-			const includedFileCount = truncated
-				? Object.keys(truncatedMap).length
-				: fileCount;
-
-			const headerNote = truncated
-				? "⚠️ Output truncated: showing " +
-					`${includedSymbolCount} of ${symbolCount} symbols ` +
-					`(top ${includedFileCount} of ${fileCount} files by symbol count). ` +
-					"Retry with a smaller target_directory or max_depth for focused results.\n\n"
-				: "";
-
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text:
-							`Codebase map for: ${targetDir}\n` +
-							`Files: ${includedFileCount}${truncated ? ` of ${fileCount}` : ""}, ` +
-							`Symbols: ${includedSymbolCount}${truncated ? ` of ${symbolCount}` : ""}\n\n` +
-							headerNote +
-							"```json\n" +
-							json +
-							"\n```",
-					},
-				],
-				details: { success: true, fileCount, symbolCount, map } as Record<string, unknown>,
-			};
-		},
-	});
 }

--- a/.pi/extensions/ranked-map.ts
+++ b/.pi/extensions/ranked-map.ts
@@ -25,6 +25,7 @@ export interface RankedMapConfig {
 	tokenBudget: number;
 	recencyWindowDays: number;
 	cacheTtlHours: number;
+	autoThreshold: number;
 	weights: { keyword: number; recency: number };
 }
 
@@ -52,6 +53,7 @@ export interface RankedMapResult {
 	total_tokens: number;
 	budget: number;
 	truncated: boolean;
+	mode: "ranked" | "full_dump";
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -62,6 +64,7 @@ const DEFAULT_CONFIG: RankedMapConfig = {
 	tokenBudget: 2048,
 	recencyWindowDays: 30,
 	cacheTtlHours: 24,
+	autoThreshold: 20000,
 	weights: { keyword: 0.5, recency: 0.3 },
 };
 
@@ -78,6 +81,63 @@ const MAX_RECENCY_WINDOW_DAYS = 365;
 export function estimateTokens(text: string): number {
 	if (!text) return 0;
 	return Math.ceil(text.length / 4);
+}
+
+/**
+ * Determine tool mode based on query presence, symbol count, and autoThreshold.
+ * query provided → ranked (keyword + recency)
+ * no query, totalSymbols <= autoThreshold → full_dump (path-sorted)
+ * no query, totalSymbols > autoThreshold → ranked (recency-only)
+ */
+export function selectMode(
+	query: string,
+	totalSymbols: number,
+	autoThreshold: number,
+): "ranked" | "full_dump" {
+	if (query.trim()) return "ranked";
+	if (totalSymbols <= autoThreshold) return "full_dump";
+	return "ranked";
+}
+
+/**
+ * Dump all symbols sorted by file path, filling greedily within token budget.
+ * Each file gets score=0 and empty preview.
+ */
+export function dumpAllFiles(
+	symbols: Record<string, SymbolEntry[]>,
+	tokenBudget: number,
+): { files: RankedFileScore[]; totalTokens: number; truncated: boolean } {
+	const filePaths = Object.keys(symbols).sort();
+	const files: RankedFileScore[] = [];
+	let totalTokens = 0;
+	let truncated = false;
+	const PREVIEW_TOKEN_ESTIMATE = 50;
+
+	for (const path of filePaths) {
+		const syms = symbols[path] ?? [];
+		const symText = formatSymbols(syms, path);
+		const entryTokens = estimateTokens(symText) + PREVIEW_TOKEN_ESTIMATE;
+
+		if (tokenBudget <= 0) {
+			truncated = true;
+			break;
+		}
+
+		if (totalTokens + entryTokens > tokenBudget && totalTokens > 0) {
+			truncated = true;
+			break;
+		}
+
+		files.push({
+			path,
+			score: 0,
+			symbols: symText,
+			preview: "",
+		});
+		totalTokens += entryTokens;
+	}
+
+	return { files, totalTokens, truncated };
 }
 
 /**
@@ -111,6 +171,17 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 			rm.recencyWindowDays > 0
 		) {
 			recencyWindowDays = Math.min(rm.recencyWindowDays, MAX_RECENCY_WINDOW_DAYS);
+		}
+
+		// autoThreshold: non-negative integer (0 = always-ranked)
+		let autoThreshold = DEFAULT_CONFIG.autoThreshold;
+		if (
+			typeof rm.autoThreshold === "number" &&
+			Number.isFinite(rm.autoThreshold) &&
+			Number.isInteger(rm.autoThreshold) &&
+			rm.autoThreshold >= 0
+		) {
+			autoThreshold = rm.autoThreshold;
 		}
 
 		let cacheTtlHours = DEFAULT_CONFIG.cacheTtlHours;
@@ -157,6 +228,7 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 			tokenBudget,
 			recencyWindowDays,
 			cacheTtlHours,
+			autoThreshold,
 			weights: { keyword: kwWeight, recency: recWeight },
 		};
 	} catch {
@@ -308,6 +380,7 @@ export function formatOutput(
 	rankedFiles: RankedFileScore[],
 	budget: number,
 	truncated: boolean,
+	mode: "ranked" | "full_dump" = "ranked",
 ): RankedMapResult {
 	return {
 		files: rankedFiles.map((f) => ({
@@ -320,6 +393,7 @@ export function formatOutput(
 		),
 		budget,
 		truncated,
+		mode,
 	};
 }
 
@@ -496,18 +570,19 @@ export default function rankedMap(pi: ExtensionAPI): void {
 		name: "ranked_map",
 		label: "Ranked Repo Map",
 		description:
-			"Ranked file index using keyword overlap (ripgrep) and git recency scoring. " +
-			"Returns the most relevant subset of the codebase within a configurable token budget. " +
-			"Output: JSON with files array (path, score, symbols, preview), total_tokens, budget, truncated. " +
-			"Reuses ctags symbol index (cached) + rg for keyword matching + git log for recency. " +
-			"Recommended over map_codebase for large repos (submodule-scale, 50K+ files) — " +
-			"~99% token reduction compared to full map_codebase dump.",
+			"Codebase symbol index with auto-mode detection. " +
+			"With a query: ranks files by keyword overlap (ripgrep) + git recency scoring. " +
+			"Without query on repos ≤ autoThreshold (default 20K symbols): returns all symbols sorted by path (full dump). " +
+			"Without query on larger repos: ranks by recency only. " +
+			"Output: JSON with files array (path, score, symbols, preview), total_tokens, budget, truncated, mode. " +
+			"Replaces the old map_codebase tool — call ranked_map with or without a query for all use cases.",
 		promptSnippet:
-			"Ranked codebase map by keyword relevance and git recency — returns top files within token budget",
+			"Codebase symbol map with auto-mode: query → ranked, no query + small repo → full dump, no query + large repo → recency-ranked",
 		promptGuidelines: [
-			"Use ranked_map instead of map_codebase for large repos (submodule-scale, 50K+ files). Map_codebase dumps ALL symbols and can consume 280K+ tokens; ranked_map returns only the most relevant subset (~2K tokens).",
-			"Pass a `query` describing what you're looking for (e.g. 'login auth token') to rank by keyword relevance. Without query, ranking falls back to git recency only.",
+			"ranked_map replaces map_codebase — use it for all codebase browsing. Auto-mode: pass `query` for ranked results, omit for full dump (small repos) or recency-ranked (large repos).",
+			"Pass a `query` describing what you're looking for (e.g. 'login auth token') to rank by keyword relevance. Without query, the tool auto-selects full dump or recency-ranked based on repo size.",
 			"Set `tokenBudget` to control output size (default 2048 tokens). Smaller budget = fewer files = faster response.",
+			"Configure autoThreshold in .pi/settings.json rankedMap.autoThreshold (default 20000). Set to 0 for always-ranked.",
 			"The tool is on-demand (not auto-injected). Call it when you need codebase context, not every turn.",
 		],
 		parameters: Type.Object({
@@ -618,22 +693,35 @@ export default function rankedMap(pi: ExtensionAPI): void {
 				}
 			}
 
-			// Compute keyword scores (if query provided)
-			let keywordScores: Record<string, number> = {};
-			if (query) {
-				const { fileMatches, terms } = runKeywordSearch(query, targetDir, cwd);
-				keywordScores = computeKeywordScores(fileMatches, terms);
+			// Mode selection
+			const totalSymbols = Object.values(index.symbols).flat().length;
+			const mode = selectMode(query, totalSymbols, config.autoThreshold);
+
+			let ranked: { files: RankedFileScore[]; totalTokens: number; truncated: boolean };
+			let modeLabel: string;
+
+			if (mode === "full_dump") {
+				// Full dump mode: all files sorted by path, score=0, no preview
+				ranked = dumpAllFiles(index.symbols, budget);
+				modeLabel = "full_dump";
+			} else {
+				// Ranked mode: compute keyword scores (if query provided) + recency scores
+				let keywordScores: Record<string, number> = {};
+				if (query) {
+					const { fileMatches, terms } = runKeywordSearch(query, targetDir, cwd);
+					keywordScores = computeKeywordScores(fileMatches, terms);
+				}
+
+				const fileDates = runGitRecency(config.recencyWindowDays, cwd);
+				const recencyScores = computeRecencyScores(fileDates, config.recencyWindowDays);
+
+				ranked = rankFiles(keywordScores, recencyScores, config.weights, budget, index.symbols);
+				modeLabel = "ranked";
 			}
 
-			// Compute recency scores
-			const fileDates = runGitRecency(config.recencyWindowDays, cwd);
-			const recencyScores = computeRecencyScores(fileDates, config.recencyWindowDays);
-
-			// Rank files
-			const ranked = rankFiles(keywordScores, recencyScores, config.weights, budget, index.symbols);
-
-			// Fill previews from actual file contents
+			// Fill previews from actual file contents (only for ranked mode; full_dump uses empty previews)
 			const filesWithPreviews = ranked.files.map((f) => {
+				if (mode === "full_dump") return f; // preview already empty
 				let preview = "";
 				try {
 					const fullPath = resolve(cwd, targetDir, f.path);
@@ -647,13 +735,21 @@ export default function rankedMap(pi: ExtensionAPI): void {
 				return { ...f, preview };
 			});
 
-			const output = formatOutput(filesWithPreviews, budget, ranked.truncated);
+			const output = formatOutput(
+				filesWithPreviews,
+				budget,
+				ranked.truncated,
+				modeLabel as "ranked" | "full_dump",
+			);
 
 			// Build summary text
 			const symbolCount = Object.values(index.symbols).flat().length;
 			const fileCount = Object.keys(index.symbols).length;
 
-			const queryInfo = query ? `query="${query}", ` : "no query, ";
+			const modeLabel =
+				output.mode === "full_dump"
+					? "full dump"
+					: `ranked${query ? ` (query="${query}")` : " (recency-only)"}`;
 			const truncatedInfo = output.truncated
 				? ` (truncated to ${output.files.length} files)`
 				: ` (${output.files.length} files)`;
@@ -663,8 +759,8 @@ export default function rankedMap(pi: ExtensionAPI): void {
 					{
 						type: "text" as const,
 						text:
-							`Ranked repo map for: ${targetDir}\n` +
-							`${queryInfo}${output.total_tokens} of ${budget} tokens used${truncatedInfo}\n` +
+							`${output.mode === "full_dump" ? "Codebase map" : "Ranked repo map"} for: ${targetDir}\n` +
+							`Mode: ${modeLabel}, ${output.total_tokens} of ${budget} tokens used${truncatedInfo}\n` +
 							`Index: ${fileCount} files, ${symbolCount} symbols\n\n` +
 							"```json\n" +
 							JSON.stringify(output, null, 2) +

--- a/.pi/extensions/ripgrep-search.ts
+++ b/.pi/extensions/ripgrep-search.ts
@@ -72,12 +72,20 @@ export function loadSearchConfig(cwd: string): SearchConfig {
 		if (!search) return { ...DEFAULT_CONFIG };
 
 		let searchBackend: SearchConfig["searchBackend"] = DEFAULT_CONFIG.searchBackend;
-		if (search.searchBackend === "ripgrep" || search.searchBackend === "grep" || search.searchBackend === "auto") {
+		if (
+			search.searchBackend === "ripgrep" ||
+			search.searchBackend === "grep" ||
+			search.searchBackend === "auto"
+		) {
 			searchBackend = search.searchBackend;
 		}
 
 		let maxLineLength = MAX_LINE_LENGTH_DEFAULT;
-		if (typeof search.maxLineLength === "number" && Number.isInteger(search.maxLineLength) && search.maxLineLength > 0) {
+		if (
+			typeof search.maxLineLength === "number" &&
+			Number.isInteger(search.maxLineLength) &&
+			search.maxLineLength > 0
+		) {
 			maxLineLength = Math.min(search.maxLineLength, MAX_LINE_LENGTH_MAX);
 		}
 
@@ -93,10 +101,17 @@ export function loadSearchConfig(cwd: string): SearchConfig {
  * - "grep": forces grep (skips rg detection)
  * - "auto": uses ripgrep if available, grep otherwise
  */
-export function resolveBackend(config: SearchConfig, rgAvailable: boolean): { backend: "ripgrep" | "grep"; error?: string } {
+export function resolveBackend(
+	config: SearchConfig,
+	rgAvailable: boolean,
+): { backend: "ripgrep" | "grep"; error?: string } {
 	if (config.searchBackend === "ripgrep") {
 		if (!rgAvailable) {
-			return { backend: "ripgrep", error: "ripgrep not found on PATH. Install rg or set searchBackend to 'auto' or 'grep' in .pi/settings.json." };
+			return {
+				backend: "ripgrep",
+				error:
+					"ripgrep not found on PATH. Install rg or set searchBackend to 'auto' or 'grep' in .pi/settings.json.",
+			};
 		}
 		return { backend: "ripgrep" };
 	}
@@ -160,7 +175,10 @@ export function buildGrepArgs(
  * Since grep lacks column info,
  * column defaults to 1.
  */
-export function parseGrepOutput(raw: string | null | undefined, maxResults: number = Infinity): RgResult {
+export function parseGrepOutput(
+	raw: string | null | undefined,
+	maxResults: number = Infinity,
+): RgResult {
 	if (!raw) {
 		return { total_returned: 0, results: [] };
 	}
@@ -210,7 +228,7 @@ export function parseGrepOutput(raw: string | null | undefined, maxResults: numb
  * Collision rule:
  * - Empty or whitespace-only strings are rejected
  * - Patterns starting with `class `, `def `, `function ` are rejected —
- *   agent should use map_codebase (ctags) for class/def searches
+ *   agent should use ranked_map (ctags) for class/def searches
  * - Patterns containing `$` or `{` (structural AST syntax) are rejected —
  *   agent should use structural_search (ast-grep) for structural searches
  *
@@ -228,15 +246,15 @@ export function validateQuery(query: string): string | null {
 
 	// Reject patterns that look like structural/symbol searches
 	if (trimmed.startsWith("class ")) {
-		return `Query "${trimmed}" looks like a class definition search. Use map_codebase (ctags) to find class definitions, not ripgrep_search.`;
+		return `Query "${trimmed}" looks like a class definition search. Use ranked_map (ctags) to find class definitions, not ripgrep_search.`;
 	}
 
 	if (trimmed.startsWith("def ")) {
-		return `Query "${trimmed}" looks like a function definition search. Use map_codebase (ctags) to find function definitions, not ripgrep_search.`;
+		return `Query "${trimmed}" looks like a function definition search. Use ranked_map (ctags) to find function definitions, not ripgrep_search.`;
 	}
 
 	if (trimmed.startsWith("function ")) {
-		return `Query "${trimmed}" looks like a function definition search. Use map_codebase (ctags) to find function definitions, not ripgrep_search.`;
+		return `Query "${trimmed}" looks like a function definition search. Use ranked_map (ctags) to find function definitions, not ripgrep_search.`;
 	}
 
 	// Reject patterns with structural AST syntax ($ or {)
@@ -288,7 +306,10 @@ export function buildRgArgs(
  * Malformed lines (missing colons, non-numeric line/column) → skipped.
  * Lines with colons in the text portion → text is everything after third colon.
  */
-export function parseVimgrepOutput(raw: string | null | undefined, maxResults: number = Infinity): RgResult {
+export function parseVimgrepOutput(
+	raw: string | null | undefined,
+	maxResults: number = Infinity,
+): RgResult {
 	if (!raw) {
 		return { total_returned: 0, results: [] };
 	}
@@ -389,7 +410,7 @@ export default function ripgrepSearch(pi: ExtensionAPI): void {
 		promptSnippet: "Search codebase for literal text or regex using ripgrep",
 		promptGuidelines: [
 			"Use ripgrep_search for literal text searches — magic numbers, hardcoded strings, error messages, TODOs, configuration values.",
-			"Do NOT use ripgrep_search to find function definitions, class declarations, or structural code patterns. For those, use map_codebase (ctags) for symbol lookup or structural_search (ast-grep) for AST-aware pattern matching.",
+			"Do NOT use ripgrep_search to find function definitions, class declarations, or structural code patterns. For those, use ranked_map (ctags) for symbol lookup or structural_search (ast-grep) for AST-aware pattern matching.",
 			"ripgrep_search respects .gitignore natively — no extra config needed to skip ignored files.",
 			"Default max_count is 10 (limited per file). Override for targeted searches with fewer results needed.",
 			"Default directory is current working directory ('.'). Pass an explicit path to scope the search.",
@@ -399,7 +420,7 @@ export default function ripgrepSearch(pi: ExtensionAPI): void {
 				description:
 					"The literal text or regex to find. Supports regex patterns (e.g., 'TODO|FIXME'). " +
 					"Collision rule: patterns starting with 'class ', 'def ', 'function ', or containing " +
-					"'$' or '{' are rejected — use structural_search or map_codebase instead.",
+					"'$' or '{' are rejected — use structural_search or ranked_map instead.",
 			}),
 			directory: Type.Optional(
 				Type.String({
@@ -448,7 +469,10 @@ export default function ripgrepSearch(pi: ExtensionAPI): void {
 								text: `"${directory}" is a file, not a directory.`,
 							},
 						],
-						details: { success: false, error: `"${directory}" is a file, not a directory.` } as Record<string, unknown>,
+						details: {
+							success: false,
+							error: `"${directory}" is a file, not a directory.`,
+						} as Record<string, unknown>,
 						isError: true,
 					};
 				}
@@ -460,15 +484,13 @@ export default function ripgrepSearch(pi: ExtensionAPI): void {
 					try {
 						const entries = await readdir(ctx.cwd, { withFileTypes: true });
 						validDirs = entries
-							.filter(e => e.isDirectory())
-							.map(e => e.name + "/")
+							.filter((e) => e.isDirectory())
+							.map((e) => e.name + "/")
 							.sort();
 					} catch {
 						// ignore readdir errors
 					}
-					const dirList = validDirs.length > 0
-						? ` Valid directories: ${validDirs.join(", ")}`
-						: "";
+					const dirList = validDirs.length > 0 ? ` Valid directories: ${validDirs.join(", ")}` : "";
 					return {
 						content: [
 							{
@@ -491,7 +513,10 @@ export default function ripgrepSearch(pi: ExtensionAPI): void {
 								text: `"${directory}" is a file, not a directory.`,
 							},
 						],
-						details: { success: false, error: `"${directory}" is a file, not a directory.` } as Record<string, unknown>,
+						details: {
+							success: false,
+							error: `"${directory}" is a file, not a directory.`,
+						} as Record<string, unknown>,
 						isError: true,
 					};
 				}
@@ -558,27 +583,21 @@ export default function ripgrepSearch(pi: ExtensionAPI): void {
 				const engineStr = useRipgrep ? "ripgrep (`rg --version`)" : "grep";
 
 				// Check for path-related errors in stderr
-				const pathErrorPatterns = [
-					/No such file or directory/i,
-					/ENOENT/i,
-					/not found/i,
-				];
-				const isPathError = pathErrorPatterns.some(p => p.test(stderr));
+				const pathErrorPatterns = [/No such file or directory/i, /ENOENT/i, /not found/i];
+				const isPathError = pathErrorPatterns.some((p) => p.test(stderr));
 
 				// Check for tool-missing errors
-				const missingToolPatterns = [
-					/command not found/i,
-					/not recognized/i,
-					/internal error/i,
-				];
-				const isMissingTool = missingToolPatterns.some(p => p.test(stderr)) || !stderr.trim();
+				const missingToolPatterns = [/command not found/i, /not recognized/i, /internal error/i];
+				const isMissingTool = missingToolPatterns.some((p) => p.test(stderr)) || !stderr.trim();
 
 				let errorText: string;
 				if (isPathError) {
-					errorText = `${searcherName} failed (exit code ${result.code}): ${stderr}` +
+					errorText =
+						`${searcherName} failed (exit code ${result.code}): ${stderr}` +
 						`\nDirectory "${directory}" not found or inaccessible.`;
 				} else if (isMissingTool) {
-					errorText = `${searcherName} failed (exit code ${result.code}): ${stderr || "unknown error"}` +
+					errorText =
+						`${searcherName} failed (exit code ${result.code}): ${stderr || "unknown error"}` +
 						`\n\nEnsure ${engineStr} installed.`;
 				} else {
 					errorText = `${searcherName} failed (exit code ${result.code}): ${stderr}`;

--- a/.pi/prompts/improve-codebase-architecture.md
+++ b/.pi/prompts/improve-codebase-architecture.md
@@ -49,7 +49,7 @@ If target is `root` or omitted, use project root (`.`).
 
 Use Pi tools to walk the target codebase:
 
-- `map_codebase` — symbol tree: classes, functions, variables
+- `ranked_map` — symbol tree: classes, functions, variables (omit query for full dump on small repos)
 - `ripgrep_search` — hardcoded strings, magic numbers, leaky dependencies
 - `structural_search` — call chains, tightly-coupled patterns, deep nesting
 - `read` — inspect module interfaces directly

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -9,6 +9,7 @@
 		"tokenBudget": 2048,
 		"recencyWindowDays": 30,
 		"cacheTtlHours": 24,
+		"autoThreshold": 20000,
 		"weights": {
 			"keyword": 0.5,
 			"recency": 0.3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Pi coding agent for multiple git submodules.
 - Wrong: `bash | grep`, `bash | rg`, `bash | find`
 
 **Search** — function/class/struct defs
-- Correct: `map_codebase`
+- Correct: `ranked_map` (omit query for full dump on small repos)
 - Wrong: `bash | grep`, `ripgrep_search`
 
 **Search** — AST patterns (try/catch, method calls)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ This README follows your path from first encounter to daily use. Each section is
 
 AgentCastle is a **Kanban-centred AI agent** built on the [Pi coding agent](https://pi.dev). It uses a GitHub Project board to drive an autonomous multi-agent pipeline — Researcher → Architect → TestDesigner → Developer → Auditor — with tools designed to minimise token waste, enforce security boundaries, and streamline the dev workflow. Clone this repo and you get a complete toolchain:
 
-- **Codebase mapping** — `map_codebase` via universal-ctags: file-by-file symbol tree
-- **Ranked repo map** — `ranked_map` via ctags + rg + git: relevance-ranked codebase subset (~2K tokens, 99% reduction on 50K-file repos)
+- **Codebase mapping** — `ranked_map` via universal-ctags: auto-mode (query → ranked, no query → full dump for small repos, recency-ranked for large repos)
 - **Structural search** — `structural_search` via ast-grep: AST-aware pattern matching
 - **Text search** — `ripgrep_search` via ripgrep: fast literal/regex code search
 - **Web crawling** — `web_crawl`: local crawl4ai → Apify cloud → HTTP fallback
@@ -184,8 +183,7 @@ This project deliberately avoids the [Model Context Protocol (MCP)](https://mode
 
 | File/Path | What it is |
 |-----------|------------|
-| `.pi/extensions/codebase-mapper.ts` | `map_codebase` tool via universal-ctags |
-| `.pi/extensions/ranked-map.ts` | `ranked_map` tool — relevance-ranked subset via ctags + rg + git recency |
+| `.pi/extensions/ranked-map.ts` | `ranked_map` tool — unified codebase mapper (auto-mode: ranked/full dump) via ctags + rg + git recency |
 | `.pi/extensions/structural-analyzer.ts` | `structural_search` tool via ast-grep |
 | `.pi/extensions/ripgrep-search.ts` | `ripgrep_search` tool via ripgrep |
 | `.pi/extensions/crawl4ai/` | `web_crawl` tool: local crawl4ai → Apify → HTTP fallback |
@@ -228,8 +226,7 @@ Pi auto-discovers extensions from `.pi/extensions/` in the **project root**. No 
 
 | Extension | Purpose |
 |-----------|---------|
-| **Codebase Mapper** | `map_codebase` via universal-ctags. Returns symbol tree (classes, functions, variables) grouped by file. |
-| **Ranked Repo Map** | `ranked_map` via ctags + rg + git recency. Returns relevance-ranked codebase subset within token budget. Recommended over map_codebase for repos with 50K+ files. |
+| **Ranked Repo Map** | `ranked_map` via ctags + rg + git recency. Auto-mode: query → ranked, no query + small repo → full dump, no query + large repo → recency-ranked. Replaces map_codebase. |
 | **Structural Analyzer** | `structural_search` via ast-grep. AST-aware pattern matching (function calls, try/catch, class defs). |
 | **Ripgrep Search** | `ripgrep_search` via ripgrep. Fast literal/regex code search, respects `.gitignore`. |
 | **Supervisor** | Kanban-driven multi-agent pipeline. Reads issue from GitHub project, dispatches agents in loop. Registers `/supervisor <issue-number>` command. |
@@ -309,10 +306,10 @@ echo $APIFY_TOKEN   # Should print your token
 #### 6.2 Tool Verification
 
 ```bash
-# Codebase mapper (use for small repos)
-pi "Run map_codebase on the root with max_depth=1"
+# Codebase mapper — unified tool (replace old map_codebase use)
+pi "Run ranked_map on the root"
 
-# Ranked repo map (use for large repos — 50K+ files)
+# Ranked search (pass query for keyword scoring)
 pi "Call ranked_map with query='login auth' tokenBudget=2048"
 
 # Structural search
@@ -917,7 +914,7 @@ Contributions welcome — bug reports, feature requests, documentation improveme
 | crawl4ai | latest | Apache-2.0 | venv | [github.com/unclecode/crawl4ai](https://github.com/unclecode/crawl4ai) |
 | Playwright Chromium | latest | Apache-2.0 | venv | [playwright.dev](https://playwright.dev) |
 | **Project Extensions (`.pi/extensions/`)** | | | | |
-| codebase-mapper.ts | — | MIT | project | This repository |
+| ranked-map.ts | — | MIT | project | This repository (unified ctags mapper)
 | structural-analyzer.ts | — | MIT | project | This repository |
 | ripgrep-search.ts | — | MIT | project | This repository |
 | caveman/ | — | MIT | project | This repository |

--- a/benchmarks/benchmark-tools.sh
+++ b/benchmarks/benchmark-tools.sh
@@ -16,9 +16,9 @@ TASK="Audit test coverage of chart/figure generation methods in flask_planhead/a
 
 CONFIGS=(
   "1-no-tools|--no-tools --no-extensions"
-  "2-builtin-mapper|--no-extensions -e $PROJECT_DIR/.pi/extensions/codebase-mapper.ts"
-  "3-builtin-mapper-structural|--no-extensions -e $PROJECT_DIR/.pi/extensions/codebase-mapper.ts -e $PROJECT_DIR/.pi/extensions/structural-analyzer.ts"
-  "4-builtin-mapper-structural-rg|--no-extensions -e $PROJECT_DIR/.pi/extensions/codebase-mapper.ts -e $PROJECT_DIR/.pi/extensions/structural-analyzer.ts -e $PROJECT_DIR/.pi/extensions/ripgrep-search.ts"
+  "2-builtin-mapper|--no-extensions -e $PROJECT_DIR/.pi/extensions/ranked-map.ts"
+  "3-builtin-mapper-structural|--no-extensions -e $PROJECT_DIR/.pi/extensions/ranked-map.ts -e $PROJECT_DIR/.pi/extensions/structural-analyzer.ts"
+  "4-builtin-mapper-structural-rg|--no-extensions -e $PROJECT_DIR/.pi/extensions/ranked-map.ts -e $PROJECT_DIR/.pi/extensions/structural-analyzer.ts -e $PROJECT_DIR/.pi/extensions/ripgrep-search.ts"
 )
 
 GREEN='\033[0;32m'

--- a/test/ranked-map.test.mts
+++ b/test/ranked-map.test.mts
@@ -27,6 +27,7 @@ export interface RankedMapConfig {
 	tokenBudget: number;
 	recencyWindowDays: number;
 	cacheTtlHours: number;
+	autoThreshold: number;
 	weights: { keyword: number; recency: number };
 }
 
@@ -54,6 +55,7 @@ export interface RankedMapResult {
 	total_tokens: number;
 	budget: number;
 	truncated: boolean;
+	mode: "ranked" | "full_dump";
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -64,6 +66,7 @@ const DEFAULT_CONFIG: RankedMapConfig = {
 	tokenBudget: 2048,
 	recencyWindowDays: 30,
 	cacheTtlHours: 24,
+	autoThreshold: 20000,
 	weights: { keyword: 0.5, recency: 0.3 },
 };
 
@@ -74,6 +77,63 @@ const MAX_RECENCY_WINDOW_DAYS = 365;
  */
 function estimateTokens(text: string): number {
 	return Math.ceil(text.length / 4);
+}
+
+/**
+ * Determine tool mode based on query presence, symbol count, and autoThreshold.
+ * query provided → ranked (keyword + recency)
+ * no query, totalSymbols <= autoThreshold → full_dump (path-sorted)
+ * no query, totalSymbols > autoThreshold → ranked (recency-only)
+ */
+export function selectMode(
+	query: string,
+	totalSymbols: number,
+	autoThreshold: number,
+): "ranked" | "full_dump" {
+	if (query.trim()) return "ranked";
+	if (totalSymbols <= autoThreshold) return "full_dump";
+	return "ranked";
+}
+
+/**
+ * Dump all symbols sorted by file path, filling greedily within token budget.
+ * Each file gets score=0 and empty preview.
+ */
+export function dumpAllFiles(
+	symbols: Record<string, SymbolEntry[]>,
+	tokenBudget: number,
+): { files: RankedFileScore[]; totalTokens: number; truncated: boolean } {
+	const filePaths = Object.keys(symbols).sort();
+	const files: RankedFileScore[] = [];
+	let totalTokens = 0;
+	let truncated = false;
+	const PREVIEW_TOKEN_ESTIMATE = 50;
+
+	for (const path of filePaths) {
+		const syms = symbols[path] ?? [];
+		const symText = formatSymbols(syms, path);
+		const entryTokens = estimateTokens(symText) + PREVIEW_TOKEN_ESTIMATE;
+
+		if (tokenBudget <= 0) {
+			truncated = true;
+			break;
+		}
+
+		if (totalTokens + entryTokens > tokenBudget && totalTokens > 0) {
+			truncated = true;
+			break;
+		}
+
+		files.push({
+			path,
+			score: 0,
+			symbols: symText,
+			preview: "",
+		});
+		totalTokens += entryTokens;
+	}
+
+	return { files, totalTokens, truncated };
 }
 
 /**
@@ -109,6 +169,17 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 			rm.recencyWindowDays > 0
 		) {
 			recencyWindowDays = Math.min(rm.recencyWindowDays, MAX_RECENCY_WINDOW_DAYS);
+		}
+
+		// autoThreshold: non-negative integer (0 = always-ranked)
+		let autoThreshold = DEFAULT_CONFIG.autoThreshold;
+		if (
+			typeof rm.autoThreshold === "number" &&
+			Number.isFinite(rm.autoThreshold) &&
+			Number.isInteger(rm.autoThreshold) &&
+			rm.autoThreshold >= 0
+		) {
+			autoThreshold = rm.autoThreshold;
 		}
 
 		// cacheTtlHours: must be positive
@@ -158,6 +229,7 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 			tokenBudget,
 			recencyWindowDays,
 			cacheTtlHours,
+			autoThreshold,
 			weights: { keyword: kwWeight, recency: recWeight },
 		};
 	} catch {
@@ -330,6 +402,7 @@ export function formatOutput(
 	rankedFiles: RankedFileScore[],
 	budget: number,
 	truncated: boolean,
+	mode: "ranked" | "full_dump" = "ranked",
 ): RankedMapResult {
 	return {
 		files: rankedFiles.map((f) => ({
@@ -342,6 +415,7 @@ export function formatOutput(
 		),
 		budget,
 		truncated,
+		mode,
 	};
 }
 
@@ -704,11 +778,129 @@ describe("loadRankedMapConfig", () => {
 			assert.strictEqual(result.tokenBudget, 1024);
 			assert.strictEqual(result.recencyWindowDays, 30); // default
 			assert.strictEqual(result.cacheTtlHours, 24); // default
+			assert.strictEqual(result.autoThreshold, 20000); // default
 			assert.strictEqual(result.weights.keyword, 0.5); // default
 			assert.strictEqual(result.weights.recency, 0.3); // default
 		} finally {
 			cleanupDir(dir);
 		}
+	});
+
+	it("autoThreshold defaults to 20000 when not set in settings.json", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { tokenBudget: 4096 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.autoThreshold, 20000);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("parses custom autoThreshold=5000", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { autoThreshold: 5000 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.autoThreshold, 5000);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("autoThreshold=0 is valid (always-ranked mode)", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { autoThreshold: 0 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.autoThreshold, 0);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("negative autoThreshold falls back to default 20000", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { autoThreshold: -100 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.autoThreshold, 20000);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("non-integer autoThreshold falls back to default 20000", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { autoThreshold: "abc" } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.autoThreshold, 20000);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 1b: Mode Selection Logic
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("selectMode", () => {
+	it("query provided → ranked mode", () => {
+		const mode = selectMode("login auth", 100, 20000);
+		assert.strictEqual(mode, "ranked");
+	});
+
+	it("no query, totalSymbols <= autoThreshold → full_dump", () => {
+		const mode = selectMode("", 100, 20000);
+		assert.strictEqual(mode, "full_dump");
+	});
+
+	it("no query, totalSymbols == autoThreshold → full_dump", () => {
+		const mode = selectMode("", 20000, 20000);
+		assert.strictEqual(mode, "full_dump");
+	});
+
+	it("no query, totalSymbols > autoThreshold → ranked (recency-only)", () => {
+		const mode = selectMode("", 20001, 20000);
+		assert.strictEqual(mode, "ranked");
+	});
+
+	it("no query, autoThreshold=0 → always ranked (totalSymbols 0 > 0 is false, but 0 <= 0 is true, so full_dump)", () => {
+		// 0 symbols <= 0 threshold => full_dump
+		const mode = selectMode("", 0, 0);
+		assert.strictEqual(mode, "full_dump");
+	});
+
+	it("no query, autoThreshold=0, totalSymbols=1 → ranked (since 1 > 0)", () => {
+		const mode = selectMode("", 1, 0);
+		assert.strictEqual(mode, "ranked");
+	});
+
+	it("whitespace-only query treated as no query", () => {
+		const mode = selectMode("   ", 100, 20000);
+		assert.strictEqual(mode, "full_dump");
+	});
+
+	it("zero totalSymbols, no query, autoThreshold=20000 → full_dump", () => {
+		const mode = selectMode("", 0, 20000);
+		assert.strictEqual(mode, "full_dump");
 	});
 });
 
@@ -1127,12 +1319,23 @@ describe("rankFiles", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("formatOutput", () => {
-	it("output has top-level keys: files, total_tokens, budget, truncated", () => {
+	it("output has top-level keys: files, total_tokens, budget, truncated, mode", () => {
 		const result = formatOutput([], 2048, false);
 		assert.ok("files" in result);
 		assert.ok("total_tokens" in result);
 		assert.ok("budget" in result);
 		assert.ok("truncated" in result);
+		assert.ok("mode" in result);
+	});
+
+	it("mode defaults to 'ranked' when not specified", () => {
+		const result = formatOutput([], 2048, false);
+		assert.strictEqual(result.mode, "ranked");
+	});
+
+	it("mode can be set to 'full_dump'", () => {
+		const result = formatOutput([], 2048, false, "full_dump");
+		assert.strictEqual(result.mode, "full_dump");
 	});
 
 	it("each file entry has path, score, symbols, preview", () => {
@@ -1210,6 +1413,96 @@ describe("formatSymbols", () => {
 	it("single symbol formatted correctly", () => {
 		const result = formatSymbols([{ type: "function", name: "foo", line: 1 }], "a.ts");
 		assert.strictEqual(result, "a.ts\n  function foo");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 6b: dumpAllFiles
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("dumpAllFiles", () => {
+	it("returns all files sorted alphabetically by path", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"z.ts": [{ type: "function", name: "zFunc", line: 1 }],
+			"a.ts": [{ type: "class", name: "AClass", line: 1 }],
+			"m.ts": [{ type: "method", name: "mMethod", line: 5 }],
+		};
+		const result = dumpAllFiles(syms, 5000);
+		assert.strictEqual(result.files.length, 3);
+		assert.strictEqual(result.files[0]!.path, "a.ts");
+		assert.strictEqual(result.files[1]!.path, "m.ts");
+		assert.strictEqual(result.files[2]!.path, "z.ts");
+	});
+
+	it("each file has score=0 in full dump", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"a.ts": [{ type: "function", name: "foo", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 5000);
+		assert.strictEqual(result.files[0]!.score, 0);
+	});
+
+	it("each file has empty preview in full dump", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"a.ts": [{ type: "function", name: "foo", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 5000);
+		assert.strictEqual(result.files[0]!.preview, "");
+	});
+
+	it("empty symbols → empty result, no crash", () => {
+		const result = dumpAllFiles({}, 5000);
+		assert.strictEqual(result.files.length, 0);
+		assert.strictEqual(result.totalTokens, 0);
+		assert.strictEqual(result.truncated, false);
+	});
+
+	it("truncated when token budget exceeded", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"big.ts": Array.from({ length: 100 }, (_, i) => ({
+				type: "function",
+				name: `f${i}`,
+				line: i,
+			})),
+			"small.ts": [{ type: "function", name: "g", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 50);
+		assert.ok(result.truncated);
+	});
+
+	it("zero token budget → empty result, truncated=true", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"a.ts": [{ type: "function", name: "foo", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 0);
+		assert.strictEqual(result.files.length, 0);
+		assert.strictEqual(result.truncated, true);
+	});
+
+	it("all files fit within budget → truncated=false", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"a.ts": [{ type: "function", name: "foo", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 5000);
+		assert.strictEqual(result.truncated, false);
+	});
+
+	it("files without symbols still included (empty symbol list)", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"empty.ts": [],
+			"with.ts": [{ type: "function", name: "foo", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 5000);
+		assert.strictEqual(result.files.length, 2);
+		assert.ok(result.files.find((f) => f.path === "empty.ts"));
+	});
+
+	it("totalTokens reflects consumed token count", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"a.ts": [{ type: "function", name: "foo", line: 1 }],
+		};
+		const result = dumpAllFiles(syms, 5000);
+		assert.ok(result.totalTokens > 0);
 	});
 });
 

--- a/test/ripgrep-search.test.mts
+++ b/test/ripgrep-search.test.mts
@@ -67,12 +67,20 @@ function loadSearchConfig(cwd: string): SearchConfig {
 		if (!search) return { ...DEFAULT_CONFIG };
 
 		let searchBackend: SearchConfig["searchBackend"] = DEFAULT_CONFIG.searchBackend;
-		if (search.searchBackend === "ripgrep" || search.searchBackend === "grep" || search.searchBackend === "auto") {
+		if (
+			search.searchBackend === "ripgrep" ||
+			search.searchBackend === "grep" ||
+			search.searchBackend === "auto"
+		) {
 			searchBackend = search.searchBackend;
 		}
 
 		let maxLineLength = MAX_LINE_LENGTH_DEFAULT;
-		if (typeof search.maxLineLength === "number" && Number.isInteger(search.maxLineLength) && search.maxLineLength > 0) {
+		if (
+			typeof search.maxLineLength === "number" &&
+			Number.isInteger(search.maxLineLength) &&
+			search.maxLineLength > 0
+		) {
 			maxLineLength = Math.min(search.maxLineLength, MAX_LINE_LENGTH_MAX);
 		}
 
@@ -85,10 +93,17 @@ function loadSearchConfig(cwd: string): SearchConfig {
 /**
  * Resolve the active search backend based on user config and rg availability.
  */
-function resolveBackend(config: SearchConfig, rgAvailable: boolean): { backend: "ripgrep" | "grep"; error?: string } {
+function resolveBackend(
+	config: SearchConfig,
+	rgAvailable: boolean,
+): { backend: "ripgrep" | "grep"; error?: string } {
 	if (config.searchBackend === "ripgrep") {
 		if (!rgAvailable) {
-			return { backend: "ripgrep", error: "ripgrep not found on PATH. Install rg or set searchBackend to 'auto' or 'grep' in .pi/settings.json." };
+			return {
+				backend: "ripgrep",
+				error:
+					"ripgrep not found on PATH. Install rg or set searchBackend to 'auto' or 'grep' in .pi/settings.json.",
+			};
 		}
 		return { backend: "ripgrep" };
 	}
@@ -115,15 +130,15 @@ function validateQuery(query: string): string | null {
 
 	// Reject patterns that look like structural/symbol searches
 	if (trimmed.startsWith("class ")) {
-		return `Query "${trimmed}" looks like a class definition search. Use map_codebase (ctags) to find class definitions, not ripgrep_search.`;
+		return `Query "${trimmed}" looks like a class definition search. Use ranked_map (ctags) to find class definitions, not ripgrep_search.`;
 	}
 
 	if (trimmed.startsWith("def ")) {
-		return `Query "${trimmed}" looks like a function definition search. Use map_codebase (ctags) to find function definitions, not ripgrep_search.`;
+		return `Query "${trimmed}" looks like a function definition search. Use ranked_map (ctags) to find function definitions, not ripgrep_search.`;
 	}
 
 	if (trimmed.startsWith("function ")) {
-		return `Query "${trimmed}" looks like a function definition search. Use map_codebase (ctags) to find function definitions, not ripgrep_search.`;
+		return `Query "${trimmed}" looks like a function definition search. Use ranked_map (ctags) to find function definitions, not ripgrep_search.`;
 	}
 
 	// Reject patterns with structural AST syntax ($ or {)
@@ -322,19 +337,19 @@ describe("validateQuery", () => {
 	it("rejects 'class User' (collision rule)", () => {
 		const result = validateQuery("class User");
 		assert.ok(result !== null, "Expected error for class definition pattern");
-		assert.ok(result!.includes("map_codebase"), "Error should mention map_codebase");
+		assert.ok(result!.includes("ranked_map"), "Error should mention ranked_map");
 	});
 
 	it("rejects 'def verify_token' (collision rule)", () => {
 		const result = validateQuery("def verify_token");
 		assert.ok(result !== null);
-		assert.ok(result!.includes("map_codebase"));
+		assert.ok(result!.includes("ranked_map"));
 	});
 
 	it("rejects 'function bootstrap' (collision rule)", () => {
 		const result = validateQuery("function bootstrap");
 		assert.ok(result !== null);
-		assert.ok(result!.includes("map_codebase"));
+		assert.ok(result!.includes("ranked_map"));
 	});
 
 	it("rejects pattern with $ (structural syntax)", () => {
@@ -719,7 +734,11 @@ describe("loadSearchConfig", () => {
 
 	function cleanupTmpDir(dir: string) {
 		for (const d of [dir]) {
-			try { rmSync(d, { recursive: true, force: true }); } catch { /* ignore */ }
+			try {
+				rmSync(d, { recursive: true, force: true });
+			} catch {
+				/* ignore */
+			}
 		}
 	}
 
@@ -761,7 +780,10 @@ describe("loadSearchConfig", () => {
 	it("parses searchBackend: auto", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { searchBackend: "auto" } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { searchBackend: "auto" } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.searchBackend, "auto");
 			assert.strictEqual(result.maxLineLength, 200);
@@ -773,7 +795,10 @@ describe("loadSearchConfig", () => {
 	it("parses searchBackend: ripgrep", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { searchBackend: "ripgrep" } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { searchBackend: "ripgrep" } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.searchBackend, "ripgrep");
 		} finally {
@@ -784,7 +809,10 @@ describe("loadSearchConfig", () => {
 	it("parses searchBackend: grep", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { searchBackend: "grep" } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { searchBackend: "grep" } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.searchBackend, "grep");
 		} finally {
@@ -795,7 +823,10 @@ describe("loadSearchConfig", () => {
 	it("falls back to auto for invalid searchBackend", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { searchBackend: "invalid" } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { searchBackend: "invalid" } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.searchBackend, "auto");
 		} finally {
@@ -806,7 +837,10 @@ describe("loadSearchConfig", () => {
 	it("parses maxLineLength: 100", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { maxLineLength: 100 } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { maxLineLength: 100 } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.maxLineLength, 100);
 		} finally {
@@ -817,7 +851,10 @@ describe("loadSearchConfig", () => {
 	it("rejects maxLineLength: 0 (must be positive)", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { maxLineLength: 0 } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { maxLineLength: 0 } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.maxLineLength, 200);
 		} finally {
@@ -828,7 +865,10 @@ describe("loadSearchConfig", () => {
 	it("rejects maxLineLength: -50 (negative)", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { maxLineLength: -50 } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { maxLineLength: -50 } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.maxLineLength, 200);
 		} finally {
@@ -839,7 +879,10 @@ describe("loadSearchConfig", () => {
 	it("clamps maxLineLength: 5000 to 2000", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { maxLineLength: 5000 } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { maxLineLength: 5000 } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.maxLineLength, 2000);
 		} finally {
@@ -850,7 +893,10 @@ describe("loadSearchConfig", () => {
 	it("rejects maxLineLength: 'abc' (non-numeric)", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { maxLineLength: "abc" } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { maxLineLength: "abc" } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.maxLineLength, 200);
 		} finally {
@@ -861,7 +907,10 @@ describe("loadSearchConfig", () => {
 	it("accepts maxLineLength at upper bound: 2000", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { maxLineLength: 2000 } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { maxLineLength: 2000 } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.maxLineLength, 2000);
 		} finally {
@@ -872,7 +921,10 @@ describe("loadSearchConfig", () => {
 	it("handles both searchBackend and maxLineLength together", () => {
 		const dir = setupTmpDir();
 		try {
-			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ search: { searchBackend: "grep", maxLineLength: 150 } }));
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ search: { searchBackend: "grep", maxLineLength: 150 } }),
+			);
 			const result = loadSearchConfig(dir);
 			assert.strictEqual(result.searchBackend, "grep");
 			assert.strictEqual(result.maxLineLength, 150);
@@ -905,7 +957,10 @@ describe("resolveBackend", () => {
 		const result = resolveBackend({ searchBackend: "ripgrep", maxLineLength: 200 }, false);
 		assert.strictEqual(result.backend, "ripgrep");
 		assert.ok(result.error !== undefined, "Should return an error message");
-		assert.ok(result.error!.includes("ripgrep not found"), "Error should mention ripgrep not found");
+		assert.ok(
+			result.error!.includes("ripgrep not found"),
+			"Error should mention ripgrep not found",
+		);
 	});
 
 	it("grep + rg available → grep (skips detection)", () => {
@@ -935,117 +990,168 @@ describe("integration: rg binary", () => {
 		}
 	})();
 
-	const skipMsg = "rg binary not installed — skip integration test (install with: apt install ripgrep or brew install ripgrep)";
+	const skipMsg =
+		"rg binary not installed — skip integration test (install with: apt install ripgrep or brew install ripgrep)";
 
-it('searches "5000" on fixture dir and returns 2 results', { skip: !hasRg ? skipMsg : false, timeout: 15_000 }, () => {
-		const sampleDir = resolve("test/fixtures/ripgrep-sample");
-		if (!existsSync(sampleDir)) {
-			throw new Error("test/fixtures/ripgrep-sample/ not found");
-		}
+	it(
+		'searches "5000" on fixture dir and returns 2 results',
+		{ skip: !hasRg ? skipMsg : false, timeout: 15_000 },
+		() => {
+			const sampleDir = resolve("test/fixtures/ripgrep-sample");
+			if (!existsSync(sampleDir)) {
+				throw new Error("test/fixtures/ripgrep-sample/ not found");
+			}
 
-		const stdout = execSync("rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 5000 .", {
-			cwd: sampleDir,
-			encoding: "utf-8",
-			stdio: "pipe",
-			timeout: 10_000,
-		});
+			const stdout = execSync(
+				"rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 5000 .",
+				{
+					cwd: sampleDir,
+					encoding: "utf-8",
+					stdio: "pipe",
+					timeout: 10_000,
+				},
+			);
 
-		const result = parseVimgrepOutput(stdout);
-		assert.strictEqual(result.total_returned, 2, `Expected 2 results, got ${result.total_returned}`);
+			const result = parseVimgrepOutput(stdout);
+			assert.strictEqual(
+				result.total_returned,
+				2,
+				`Expected 2 results, got ${result.total_returned}`,
+			);
 
-		// Normalize file paths (rg may include ./ prefix when cwd matches search dir)
-		const files = result.results.map((r) => r.file.replace(/^\.\//, "")).sort();
-		assert.ok(files.includes("config/settings.py"), "Should find config/settings.py");
-		assert.ok(files.includes("src/app.ts"), "Should find src/app.ts");
+			// Normalize file paths (rg may include ./ prefix when cwd matches search dir)
+			const files = result.results.map((r) => r.file.replace(/^\.\//, "")).sort();
+			assert.ok(files.includes("config/settings.py"), "Should find config/settings.py");
+			assert.ok(files.includes("src/app.ts"), "Should find src/app.ts");
 
-		// Each result has proper types
-		for (const entry of result.results) {
-			assert.ok(typeof entry.file === "string" && entry.file.length > 0);
-			assert.ok(typeof entry.line === "number" && entry.line > 0);
-			assert.ok(typeof entry.column === "number" && entry.column > 0);
-			assert.ok(typeof entry.text === "string");
-		}
-	});
+			// Each result has proper types
+			for (const entry of result.results) {
+				assert.ok(typeof entry.file === "string" && entry.file.length > 0);
+				assert.ok(typeof entry.line === "number" && entry.line > 0);
+				assert.ok(typeof entry.column === "number" && entry.column > 0);
+				assert.ok(typeof entry.text === "string");
+			}
+		},
+	);
 
-	it('searches "TODO" on fixture dir and returns 0 results', { skip: !hasRg ? skipMsg : false, timeout: 15_000 }, () => {
-		const sampleDir = resolve("test/fixtures/ripgrep-sample");
-		if (!existsSync(sampleDir)) {
-			throw new Error("test/fixtures/ripgrep-sample/ not found");
-		}
+	it(
+		'searches "TODO" on fixture dir and returns 0 results',
+		{ skip: !hasRg ? skipMsg : false, timeout: 15_000 },
+		() => {
+			const sampleDir = resolve("test/fixtures/ripgrep-sample");
+			if (!existsSync(sampleDir)) {
+				throw new Error("test/fixtures/ripgrep-sample/ not found");
+			}
 
-		// rg exits with code 1 when no matches found — execSync throws on non-zero
-		// We catch the exception and parse stdout for empty result
-		let stdout = "";
-		try {
-			stdout = execSync("rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 TODO .", {
-				cwd: sampleDir,
-				encoding: "utf-8",
-				stdio: "pipe",
-				timeout: 10_000,
-			});
-		} catch (e: unknown) {
-			const err = e as { stdout?: string; stderr?: string; status?: number };
-			// rg exit code 1 = no matches — stdout should be empty
-			stdout = err.stdout || "";
-		}
+			// rg exits with code 1 when no matches found — execSync throws on non-zero
+			// We catch the exception and parse stdout for empty result
+			let stdout = "";
+			try {
+				stdout = execSync("rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 TODO .", {
+					cwd: sampleDir,
+					encoding: "utf-8",
+					stdio: "pipe",
+					timeout: 10_000,
+				});
+			} catch (e: unknown) {
+				const err = e as { stdout?: string; stderr?: string; status?: number };
+				// rg exit code 1 = no matches — stdout should be empty
+				stdout = err.stdout || "";
+			}
 
-		const result = parseVimgrepOutput(stdout);
-		assert.strictEqual(result.total_returned, 0, `Expected 0 results for TODO, got ${result.total_returned}`);
-	});
+			const result = parseVimgrepOutput(stdout);
+			assert.strictEqual(
+				result.total_returned,
+				0,
+				`Expected 0 results for TODO, got ${result.total_returned}`,
+			);
+		},
+	);
 
-	it('searches "TIMEOUT_MS" with max_count=1 and respects per-file limit', { skip: !hasRg ? skipMsg : false, timeout: 15_000 }, () => {
-		const sampleDir = resolve("test/fixtures/ripgrep-sample");
-		if (!existsSync(sampleDir)) {
-			throw new Error("test/fixtures/ripgrep-sample/ not found");
-		}
+	it(
+		'searches "TIMEOUT_MS" with max_count=1 and respects per-file limit',
+		{ skip: !hasRg ? skipMsg : false, timeout: 15_000 },
+		() => {
+			const sampleDir = resolve("test/fixtures/ripgrep-sample");
+			if (!existsSync(sampleDir)) {
+				throw new Error("test/fixtures/ripgrep-sample/ not found");
+			}
 
-		// TIMEOUT_MS appears once per file, so max_count=1 should still return 2
-		const stdout = execSync("rg --vimgrep --max-columns=200 --max-count=1 --no-heading -j1 TIMEOUT_MS .", {
-			cwd: sampleDir,
-			encoding: "utf-8",
-			stdio: "pipe",
-			timeout: 10_000,
-		});
+			// TIMEOUT_MS appears once per file, so max_count=1 should still return 2
+			const stdout = execSync(
+				"rg --vimgrep --max-columns=200 --max-count=1 --no-heading -j1 TIMEOUT_MS .",
+				{
+					cwd: sampleDir,
+					encoding: "utf-8",
+					stdio: "pipe",
+					timeout: 10_000,
+				},
+			);
 
-		const result = parseVimgrepOutput(stdout);
-		assert.strictEqual(result.total_returned, 2, `Expected 2 results for TIMEOUT_MS, got ${result.total_returned}`);
-	});
+			const result = parseVimgrepOutput(stdout);
+			assert.strictEqual(
+				result.total_returned,
+				2,
+				`Expected 2 results for TIMEOUT_MS, got ${result.total_returned}`,
+			);
+		},
+	);
 
-	it("column values are 1-indexed character positions", { skip: !hasRg ? skipMsg : false, timeout: 15_000 }, () => {
-		const sampleDir = resolve("test/fixtures/ripgrep-sample");
-		if (!existsSync(sampleDir)) {
-			throw new Error("test/fixtures/ripgrep-sample/ not found");
-		}
+	it(
+		"column values are 1-indexed character positions",
+		{ skip: !hasRg ? skipMsg : false, timeout: 15_000 },
+		() => {
+			const sampleDir = resolve("test/fixtures/ripgrep-sample");
+			if (!existsSync(sampleDir)) {
+				throw new Error("test/fixtures/ripgrep-sample/ not found");
+			}
 
-		const stdout = execSync("rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 5000 .", {
-			cwd: sampleDir,
-			encoding: "utf-8",
-			stdio: "pipe",
-			timeout: 10_000,
-		});
+			const stdout = execSync(
+				"rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 5000 .",
+				{
+					cwd: sampleDir,
+					encoding: "utf-8",
+					stdio: "pipe",
+					timeout: 10_000,
+				},
+			);
 
-		const result = parseVimgrepOutput(stdout);
-		for (const entry of result.results) {
-			assert.ok(typeof entry.column === "number" && entry.column > 0, `Column should be positive number, got ${entry.column}`);
-		}
-	});
+			const result = parseVimgrepOutput(stdout);
+			for (const entry of result.results) {
+				assert.ok(
+					typeof entry.column === "number" && entry.column > 0,
+					`Column should be positive number, got ${entry.column}`,
+				);
+			}
+		},
+	);
 
-	it("--max-columns=200 enforced (lines over 200 chars truncated)", { skip: !hasRg ? skipMsg : false, timeout: 15_000 }, () => {
-		const sampleDir = resolve("test/fixtures/ripgrep-sample");
-		if (!existsSync(sampleDir)) {
-			throw new Error("test/fixtures/ripgrep-sample/ not found");
-		}
+	it(
+		"--max-columns=200 enforced (lines over 200 chars truncated)",
+		{ skip: !hasRg ? skipMsg : false, timeout: 15_000 },
+		() => {
+			const sampleDir = resolve("test/fixtures/ripgrep-sample");
+			if (!existsSync(sampleDir)) {
+				throw new Error("test/fixtures/ripgrep-sample/ not found");
+			}
 
-		const stdout = execSync("rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 '[\\s\\S]' .", {
-			cwd: sampleDir,
-			encoding: "utf-8",
-			stdio: "pipe",
-			timeout: 10_000,
-		});
+			const stdout = execSync(
+				"rg --vimgrep --max-columns=200 --max-count=10 --no-heading -j1 '[\\s\\S]' .",
+				{
+					cwd: sampleDir,
+					encoding: "utf-8",
+					stdio: "pipe",
+					timeout: 10_000,
+				},
+			);
 
-		const result = parseVimgrepOutput(stdout);
-		for (const entry of result.results) {
-			assert.ok(entry.text.length <= 200, `Text should be <= 200 chars with --max-columns=200, got ${entry.text.length}`);
-		}
-	});
+			const result = parseVimgrepOutput(stdout);
+			for (const entry of result.results) {
+				assert.ok(
+					entry.text.length <= 200,
+					`Text should be <= 200 chars with --max-columns=200, got ${entry.text.length}`,
+				);
+			}
+		},
+	);
 });


### PR DESCRIPTION
## Audit Approved

### Summary
Merged `map_codebase` + `ranked_map` into single `ranked_map` tool with auto-mode detection. `codebase-mapper.ts` reduced to pure library; tool registration moved to `ranked-map.ts`.

### How it works
`ranked_map` auto-selects mode: query → ranked (keyword+recency); no query + ≤20K symbols → full dump (path-sorted); no query + >20K symbols → ranked (recency-only). New `autoThreshold` config in `.pi/settings.json` controls boundary (default 20K, set 0 for always-ranked). `dumpAllFiles()` sorts all files by path within tokenBudget; `selectMode()` enforces the three-way decision. Output now includes `mode` field ("ranked" | "full_dump").

### Key decisions
- **Accept**: dropping `max_depth` param — scope via `directory` instead; library still exports `buildCtagsArgs(maxDepth)` if needed later.
- **Accept**: full dump replaces 750-symbol hard cap with token-budget-driven truncation — observable only on large repos.
- **Accept**: breaking `map_codebase` tool name — migration path: call `ranked_map` without query.

### Review findings
- 🟡 Warning — test coverage gap: test plan specified 3 integration scenarios (ranked+query, full_dump on small fixture, recency-only on large repo); only the first has an end-to-end integration test. Scenarios 2 and 3 are covered by pure-function unit tests only (selectMode: 8 cases, dumpAllFiles: 9 cases). Not a rejection — mode-selection logic is well-tested.

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (188 tests, 0 failures)
- Test quality: ✓ (with warning)
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓

PR created. Ready for merge.
