### PR TITLE
feat(#201): Bug: caveman - showStatus config change not applied until session restart (stale in-memory config)

### DIFF
--- a/.pi/extensions/caveman/config.ts
+++ b/.pi/extensions/caveman/config.ts
@@ -64,6 +64,7 @@ export function createConfigStore(configPath?: string): ConfigStore {
 	};
 
 	const saveConfig = async (newConfig: CavemanConfig): Promise<void> => {
+		config = newConfig; // Update in-memory immediately
 		const snapshot = JSON.stringify(newConfig, null, 2) + "\n";
 		saveQueue = saveQueue.then(async () => {
 			try {

--- a/test/caveman-config.test.mts
+++ b/test/caveman-config.test.mts
@@ -106,6 +106,27 @@ describe("config.ts — ensureConfigLoaded caches after first call", () => {
 	});
 });
 
+describe("config.ts — saveConfig updates in-memory config immediately", () => {
+	it("getConfig returns new showStatus right after saveConfig", async () => {
+		const store = createConfigStore(join(tmpDir, "caveman.json"));
+		await store.saveConfig({ defaultLevel: "ultra", showStatus: false });
+		// In-memory must reflect new value before disk write resolves
+		assert.strictEqual(store.getConfig().showStatus, false);
+		assert.strictEqual(store.getConfig().defaultLevel, "ultra");
+	});
+
+	it("subsequent getConfig calls return latest saved config", async () => {
+		const store = createConfigStore(join(tmpDir, "caveman.json"));
+		await store.saveConfig({ defaultLevel: "full", showStatus: true });
+		assert.strictEqual(store.getConfig().defaultLevel, "full");
+
+		// Save again with different values
+		await store.saveConfig({ defaultLevel: "ultra", showStatus: false });
+		assert.strictEqual(store.getConfig().defaultLevel, "ultra");
+		assert.strictEqual(store.getConfig().showStatus, false);
+	});
+});
+
 describe("config.ts — error paths", () => {
 	it("malformed JSON falls back to DEFAULT_CONFIG", async () => {
 		const configPath = join(tmpDir, "caveman.json");


### PR DESCRIPTION
## Audit Approved

### Summary
Fix stale in-memory config in caveman extension — `saveConfig()` now updates closure-scoped `config` before async disk write. `getConfig().showStatus` returns latest value immediately after save.

### How it works
Single line `config = newConfig` added as first statement in `saveConfig()`. This makes the closure-scoped variable point to the new config object before the async disk write queue runs. All consumers reading via `getConfig()` see fresh state synchronously.

### Key decisions
- **State mutation in config module** — updating `config` inside `saveConfig()` keeps ownership at single point, not duplicated to callers
- **Before disk queue** — memory updated first; disk write failures (silent catch) don't block UI reactivity
- **Full replacement semantics** — callers already spread `...currentConfig`, no regression

### Review findings
- 🟢 **Suggestion** — `saveConfig` now updates in-memory config for all fields, not just `showStatus`. Future config properties benefit automatically.

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (12/12)
- Test quality: ✓
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓

PR created. Ready for merge.
