### PR TITLE
feat(#219): Bug: lsp-auditor - retry mechanism broken (countRetryAttempts uses e.type instead of e.customType)

### DIFF
--- a/.pi/extensions/lsp-auditor/run-pre-audit.ts
+++ b/.pi/extensions/lsp-auditor/run-pre-audit.ts
@@ -17,6 +17,26 @@ import { auditFileGroup } from "./lsp-client.ts";
 import { readSettings } from "./settings.ts";
 
 /**
+ * Map session-storage entries to retry-logic shape.
+ *
+ * Session entries from `appendEntry()` have shape:
+ *   { type: "custom", customType: "<type>", data: <payload> }
+ * Retry logic expects:  { type: "<type>", payload: <payload> }
+ *
+ * Non-custom entries pass through with full entry as payload.
+ */
+export function mapSessionEntriesToRetryEntries(
+	entries: Array<Record<string, unknown>>,
+): Array<{ type: string; payload: unknown }> {
+	return entries.map((e) => {
+		if (e.type === "custom") {
+			return { type: (e.customType as string) ?? "", payload: e.data };
+		}
+		return { type: e.type as string, payload: e };
+	});
+}
+
+/**
  * Run pre-audit LSP diagnostics on modified files.
  *
  * Called by supervisor before transitioning Implementation → Audit.
@@ -110,7 +130,7 @@ export async function runPreAudit(
 
 	// 6. Check retry count
 	const sessionManager = ctx.sessionManager;
-	const entries = sessionManager.getEntries().map((e) => ({ type: e.type, payload: e }));
+	const entries = mapSessionEntriesToRetryEntries(sessionManager.getEntries());
 	const retryCount = countRetryAttempts(entries, issueNum);
 
 	if (!shouldRetry(retryCount)) {

--- a/test/lsp-auditor.test.mts
+++ b/test/lsp-auditor.test.mts
@@ -32,10 +32,86 @@ import {
 	shouldRetry,
 	MAX_RETRIES,
 } from "../.pi/extensions/lsp-auditor/retry.ts";
+import { mapSessionEntriesToRetryEntries } from "../.pi/extensions/lsp-auditor/run-pre-audit.ts";
 
 // =========================================================================
 // Tests
 // =========================================================================
+
+describe("mapSessionEntriesToRetryEntries", () => {
+	it("custom entry → maps customType as type and data as payload", () => {
+		const input = [
+			{ type: "custom", customType: "lsp-audit-retry", data: { issueNum: 42, attempt: 1 } },
+		];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.deepStrictEqual(result, [
+			{ type: "lsp-audit-retry", payload: { issueNum: 42, attempt: 1 } },
+		]);
+	});
+
+	it("non-custom entry → passes through unchanged", () => {
+		const input = [{ type: "message", text: "hello", turnIndex: 0 }];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.deepStrictEqual(result, [{ type: "message", payload: input[0] }]);
+	});
+
+	it("empty array → []", () => {
+		assert.deepStrictEqual(mapSessionEntriesToRetryEntries([]), []);
+	});
+
+	it("customType undefined → type: '' fallback", () => {
+		const input = [{ type: "custom", data: { issueNum: 7 } }];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.strictEqual(result[0]!.type, "");
+		assert.deepStrictEqual(result[0]!.payload, { issueNum: 7 });
+	});
+
+	it("customType empty string → type: ''", () => {
+		const input = [{ type: "custom", customType: "", data: { issueNum: 7 } }];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.strictEqual(result[0]!.type, "");
+		assert.deepStrictEqual(result[0]!.payload, { issueNum: 7 });
+	});
+
+	it("data null → payload null", () => {
+		const input = [{ type: "custom", customType: "lsp-audit-retry", data: null }];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.strictEqual(result[0]!.type, "lsp-audit-retry");
+		assert.strictEqual(result[0]!.payload, null);
+	});
+
+	it("data undefined → payload undefined", () => {
+		const input = [{ type: "custom", customType: "lsp-audit-retry" }];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.strictEqual(result[0]!.type, "lsp-audit-retry");
+		assert.strictEqual(result[0]!.payload, undefined);
+	});
+
+	it("mixed entries → each mapped independently", () => {
+		const input = [
+			{ type: "message", text: "hello" },
+			{ type: "custom", customType: "lsp-audit-retry", data: { issueNum: 1 } },
+			{ type: "model_change", model: "claude" },
+		];
+		const result = mapSessionEntriesToRetryEntries(input);
+		assert.strictEqual(result.length, 3);
+		assert.strictEqual(result[0]!.type, "message");
+		assert.strictEqual(result[1]!.type, "lsp-audit-retry");
+		assert.deepStrictEqual(result[1]!.payload, { issueNum: 1 });
+		assert.strictEqual(result[2]!.type, "model_change");
+		assert.strictEqual(result[2]!.payload, input[2]);
+	});
+
+	it("mapped entries fed to countRetryAttempts → correct count", () => {
+		const entries = [
+			{ type: "custom", customType: "lsp-audit-retry", data: { issueNum: 42, attempt: 1 } },
+			{ type: "custom", customType: "lsp-audit-retry", data: { issueNum: 42, attempt: 2 } },
+			{ type: "custom", customType: "other-type", data: { issueNum: 42 } },
+		];
+		const mapped = mapSessionEntriesToRetryEntries(entries);
+		assert.strictEqual(countRetryAttempts(mapped, 42), 2);
+	});
+});
 
 describe("formatDiagnostics", () => {
 	it("empty array → empty string", () => {


### PR DESCRIPTION
## Audit Approved

### Summary
Fix broken retry mechanism in lsp-auditor — session entry mapping used `e.type` (always `"custom"`) instead of `e.customType` (actual retry discriminator), causing `countRetryAttempts` to always return 0 and `shouldRetry` to never exhaust.

### How it works
Extracted `mapSessionEntriesToRetryEntries()` in `run-pre-audit.ts` — adapter function that translates session-storage entry shape (`{type, customType, data}`) to retry-logic shape (`{type, payload}`). When `e.type === "custom"`, uses `e.customType` as `type` and `e.data` as `payload`. Non-custom entries pass through unchanged. `retry.ts` is untouched — boundary preserved.

### Key decisions
- **Adapter layer** — mapping lives in `run-pre-audit.ts` (outer adapter), not `retry.ts` (inner domain), respecting Dependency Rule
- **`?? ""` fallback** — if `customType` undefined for a custom entry, type becomes empty string (safe skip in `countRetryAttempts`)
- **Extracted as pure function** — exported for direct unit testing without mocking

### Review findings
- 🟢 _Suggestion_ — `mapSessionEntriesToRetryEntries` could add a type guard narrowing `Record<string, unknown>` to known shape, but the function is small and well-documented; acceptable as-is.

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (ran: `node --experimental-strip-types --test test/lsp-auditor.test.mts test/lsp-auditor-settings.test.mts`)
- Test quality: ✓
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓

PR created. Ready for merge.
