### PR TITLE
feat(#235): Agent Harness: isCatHeadTailInBash blocks valid patterns, cascade fires on legitimate multi-step bash

### DIFF
--- a/.pi/extensions/agent-harness/index.test.ts
+++ b/.pi/extensions/agent-harness/index.test.ts
@@ -695,3 +695,192 @@ describe("agent-harness integration with mock ExtensionAPI", () => {
 		assert.ok(pass == null, "read after blocked cache hit should pass");
 	});
 });
+
+// ── Phase 2: CallCounter subKey cascade (Bug 3) ──
+
+describe("Bug 3 fix: CallCounter subKey cascade", () => {
+	it("8 bash calls with same sub-command — 8th blocked", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		let result: ToolCallResult | null = null;
+		for (let i = 0; i < 8; i++) {
+			result = handler(makeEvent("bash", { command: "ls -la" }), makeCtx());
+			if (i < 7) {
+				assert.equal(result, null, `bash ls call ${i + 1} should pass`);
+			}
+		}
+		assert.ok(result?.block, "8th same-subKey bash call should block");
+	});
+
+	it("diverse bash sub-commands never block", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		const commands = [
+			"ls",
+			"cd src",
+			"file index.ts",
+			"stat main.ts",
+			"timeout 10",
+			"find .",
+			"git log",
+			"npm test",
+		];
+		for (let i = 0; i < commands.length; i++) {
+			const result = handler(makeEvent("bash", { command: commands[i] }), makeCtx());
+			assert.equal(result, null, `diverse cmd ${i} (${commands[i]}) should pass`);
+		}
+	});
+
+	it("8 git sub-commands — 8th blocked (same-subKey bash:git)", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		const gitCommands = [
+			"git status",
+			"git diff",
+			"git log",
+			"git stash",
+			"git branch",
+			"git merge",
+			"git push",
+			"git pull",
+		];
+		let result: ToolCallResult | null = null;
+		for (let i = 0; i < gitCommands.length; i++) {
+			result = handler(makeEvent("bash", { command: gitCommands[i] }), makeCtx());
+			if (i < 7) {
+				assert.equal(result, null, `git cmd ${i} should pass`);
+			}
+		}
+		assert.ok(result?.block, "8th git sub-command should block");
+	});
+
+	it("bash subKey resets when switching between different first tokens", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// bash:ls ×4 → bash:cd ×4 → bash:ls ×4 — never blocks
+		for (let round = 0; round < 3; round++) {
+			for (let i = 0; i < 4; i++) {
+				const cmd = round === 1 ? "cd .." : "ls";
+				const result = handler(makeEvent("bash", { command: cmd }), makeCtx());
+				assert.equal(result, null, `bash ${cmd} round ${round} call ${i} should pass`);
+			}
+		}
+
+		// Final check: total 12 calls, 0 blocks
+		assert.equal(state.currentTurn, 12);
+	});
+
+	it("non-bash tool cascade still works (backward compat)", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		let result: ToolCallResult | null = null;
+		for (let i = 0; i < 8; i++) {
+			result = handler(makeEvent("write", { path: `f${i}.ts`, content: "" }), makeCtx());
+			if (i < 7) {
+				assert.equal(result, null, `write call ${i + 1} should pass`);
+			}
+		}
+		assert.ok(result?.block, "8th write call should block (backward compat)");
+	});
+
+	it("bash empty command recorded without subKey — backward compat", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// Empty command passes through, no subKey extracted
+		const r1 = handler(makeEvent("bash", {}), makeCtx());
+		assert.equal(r1, null);
+
+		// Next bash call with command — should be different subKey vs no subKey
+		const r2 = handler(makeEvent("bash", { command: "echo hi" }), makeCtx());
+		assert.equal(r2, null);
+
+		// Since empty command had no subKey and echo has subKey "echo",
+		// they're different keys, so both have count 1.
+		// Total turns: 2
+		assert.equal(state.currentTurn, 2);
+	});
+});
+
+// ── Phase 3: Read cache [pending] same-turn pass-through (Bug 5) ──
+
+describe("Bug 5 fix: read cache [pending] same-turn pass-through", () => {
+	it("same-turn [pending] re-read passes through", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// First read at turn 0: cache miss, set [pending], pass
+		const r1 = handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+		assert.equal(r1, null);
+		assert.equal(state.currentTurn, 1);
+
+		// Reset turn to 0 to simulate same-turn re-read
+		state.currentTurn = 0;
+
+		// Second read at turn 0: cache hit with [pending] at turn 0 → pass through
+		const r2 = handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+		assert.equal(r2, null, "same-turn [pending] should pass through");
+	});
+
+	it("cross-turn [pending] re-read blocks", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// First read: turn 0, sets [pending]
+		handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+		assert.equal(state.currentTurn, 1);
+
+		// Second read at turn 1: cache hit with [pending] at turn 0
+		// Since cached.turn(0) !== currentTurn(1), it blocks
+		const r2 = handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+		assert.ok(r2?.block, "cross-turn [pending] should block");
+	});
+
+	it("same-turn normal content still blocks", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// Manually set cache with real content at turn 0
+		state.readCache.set("a.ts|0|", "real content", 0);
+
+		// Read at turn 0: cache hit with real content at turn 0 → block
+		const r1 = handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+		assert.ok(r1?.block, "same-turn real content should still block");
+	});
+
+	it("different cache keys both pass", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// Read with offset 0, limit 100
+		const r1 = handler(makeEvent("read", { path: "a.ts", offset: 0, limit: 100 }), makeCtx());
+		assert.equal(r1, null);
+
+		// Reset turn to 0 for same-turn
+		state.currentTurn = 0;
+
+		// Read with offset 100, limit 100 — different cache key, should pass
+		const r2 = handler(makeEvent("read", { path: "a.ts", offset: 100, limit: 100 }), makeCtx());
+		assert.equal(r2, null, "different offset should have different cache key");
+	});
+
+	it("TTL-expired [pending] cache miss passes through", () => {
+		const state = createHarnessState();
+		const handler = createToolCallHandler(state);
+
+		// First read at turn 0: sets [pending]
+		handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+
+		// Set turn to 6 (CACHE_TTL_TURNS = 6, diff >= 6 → TTL expired)
+		state.currentTurn = 6;
+
+		// Re-read: cache TTL expired, miss, pass through
+		const r2 = handler(makeEvent("read", { path: "a.ts" }), makeCtx());
+		assert.equal(r2, null, "TTL-expired cache miss should pass through");
+	});
+});

--- a/.pi/extensions/agent-harness/index.ts
+++ b/.pi/extensions/agent-harness/index.ts
@@ -125,10 +125,15 @@ export function createToolCallHandler(state: HarnessState) {
 					const cacheKey = `${path}|${offset}|${limit}`;
 					const cached = state.readCache.get(cacheKey, turn);
 					if (cached) {
-						result = {
-							block: true,
-							reason: `Content cached from turn ${cached.turn} — use offset/limit to page or re-read after 3 turns.`,
-						};
+						// Same-turn [pending] → pass through (let re-read happen)
+						if (cached.content === "[pending]" && cached.turn === turn) {
+							// result stays null, pass through
+						} else {
+							result = {
+								block: true,
+								reason: `Content cached from turn ${cached.turn} — use offset/limit to page or re-read after 3 turns.`,
+							};
+						}
 					} else {
 						// Store marker to track that this path+offset+limit was recently read
 						state.readCache.set(cacheKey, "[pending]", turn);
@@ -137,12 +142,20 @@ export function createToolCallHandler(state: HarnessState) {
 			}
 		}
 
+		// ── Extract bash subKey for sub-command-aware cascade detection ──
+		// First token of bash command becomes subKey. Empty/absent command → undefined.
+		const bashSubKey =
+			toolName === "bash"
+				? ((args.command ?? "") as string).trim().split(/\s+/)[0] || undefined
+				: undefined;
+
 		// ── 5. Same-tool cascade detection (skip read — cache handles redundant reads) ──
 		// Cascade check uses count + 1 BEFORE recording, accounting for current call
 		// without recording it (if blocked, call is not real).
+		// Uses bashSubKey for sub-command-aware cascade (Bug 3 fix).
 		if (!result && toolName !== "read") {
 			const cascadeThreshold = meta.cascadeThreshold ?? CASCADE_THRESHOLD;
-			const consecutive = state.callCounter.getConsecutive(toolName);
+			const consecutive = state.callCounter.getConsecutive(toolName, bashSubKey);
 			// Add 1 for current call (not yet recorded)
 			const effectiveCount = consecutive.count + 1;
 			if (effectiveCount >= cascadeThreshold) {
@@ -189,8 +202,9 @@ export function createToolCallHandler(state: HarnessState) {
 		// ── 7. Record only if NOT blocked ──
 		// Blocked calls (any guard) are NOT recorded (Bug 5 fix)
 		// so they don't inflate the cascade counter.
+		// Uses bashSubKey for sub-command-aware cascade (Bug 3 fix).
 		if (!result) {
-			state.callCounter.record(toolName, turn);
+			state.callCounter.record(toolName, turn, bashSubKey);
 		}
 
 		// ── 8. Increment turn for every code path, return result ──

--- a/.pi/lib/harness-state.ts
+++ b/.pi/lib/harness-state.ts
@@ -49,10 +49,17 @@ export interface ErrorTracker {
 }
 
 export interface CallCounter {
-	/** Record a tool call. Resets consecutive count if tool changes. */
-	record(toolName: string, turn: number): void;
-	/** Get consecutive call info for a tool. */
-	getConsecutive(toolName: string): ConsecutiveInfo;
+	/**
+	 * Record a tool call. Resets consecutive count if composite key changes.
+	 * Composite key = toolName:subKey (when subKey provided) or just toolName.
+	 * Different subKey within same tool resets the counter.
+	 */
+	record(toolName: string, turn: number, subKey?: string): void;
+	/**
+	 * Get consecutive call info for a composite key.
+	 * Returns count 0 if composite key doesn't match the last recorded key.
+	 */
+	getConsecutive(toolName: string, subKey?: string): ConsecutiveInfo;
 	/** Reset all counters. */
 	reset(): void;
 }
@@ -140,15 +147,21 @@ export function createHarnessState(): HarnessState {
 
 	// ── Call Counter ──
 
-	let lastToolName = "";
+	let lastKey: string | null = null;
 	let consecutiveCount = 0;
 	let sinceTurn = 0;
 
+	/** Build composite key from toolName and optional subKey. */
+	function makeKey(toolName: string, subKey?: string): string {
+		return subKey !== undefined ? `${toolName}\x00${subKey}` : toolName;
+	}
+
 	const callCounter: CallCounter = {
-		record(toolName: string, turn: number): void {
-			if (toolName !== lastToolName) {
-				// Tool changed — reset counter for previous tool
-				lastToolName = toolName;
+		record(toolName: string, turn: number, subKey?: string): void {
+			const key = makeKey(toolName, subKey);
+			if (key !== lastKey) {
+				// Composite key changed — reset counter
+				lastKey = key;
 				consecutiveCount = 1;
 				sinceTurn = turn;
 			} else {
@@ -156,19 +169,20 @@ export function createHarnessState(): HarnessState {
 			}
 		},
 
-		getConsecutive(toolName: string): ConsecutiveInfo {
-			if (toolName !== lastToolName) {
+		getConsecutive(toolName: string, subKey?: string): ConsecutiveInfo {
+			const key = makeKey(toolName, subKey);
+			if (key !== lastKey) {
 				return { toolName: "", count: 0, sinceTurn: 0 };
 			}
 			return {
-				toolName: lastToolName,
+				toolName,
 				count: consecutiveCount,
 				sinceTurn,
 			};
 		},
 
 		reset(): void {
-			lastToolName = "";
+			lastKey = null;
 			consecutiveCount = 0;
 			sinceTurn = 0;
 		},

--- a/test/agent-harness-state.test.mts
+++ b/test/agent-harness-state.test.mts
@@ -199,6 +199,80 @@ describe("CallCounter", () => {
 		const info = state.callCounter.getConsecutive("bash");
 		assert.strictEqual(info.sinceTurn, 5);
 	});
+
+	// ── subKey support (Bug 3 fix) ──
+
+	it("records first subKey call", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0, "ls");
+		const info = state.callCounter.getConsecutive("bash", "ls");
+		assert.strictEqual(info.toolName, "bash");
+		assert.strictEqual(info.count, 1);
+		assert.strictEqual(info.sinceTurn, 0);
+	});
+
+	it("different subKey resets counter", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0, "ls");
+		state.callCounter.record("bash", 1, "cd");
+		const cdInfo = state.callCounter.getConsecutive("bash", "cd");
+		assert.strictEqual(cdInfo.count, 1);
+	});
+
+	it("same subKey increments counter", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0, "ls");
+		state.callCounter.record("bash", 0, "ls");
+		state.callCounter.record("bash", 0, "ls");
+		const info = state.callCounter.getConsecutive("bash", "ls");
+		assert.strictEqual(info.count, 3);
+	});
+
+	it("stale subKey returns count 0", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0, "ls");
+		state.callCounter.record("bash", 1, "cd");
+		const lsInfo = state.callCounter.getConsecutive("bash", "ls");
+		assert.strictEqual(lsInfo.count, 0);
+	});
+
+	it("no subKey maintains backward compat", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0);
+		state.callCounter.record("bash", 1);
+		const info = state.callCounter.getConsecutive("bash");
+		assert.strictEqual(info.count, 2);
+	});
+
+	it("subKey resets on tool switch", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0, "ls");
+		state.callCounter.record("read", 1);
+		const readInfo = state.callCounter.getConsecutive("read");
+		assert.strictEqual(readInfo.count, 1);
+		const bashLsInfo = state.callCounter.getConsecutive("bash", "ls");
+		assert.strictEqual(bashLsInfo.count, 0);
+	});
+
+	it("no subKey tools maintain backward compat count", () => {
+		const state = createHarnessState();
+		state.callCounter.record("write", 0);
+		state.callCounter.record("write", 1);
+		state.callCounter.record("write", 2);
+		const info = state.callCounter.getConsecutive("write");
+		assert.strictEqual(info.count, 3);
+	});
+
+	it("reset clears subKey counters", () => {
+		const state = createHarnessState();
+		state.callCounter.record("bash", 0, "ls");
+		state.callCounter.record("bash", 1, "cd");
+		state.callCounter.record("read", 2);
+		state.callCounter.reset();
+		assert.strictEqual(state.callCounter.getConsecutive("bash", "ls").count, 0);
+		assert.strictEqual(state.callCounter.getConsecutive("bash", "cd").count, 0);
+		assert.strictEqual(state.callCounter.getConsecutive("read").count, 0);
+	});
 });
 
 // ─── Factory isolation ────────────────────────────────────────────


### PR DESCRIPTION
## Audit Approved

### Summary
Fix Bug 3 (same-tool cascade fires on diverse bash commands) and Bug 5 (read cache [pending] blocks same-turn re-read). Bug 1+2+4 already fixed in prior work.

### How it works
**Bug 3:** `CallCounter.record()` gains optional `subKey` param. Composite key `toolName\x00subKey` tracks consecutive calls per sub-command. Bash first token becomes subKey — `ls`→`cd`→`file` resets counter each time. `git status`→`git diff`→...→`git pull` all share `bash:git` counter (same-family cascade still detected).

**Bug 5:** Read cache guard checks if cached content is `[pending]` from same turn — if so, treated as cache miss (pass through). Cross-turn `[pending]` still blocks.

### Key decisions
- Null-byte separator `\x00` in composite key safe — never appears in valid tool names.
- Git-family cascades (8 consecutive git ops) still blocked — same-subKey is still a loop, just broader than before.
- Same-turn normal content re-read still blocked — `[pending]` is the only same-turn bypass.

### Review findings
🟢 **Code Quality** — `makeKey()` uses `\x00` separator. Unusual but safe. Considered hyphens or dots but none guaranteed absent from tool names.

- Architecture compliance: ✓
- Ticket fulfillment: ✓
- Tests passed: ✓ (ran: node --experimental-strip-types --test test/agent-harness-state.test.mts test/agent-harness-rules.test.mts .pi/extensions/agent-harness/index.test.ts)
- Test quality: ✓
- Correctness & Safety: ✓
- Code quality: ✓
- Completeness: ✓
