### PR TITLE
feat(#220): Bug: check-extensions - findImportFindings uses substring matching (importedNames.includes(api)) causing false positives

### DIFF
--- a/.pi/extensions/check-extensions/ast-scanner.ts
+++ b/.pi/extensions/check-extensions/ast-scanner.ts
@@ -247,13 +247,15 @@ function findImportFindings(filePath: string, content: string, extName: string):
 		const valueImportMatch = trimmed.match(/^import\s+\{\s*([^}]+)\s*\}\s+from\s+["']([^"']+)["']/);
 		if (valueImportMatch && piModulePattern.test(valueImportMatch[2]!)) {
 			const importedNames = valueImportMatch[1]!;
-			// Check for pi API function imports
-			for (const api of PI_APIS) {
-				if (importedNames.includes(api)) {
+			// Parse individual import names for exact matching (fix substring false positives)
+			const trimmedNames = importedNames.split(",").map((name: string) => name.trim());
+			// Check for pi API function imports using exact match
+			for (const name of trimmedNames) {
+				if (PI_APIS.has(name)) {
 					findings.push({
 						extensionName: extName,
 						file: filePath,
-						apiName: `pi.${api}`,
+						apiName: `pi.${name}`,
 						line: i + 1,
 						column: 1,
 						lineContent: trimmed,
@@ -363,7 +365,9 @@ export async function scanExtensionsAST(
 	} catch {
 		return { findings, skipCount };
 	}
-	const hasExtensionSubdirs = entries.some((entry) => entry.isDirectory() && !entry.name.startsWith("."));
+	const hasExtensionSubdirs = entries.some(
+		(entry) => entry.isDirectory() && !entry.name.startsWith("."),
+	);
 
 	for (const entry of entries) {
 		if (!entry.isDirectory()) continue;

--- a/test/check-extensions.test.mts
+++ b/test/check-extensions.test.mts
@@ -878,6 +878,113 @@ describe("ast-scanner", () => {
 		assert.ok(runtimeCalls.length >= 1, `Expected >=1 runtime-call, got ${runtimeCalls.length}`);
 	});
 
+	// ═══════════════════════════════════════════════════════════
+	// False-positive prevention: substring matching in import findings
+	// ═══════════════════════════════════════════════════════════
+
+	it("value import with false-positive substrings produces zero import-value findings", async () => {
+		const extDir = join(tmpDir, "false-pos-ext");
+		mkdirSync(extDir, { recursive: true });
+		// Each name below contains a PI_APIS short name as substring
+		// but has no exact match. "connect".includes("on") = true,
+		// "ExtensionAPI".includes("on") = true, "ExecResult".includes("exec") = true, etc.
+		writeFileSync(
+			join(extDir, "index.ts"),
+			[
+				`import { connect, ExtensionAPI, ExecResult, ExecOptions, isToolCallEventType } from "@earendil-works/pi-coding-agent";`,
+			].join("\n"),
+		);
+
+		const execFn = async (
+			cmd: string,
+			args: string[],
+		): Promise<{ stdout: string; stderr: string; code: number; killed: boolean }> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on", "pi.exec"], execFn, astGrepPath);
+
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			0,
+			`Expected 0 import-value findings for false-positive names, got ${valueImports.length}`,
+		);
+	});
+
+	it("Edge: empty value import produces zero findings, no crash", async () => {
+		const extDir = join(tmpDir, "empty-import-ext");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(join(extDir, "index.ts"), `import {} from "@earendil-works/pi-coding-agent";\n`);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on", "pi.exec"], execFn, astGrepPath);
+
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(valueImports.length, 0, "Empty import should produce 0 findings");
+	});
+
+	it("Edge: single exact match 'on' produces one pi.on import-value finding", async () => {
+		const extDir = join(tmpDir, "exact-match-on");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import { on } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(valueImports.length, 1, "Single exact match 'on' should produce 1 finding");
+		assert.strictEqual(valueImports[0]!.apiName, "pi.on");
+	});
+
+	it("Edge: multiple exact matches 'on, exec' produce two findings", async () => {
+		const extDir = join(tmpDir, "multi-exact-ext");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import { on, exec } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on", "pi.exec"], execFn, astGrepPath);
+
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			2,
+			`Multiple exact matches should produce 2 findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi.exec", "pi.on"]);
+	});
+
 	it("extracts call args from pi.on matches", async () => {
 		const extDir = join(tmpDir, "args-ext");
 		mkdirSync(extDir, { recursive: true });


### PR DESCRIPTION
## Audit Approved

### Summary

Fixed `findImportFindings()` substring matching bug where `importedNames.includes(api)` produced false positives for names like `connect` (containing "on") and `ExecResult` (containing "exec"). Changed to parse individual import names and exact-match against `PI_APIS` Set via `.has()`.

### How it works

Value-import branch now splits the comma-separated import names from the regex capture group, trims whitespace, and checks each name against `PI_APIS` using `Set.has()` (exact match) — same pattern already used at line 88 for runtime-call classification.

### Key decisions

- Accept: heuristic regex import parsing remains (higher complexity of full ast-grep scanning deferred to future PR, per architecture comment).

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (88/88 — `node --experimental-strip-types --test test/check-extensions.test.mts`)
- Test quality: ✓
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓
