### PR TITLE
feat(#238): Bug: session-advice - detectRedundantReads and detectImmediateRedundantRead double-report same issue

### DIFF
--- a/.pi/extensions/session-advice/advisor.ts
+++ b/.pi/extensions/session-advice/advisor.ts
@@ -269,40 +269,6 @@ function detectRedundantReads(data: SessionData): AdviceEntry[] {
 }
 
 /**
- * Rule 3b: Immediate redundant read — same file path read within 1 turn.
- * Tighter window than existing redundant-read (2 turns). Separate category.
- */
-function detectImmediateRedundantRead(data: SessionData): AdviceEntry[] {
-	const results: AdviceEntry[] = [];
-	const reads: Array<{ path: string; turnIndex: number }> = [];
-
-	for (const entry of data.entries) {
-		if (entry.toolName !== "read") continue;
-
-		const p = (entry.args?.path ?? entry.text ?? "") as string;
-		if (!p) continue;
-		const ti = entry.turnIndex;
-
-		const recent = reads.filter(
-			(r) => r.path === p && Math.abs(r.turnIndex - ti) <= 1 && r.turnIndex !== ti,
-		);
-		if (recent.length > 0) {
-			results.push({
-				severity: "warning",
-				category: "immediate-redundant-read",
-				detail: `\`${shortPath(p)}\` read again within 1 turn (turn ${ti})`,
-				recommendation: `For \`${shortPath(p)}\`, use \`read(path, offset, limit)\` to page. Read once, cache results.`,
-				turns: [Math.min(...recent.map((r) => r.turnIndex), ti), ti],
-			});
-		}
-
-		reads.push({ path: p, turnIndex: ti });
-	}
-
-	return results;
-}
-
-/**
  * Rule 4: Error not actioned — tool error followed by same tool retry.
  */
 function detectErrorNotActioned(data: SessionData): AdviceEntry[] {
@@ -491,7 +457,6 @@ export function analyzeSession(data: SessionData): AdviceResult {
 		...detectSameToolCascade(data),
 		...detectToolMismatch(data),
 		...detectRedundantReads(data),
-		...detectImmediateRedundantRead(data),
 		...detectErrorNotActioned(data),
 		...detectToolCoverageGap(data),
 		...detectStructuralSearchUnderuse(data),
@@ -516,7 +481,6 @@ export function analyzeSession(data: SessionData): AdviceResult {
 		"identical-call-loop": 0.35,
 		"same-tool-cascade": 0.2,
 		"redundant-read": 0.15,
-		"immediate-redundant-read": 0.15,
 		"high-error-rate": 0.3,
 		"excessive-turns": 0.15,
 		"tool-coverage-gap": 0.1,

--- a/.pi/extensions/session-advice/index.ts
+++ b/.pi/extensions/session-advice/index.ts
@@ -55,10 +55,6 @@ const FIXES: Record<string, FixSuggestion> = {
 		idea: "Add auto-detection hook: when code files read/edited but structural_search never called in first 3 turns, emit in-context reminder to use AST queries. Code reminder over AGENTS.md mention.",
 		effort: "Low",
 	},
-	"immediate-redundant-read": {
-		idea: "Add harness interceptor: flag same-path reads within 1 turn and suggest offset/limit paging. Code-based detection over rule in AGENTS.md.",
-		effort: "Low",
-	},
 	"structural-search-underuse": {
 		idea: "Add runtime counter: track read/edit calls on code files. If count hits 3 and structural_search never invoked, auto-prompt agent with AST query suggestion. Code trigger over AGENTS.md instruction.",
 		effort: "Low",

--- a/README.md
+++ b/README.md
@@ -414,8 +414,7 @@ Detects inefficient patterns in each session and writes `.advice.md` alongside t
 | Same-tool cascade | warning | `bash` called 12x consecutively |
 | Tool coverage gap | warning | Code files present but `structural_search` unused |
 | Structural-search underuse | warning | 3+ code files read/edited, `structural_search` never called |
-| Redundant reads | warning | Same file read 3x within 2 turns |
-| Immediate redundant read | warning | Same file read again within 1 turn |
+| Redundant reads | warning | Same file read within 2 turns |
 | Excessive turns | warning | 20+ tool calls with no file changes |
 
 **Feedback loop (before_agent_start):** On next session start, reads `latest.advice.md` and injects top 3 past findings as `⚠️ Past Session Lessons` into system prompt — agent learns from its own mistakes without manual intervention.

--- a/test/session-advice-advisor.test.mts
+++ b/test/session-advice-advisor.test.mts
@@ -66,7 +66,7 @@ function readToolError(turnIndex: number): SessionEntry {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("analyzeSession → immediate-redundant-read", () => {
+describe("analyzeSession → redundant-read", () => {
 	it("flags same file read within 1-turn window", () => {
 		const data = makeSession([readEntry("/repo/src/app.ts", 0), readEntry("/repo/src/app.ts", 1)]);
 		const result = analyzeSession(data);
@@ -212,32 +212,6 @@ describe("analyzeSession → structural-search-underuse (new rule)", () => {
 		const result = analyzeSession(data);
 		const underuse = result.entries.filter((e) => e.category === "structural-search-underuse");
 		assert.strictEqual(underuse.length, 0, "should not flag when structural_search used");
-	});
-});
-
-describe("analyzeSession → immediate-redundant-read (new rule)", () => {
-	it("flags same file read within 1 turn", () => {
-		const data = makeSession([readEntry("/repo/src/app.ts", 0), readEntry("/repo/src/app.ts", 1)]);
-		const result = analyzeSession(data);
-		const imm = result.entries.filter((e) => e.category === "immediate-redundant-read");
-		assert.ok(imm.length >= 1, "should flag immediate redundant read");
-	});
-
-	it("does NOT flag same file read 2+ turns apart", () => {
-		const data = makeSession([readEntry("/repo/src/app.ts", 0), readEntry("/repo/src/app.ts", 2)]);
-		const result = analyzeSession(data);
-		const imm = result.entries.filter((e) => e.category === "immediate-redundant-read");
-		assert.strictEqual(imm.length, 0, "2 turns apart should not flag immediate");
-	});
-
-	it("coexists with existing redundant-read (2-turn window)", () => {
-		const data = makeSession([readEntry("/repo/src/app.ts", 0), readEntry("/repo/src/app.ts", 1)]);
-		const result = analyzeSession(data);
-		const imm = result.entries.filter((e) => e.category === "immediate-redundant-read");
-		const red = result.entries.filter((e) => e.category === "redundant-read");
-		// Both should fire: same file within 1 turn triggers both rules
-		assert.ok(imm.length >= 1, "immediate-redundant-read should fire");
-		assert.ok(red.length >= 1, "existing redundant-read should also fire");
 	});
 });
 


### PR DESCRIPTION
## Audit Approved

### Summary
Remove `detectImmediateRedundantRead` function and all references. It duplicated `detectRedundantReads` with narrower window (≤1 turn vs ≤2 turns). Both had same severity, weight, recommendation — no actionable difference lost.

### How it works
`detectRedundantReads` (window ≤2 turns) already subsumes ≤1-turn window. Single function now handles all redundant-read detection. Dedup in `analyzeSession` continues merging same-category+detail entries. No output schema change.

### Review findings

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (19/19 pass, 0 fail)
- Test quality: ✓
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓
