### PR TITLE
feat(#202): Bug: session-logger - tool execution durations tracked but never persisted to metadata (always 0)

### DIFF
--- a/.pi/extensions/session-logger/index.ts
+++ b/.pi/extensions/session-logger/index.ts
@@ -11,7 +11,8 @@ import * as path from "node:path";
 import * as fs from "node:fs";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { createSessionStats } from "./stats.js";
+import { createSessionStats, computeToolStats } from "./stats.js";
+import type { StatsSnapshot } from "./stats.js";
 import { createFileOps } from "./files.js";
 import { renderSessionToMarkdown, parseSessionStats } from "./renderer.js";
 import type { ParsedSessionStats } from "./renderer.js";
@@ -69,11 +70,15 @@ export default function (pi: ExtensionAPI): void {
 		const sf = sm.getSessionFile();
 		if (!sf) return;
 
+		// Capture in-memory tool execution timing before shutdown.
+		// This bridges accurate start/end times into metadata.
+		const snapshot = stats.getSnapshot();
+
 		// Wrap everything so one failure doesn't block the rest.
 		// Pi's extension runner catches errors silently per-handler —
 		// an uncaught throw stops execution of this handler entirely.
 		try {
-			await generateMissingReports(sf, files);
+			await generateMissingReports(sf, files, snapshot);
 		} catch (err) {
 			console.error(`[session-logger] Shutdown handler failed: ${(err as Error).message}`);
 		}
@@ -152,9 +157,10 @@ export default function (pi: ExtensionAPI): void {
  * Generate metadata.json and .md report for a session file if they're missing.
  * Called from session_shutdown (primary) and session_start (recovery).
  */
-async function generateMissingReports(
+export async function generateMissingReports(
 	sessionFilePath: string,
 	files: ReturnType<typeof createFileOps>,
+	snapshot?: StatsSnapshot,
 ): Promise<void> {
 	// Check if the JSONL file still exists (might have been cleaned up)
 	if (!fs.existsSync(sessionFilePath)) return;
@@ -178,6 +184,25 @@ async function generateMissingReports(
 
 	if (!parsed) return;
 
+	// Build tool stats — prefer in-memory timing when snapshot is available.
+	// Parsed stats are source of truth for call/error counts (message replay).
+	// In-memory stats provide accurate totalDurationMs.
+	let toolStats = parsed.toolStats;
+	if (snapshot) {
+		const computedStats = computeToolStats(snapshot.toolExecutions);
+		const merged = { ...parsed.toolStats };
+		for (const [toolName, stats] of Object.entries(computedStats)) {
+			if (merged[toolName]) {
+				// Keep parsed call/error counts, override duration from memory
+				merged[toolName].totalDurationMs = stats.totalDurationMs;
+			} else {
+				// Tool exists in memory but not in JSONL — add it
+				merged[toolName] = stats;
+			}
+		}
+		toolStats = merged;
+	}
+
 	const meta: Metadata = {
 		sessionId: parsed.sessionId,
 		name: undefined,
@@ -194,7 +219,7 @@ async function generateMissingReports(
 			level: l,
 		})),
 		perTurnTokens: parsed.perTurnTokens,
-		toolStats: parsed.toolStats,
+		toolStats,
 		fileModifications: parsed.fileModifications,
 	};
 
@@ -218,27 +243,4 @@ async function generateMissingReports(
 			console.error(`[session-logger] Failed to write report: ${(err as Error).message}`);
 		}
 	}
-}
-
-/** Aggregate tool executions into a summary map. */
-function computeToolStats(
-	executions: Array<{
-		toolName: string;
-		isError: boolean;
-		startTime: number;
-		endTime: number | null;
-	}>,
-): Record<string, { calls: number; errors: number; totalDurationMs: number }> {
-	const stats: Record<string, { calls: number; errors: number; totalDurationMs: number }> = {};
-	for (const exec of executions) {
-		if (!stats[exec.toolName]) {
-			stats[exec.toolName] = { calls: 0, errors: 0, totalDurationMs: 0 };
-		}
-		stats[exec.toolName].calls++;
-		if (exec.isError) stats[exec.toolName].errors++;
-		if (exec.endTime != null) {
-			stats[exec.toolName].totalDurationMs += exec.endTime - exec.startTime;
-		}
-	}
-	return stats;
 }

--- a/.pi/extensions/session-logger/stats.ts
+++ b/.pi/extensions/session-logger/stats.ts
@@ -51,6 +51,29 @@ export interface SessionStats {
 	recordFileModification(action: "read" | "write" | "edit", path: string, size?: number): void;
 }
 
+/** Aggregate tool executions into a summary map with durations. */
+export function computeToolStats(
+	executions: Array<{
+		toolName: string;
+		isError: boolean;
+		startTime: number;
+		endTime: number | null;
+	}>,
+): Record<string, { calls: number; errors: number; totalDurationMs: number }> {
+	const stats: Record<string, { calls: number; errors: number; totalDurationMs: number }> = {};
+	for (const exec of executions) {
+		if (!stats[exec.toolName]) {
+			stats[exec.toolName] = { calls: 0, errors: 0, totalDurationMs: 0 };
+		}
+		stats[exec.toolName].calls++;
+		if (exec.isError) stats[exec.toolName].errors++;
+		if (exec.endTime != null) {
+			stats[exec.toolName].totalDurationMs += exec.endTime - exec.startTime;
+		}
+	}
+	return stats;
+}
+
 export function createSessionStats(): SessionStats {
 	let totalInputTokens = 0;
 	let totalOutputTokens = 0;

--- a/test/session-logger-timing.test.mts
+++ b/test/session-logger-timing.test.mts
@@ -1,0 +1,322 @@
+/**
+ * Tests for session-logger timing bridge — computeToolStats + merge logic
+ *
+ * Uses Node built-in test runner. Run with:
+ *   node --experimental-strip-types --test test/session-logger-timing.test.mts
+ */
+
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { computeToolStats } from "../.pi/extensions/session-logger/stats.ts";
+import type { ToolExecution } from "../.pi/extensions/session-logger/stats.ts";
+import { parseSessionStats } from "../.pi/extensions/session-logger/renderer.ts";
+import type { Metadata } from "../.pi/extensions/session-logger/types.ts";
+
+// Helper: build ToolExecution objects
+const START_BASE = 1_000_000;
+
+function makeExec(
+	toolName: string,
+	opts: { isError?: boolean; durationMs?: number; hasEndTime?: boolean } = {},
+): ToolExecution {
+	const startTime = START_BASE;
+	const endTime = opts.hasEndTime !== false ? startTime + (opts.durationMs ?? 100) : null;
+	return {
+		toolCallId: `call-${toolName}-${Date.now()}`,
+		toolName,
+		isError: opts.isError ?? false,
+		startTime,
+		endTime,
+		resultSize: 0,
+	};
+}
+
+// =========================================================================
+// computeToolStats — pure function unit tests
+// =========================================================================
+
+describe("computeToolStats", () => {
+	it("returns empty stats for empty executions array", () => {
+		const result = computeToolStats([]);
+		assert.deepStrictEqual(result, {});
+	});
+
+	it("computes single tool execution duration correctly", () => {
+		const execs = [makeExec("read", { durationMs: 500 })];
+		const result = computeToolStats(execs);
+		assert.deepStrictEqual(result, {
+			read: { calls: 1, errors: 0, totalDurationMs: 500 },
+		});
+	});
+
+	it("sums duration across multiple executions of same tool", () => {
+		const execs = [
+			makeExec("read", { durationMs: 100 }),
+			makeExec("read", { durationMs: 200 }),
+			makeExec("read", { durationMs: 300 }),
+		];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.read.calls, 3);
+		assert.strictEqual(result.read.totalDurationMs, 600);
+	});
+
+	it("counts errors correctly", () => {
+		const execs = [
+			makeExec("bash", { isError: true, durationMs: 50 }),
+			makeExec("bash", { durationMs: 100 }),
+			makeExec("bash", { isError: true, durationMs: 75 }),
+		];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.bash.calls, 3);
+		assert.strictEqual(result.bash.errors, 2);
+		assert.strictEqual(result.bash.totalDurationMs, 225);
+	});
+
+	it("handles tools without endTime (in-flight) — excludes from duration", () => {
+		const execs = [
+			makeExec("read", { durationMs: 100 }),
+			makeExec("write", { hasEndTime: false }),
+			makeExec("bash", { durationMs: 200 }),
+		];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.read.calls, 1);
+		assert.strictEqual(result.read.totalDurationMs, 100);
+		assert.strictEqual(result.write.calls, 1);
+		assert.strictEqual(result.write.totalDurationMs, 0);
+		assert.strictEqual(result.bash.calls, 1);
+		assert.strictEqual(result.bash.totalDurationMs, 200);
+	});
+
+	it("zero-duration execution is counted as call", () => {
+		const execs = [makeExec("read", { durationMs: 0 })];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.read.calls, 1);
+		assert.strictEqual(result.read.errors, 0);
+		assert.strictEqual(result.read.totalDurationMs, 0);
+	});
+
+	it("handles multiple different tools", () => {
+		const execs = [
+			makeExec("read", { durationMs: 100 }),
+			makeExec("write", { durationMs: 200 }),
+			makeExec("bash", { durationMs: 300 }),
+			makeExec("read", { durationMs: 150 }),
+			makeExec("edit", { durationMs: 50, isError: true }),
+		];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.read.calls, 2);
+		assert.strictEqual(result.read.totalDurationMs, 250);
+		assert.strictEqual(result.write.calls, 1);
+		assert.strictEqual(result.write.totalDurationMs, 200);
+		assert.strictEqual(result.bash.calls, 1);
+		assert.strictEqual(result.bash.totalDurationMs, 300);
+		assert.strictEqual(result.edit.calls, 1);
+		assert.strictEqual(result.edit.errors, 1);
+		assert.strictEqual(result.edit.totalDurationMs, 50);
+	});
+
+	it("mixed in-flight and complete — only complete contribute to duration", () => {
+		const execs = [
+			makeExec("read", { durationMs: 100 }),
+			makeExec("read", { hasEndTime: false }),
+			makeExec("write", { hasEndTime: false }),
+			makeExec("bash", { durationMs: 500 }),
+		];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.read.calls, 2);
+		assert.strictEqual(result.read.totalDurationMs, 100);
+		assert.strictEqual(result.write.calls, 1);
+		assert.strictEqual(result.write.totalDurationMs, 0);
+		assert.strictEqual(result.bash.calls, 1);
+		assert.strictEqual(result.bash.totalDurationMs, 500);
+	});
+
+	it("all in-flight — all durations zero", () => {
+		const execs = [
+			makeExec("read", { hasEndTime: false }),
+			makeExec("write", { hasEndTime: false }),
+		];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.read.calls, 1);
+		assert.strictEqual(result.read.totalDurationMs, 0);
+		assert.strictEqual(result.write.calls, 1);
+		assert.strictEqual(result.write.totalDurationMs, 0);
+	});
+
+	it("errors with null endTime counted as errors but zero duration", () => {
+		const execs = [makeExec("bash", { isError: true, hasEndTime: false })];
+		const result = computeToolStats(execs);
+		assert.strictEqual(result.bash.calls, 1);
+		assert.strictEqual(result.bash.errors, 1);
+		assert.strictEqual(result.bash.totalDurationMs, 0);
+	});
+});
+
+// =========================================================================
+// Merge logic integration tests
+//
+// Replicates the merge logic from generateMissingReports:
+// 1. Parse tool stats from JSONL
+// 2. Compute tool stats from snapshot toolExecutions
+// 3. Merge: keep parsed call/error counts, override duration from computed
+//    If a tool exists in computed but not parsed, add it fully.
+// =========================================================================
+
+describe("tool stats merge logic (snapshot integration)", () => {
+	let tmpDir: string;
+	let sessionsDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-logger-timing-"));
+		sessionsDir = path.join(tmpDir, ".pi", "sessions");
+		fs.mkdirSync(sessionsDir, { recursive: true });
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Write JSONL with given tool names, then apply merge logic and write metadata. */
+	function mergeAndWriteMetadata(
+		sessionId: string,
+		toolNames: string[],
+		toolExecutions: ToolExecution[],
+	): Metadata {
+		const jsonlFile = path.join(sessionsDir, `${sessionId}.jsonl`);
+		// Build JSONL with header + toolResult entries
+		const header = {
+			type: "session",
+			id: sessionId,
+			timestamp: "2025-06-01T00:00:00.000Z",
+			cwd: tmpDir,
+			version: 1,
+		};
+		const entries = [header];
+		for (const tn of toolNames) {
+			entries.push({
+				type: "message",
+				timestamp: "2025-06-01T00:00:01.000Z",
+				message: {
+					role: "toolResult",
+					toolName: tn,
+					isError: false,
+					content: [{ type: "text", text: "ok" }],
+				},
+			});
+		}
+		fs.writeFileSync(jsonlFile, entries.map((e) => JSON.stringify(e)).join("\n") + "\n");
+
+		// Parse stats from JSONL
+		const parsed = parseSessionStats(jsonlFile);
+		if (!parsed) throw new Error("Failed to parse JSONL");
+
+		// Merge: prefer in-memory duration, keep parsed call/error counts
+		let toolStats = parsed.toolStats;
+		const computedStats = computeToolStats(toolExecutions);
+		const merged = { ...parsed.toolStats };
+		for (const [toolName, stats] of Object.entries(computedStats)) {
+			if (merged[toolName]) {
+				merged[toolName].totalDurationMs = stats.totalDurationMs;
+			} else {
+				merged[toolName] = stats;
+			}
+		}
+		toolStats = merged;
+
+		const meta: Metadata = {
+			sessionId: parsed.sessionId,
+			name: undefined,
+			messages: parsed.entryCount,
+			tokens: parsed.tokens,
+			cost: parsed.cost,
+			compactions: parsed.compactions,
+			modelChanges: parsed.models.map((m) => ({
+				time: parsed!.timestamp,
+				model: m,
+			})),
+			thinkingChanges: parsed.thinkingLevels.map((l) => ({
+				time: parsed!.timestamp,
+				level: l,
+			})),
+			perTurnTokens: parsed.perTurnTokens,
+			toolStats,
+			fileModifications: parsed.fileModifications,
+		};
+
+		const metaPath = path.join(sessionsDir, `${sessionId}.metadata.json`);
+		fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+		return meta;
+	}
+
+	it("merges snapshot duration into parsed toolStats", () => {
+		const execs = [
+			makeExec("read", { durationMs: 150 }),
+			makeExec("read", { durationMs: 250 }),
+			makeExec("write", { durationMs: 400 }),
+		];
+		const meta = mergeAndWriteMetadata("test-merge-1", ["read", "write"], execs);
+
+		assert.ok(meta.toolStats, "toolStats should be present");
+		// Parsed (JSONL) has 1 read call, computed has 2 — merge keeps parsed count
+		assert.strictEqual(meta.toolStats.read.calls, 1, "read calls from parsed");
+		// Duration overridden from computed: 150 + 250 = 400
+		assert.strictEqual(meta.toolStats.read.totalDurationMs, 400, "read duration from computed");
+		assert.strictEqual(meta.toolStats.write.calls, 1, "write calls from parsed");
+		assert.strictEqual(meta.toolStats.write.totalDurationMs, 400, "write duration from computed");
+	});
+
+	it("no snapshot — totalDurationMs stays 0 (recovery path)", () => {
+		const meta = mergeAndWriteMetadata("test-no-snapshot", ["read"], []);
+		assert.strictEqual(meta.toolStats.read.calls, 1);
+		assert.strictEqual(meta.toolStats.read.totalDurationMs, 0, "duration 0 without snapshot");
+	});
+
+	it("in-flight tools (no endTime) — duration only from complete execs", () => {
+		const execs = [
+			makeExec("bash", { durationMs: 200 }),
+			{ ...makeExec("bash", { durationMs: 0 }), endTime: null },
+		];
+		const meta = mergeAndWriteMetadata("test-inflight", ["bash"], execs);
+		assert.strictEqual(meta.toolStats.bash.calls, 1); // parsed count
+		assert.strictEqual(meta.toolStats.bash.totalDurationMs, 200); // only complete
+	});
+
+	it("tools from snapshot not in JSONL are added", () => {
+		const execs = [
+			makeExec("read", { durationMs: 100 }),
+			makeExec("write", { durationMs: 200 }), // write not in JSONL
+		];
+		const meta = mergeAndWriteMetadata("test-extra-tools", ["read"], execs);
+		assert.strictEqual(meta.toolStats.read.calls, 1);
+		assert.strictEqual(meta.toolStats.read.totalDurationMs, 100);
+		assert.strictEqual(meta.toolStats.write.calls, 1);
+		assert.strictEqual(meta.toolStats.write.totalDurationMs, 200);
+	});
+
+	it("snapshot preserved across round-trip metadata.json", () => {
+		const execs = [makeExec("read", { durationMs: 1234 })];
+		const meta = mergeAndWriteMetadata("test-roundtrip", ["read"], execs);
+		const metaPath = path.join(sessionsDir, "test-roundtrip.metadata.json");
+		const loaded = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+		assert.strictEqual(loaded.toolStats.read.totalDurationMs, 1234);
+	});
+
+	it("multiple tools in snapshot each preserve their duration", () => {
+		const execs = [
+			makeExec("read", { durationMs: 111 }),
+			makeExec("write", { durationMs: 222 }),
+			makeExec("bash", { durationMs: 333 }),
+			makeExec("edit", { durationMs: 444, isError: true }),
+		];
+		const meta = mergeAndWriteMetadata("test-multi", ["read", "write", "bash", "edit"], execs);
+		assert.strictEqual(meta.toolStats.read.totalDurationMs, 111);
+		assert.strictEqual(meta.toolStats.write.totalDurationMs, 222);
+		assert.strictEqual(meta.toolStats.bash.totalDurationMs, 333);
+		assert.strictEqual(meta.toolStats.edit.totalDurationMs, 444);
+		// Error count comes from parsed (JSONL) — our JSONL sets isError: false
+		assert.strictEqual(meta.toolStats.edit.errors, 0, "errors from parsed (not set in JSONL)");
+	});
+});


### PR DESCRIPTION
## Audit Approved

### Summary
Bridged in-memory tool execution timing into metadata output path. `getSnapshot()` and `computeToolStats()` existed but were unreachable — shutdown path now captures snapshot from live stats and merges duration data into metadata.

### How it works
`session_shutdown` calls `stats.getSnapshot()`, passes snapshot to `generateMissingReports`. When snapshot present, `computeToolStats(snapshot.toolExecutions)` computes per-tool duration sums, merged into parsed stats: parsed call/error counts preserved, `totalDurationMs` overridden from in-memory timing. Recovery path (crashed session) passes no snapshot and falls back to parsed JSONL (0 duration — acceptable trade-off).

`computeToolStats` guards null `endTime` — tools still running at shutdown excluded from duration sums.

### Key decisions
- In-memory timing preferred over JSONL re-parse — JSONL schema has no duration field, adding one would couple visualization concern into core event format
- Parsed call/error counts remain source of truth — only `totalDurationMs` pulled from memory
- Recovery path accepts 0 duration — no in-memory state survives across sessions

### Review findings
No critical or warning findings.

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (16/16 timing tests, 18/18 stats tests, 41/41 session tests — no regressions)
- Test quality: ✓
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓
