### PR TITLE
feat(#247): Bug: lsp-auditor - withTimeout() causes unhandled promise rejection on LSP timeout

### DIFF
--- a/.pi/extensions/lsp-auditor/lsp-client.ts
+++ b/.pi/extensions/lsp-auditor/lsp-client.ts
@@ -88,12 +88,35 @@ function lspSeverityToLabel(severity: number): "Error" | "Warning" | "Informatio
 	}
 }
 
-/** Promise with timeout */
-function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
-	return Promise.race([
-		promise,
-		new Promise<null>((resolve) => setTimeout(() => resolve(null), ms)),
-	]);
+/** Promise with timeout — guarded against unhandled rejections from losing promise */
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T | null> {
+	// Use a settled flag so the losing settlement is silently absorbed.
+	// This prevents unhandled rejections when connection.dispose() rejects
+	// a timed-out sendRequest promise (issue #247), while still propagating
+	// rejections that occur before the timeout fires.
+	let settled = false;
+	return new Promise<T | null>((resolve, reject) => {
+		promise.then(
+			(val) => {
+				if (!settled) {
+					settled = true;
+					resolve(val);
+				}
+			},
+			(err) => {
+				if (!settled) {
+					settled = true;
+					reject(err);
+				}
+			},
+		);
+		setTimeout(() => {
+			if (!settled) {
+				settled = true;
+				resolve(null);
+			}
+		}, ms);
+	});
 }
 
 function sleep(ms: number): Promise<void> {

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
@@ -1,0 +1,135 @@
+/**
+ * Tests for lsp-auditor withTimeout fix.
+ *
+ * Unit tests: pure promise logic, zero I/O, runs <100ms.
+ * Verifies the withTimeout helper properly absorbs post-timeout rejections
+ * to prevent unhandled promise rejections (issue #247).
+ */
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { withTimeout } from "../lsp-client.ts";
+
+// ── Helpers ──
+
+/** Creates a deferred promise for test control */
+function deferredPromise<T>(): {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason: unknown) => void;
+} {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+// ── Tests ──
+
+describe("withTimeout", () => {
+	// ── Happy paths ──
+
+	it("returns null when timeout wins", async () => {
+		const deferred = deferredPromise<string>();
+		const start = Date.now();
+		const result = await withTimeout(deferred.promise, 10);
+		const elapsed = Date.now() - start;
+		assert.equal(result, null);
+		assert.ok(elapsed >= 8, "should wait for timeout");
+	});
+
+	it("returns value when promise wins before timeout", async () => {
+		const result = await withTimeout(Promise.resolve("hello"), 1000);
+		assert.equal(result, "hello");
+	});
+
+	// ── Error path ──
+
+	it("propagates rejection when promise rejects before timeout", async () => {
+		await assert.rejects(withTimeout(Promise.reject(new Error("early fail")), 1000), /early fail/);
+	});
+
+	// ── Bug fix: losing promise rejects after timeout ──
+
+	it("does not emit unhandledRejection when losing promise rejects after timeout", async () => {
+		const deferred = deferredPromise<string>();
+		let unhandledRejectionFired = false;
+
+		// Capture any unhandled rejection during this test
+		const handler = (err: Error) => {
+			unhandledRejectionFired = true;
+		};
+		process.on("unhandledRejection", handler);
+
+		try {
+			// Timeout wins (10ms timeout)
+			const result = await withTimeout(deferred.promise, 10);
+			assert.equal(result, null);
+
+			// Now reject the deferred promise — this simulates connection.dispose()
+			// rejecting a pending sendRequest promise after timeout.
+			deferred.reject(new Error("late rejection after timeout"));
+
+			// Give microtask queue a chance to settle
+			await new Promise((r) => setTimeout(r, 5));
+
+			// The .catch(() => {}) guard should have swallowed this rejection
+			assert.equal(
+				unhandledRejectionFired,
+				false,
+				"post-timeout rejection must not cause unhandledRejection",
+			);
+		} finally {
+			process.off("unhandledRejection", handler);
+		}
+	});
+
+	// ── Edge cases ──
+
+	it("returns null when ms=0 (immediate timeout)", async () => {
+		const deferred = deferredPromise<string>();
+		const result = await withTimeout(deferred.promise, 0);
+		assert.equal(result, null);
+	});
+
+	it("returns null when ms is negative (immediate timeout)", async () => {
+		const deferred = deferredPromise<string>();
+		const result = await withTimeout(deferred.promise, -1);
+		assert.equal(result, null);
+	});
+
+	it("returns value when promise is already resolved", async () => {
+		const result = await withTimeout(Promise.resolve("immediate"), 10_000);
+		assert.equal(result, "immediate");
+	});
+
+	it("propagates rejection when promise is already rejected", async () => {
+		await assert.rejects(
+			withTimeout(Promise.reject(new Error("already failed")), 10_000),
+			/already failed/,
+		);
+	});
+
+	it("returns null after exact timeout (not before)", async () => {
+		const deferred = deferredPromise<string>();
+		const start = Date.now();
+		const result = await withTimeout(deferred.promise, 50);
+		const elapsed = Date.now() - start;
+		assert.equal(result, null);
+		assert.ok(elapsed >= 45, "should wait ~50ms before returning null");
+	});
+
+	it("promise value type is preserved (number)", async () => {
+		const result = await withTimeout(Promise.resolve(42), 100);
+		assert.equal(result, 42);
+	});
+
+	it("promise value type is preserved (object)", async () => {
+		const obj = { foo: "bar" };
+		const result = await withTimeout(Promise.resolve(obj), 100);
+		assert.deepEqual(result, obj);
+	});
+});


### PR DESCRIPTION
💭 ...
💭 COMMENT_BODY:
💭 ...
💭 ```
💭 Or for reject:
💭 ```
💭 AUDIT_DECISION: REJECTED
💭 COMMENT_BODY:
💭 ...
💭 ```
💭 And then at the very end output `AUDIT_APPROVED` or `AUDIT_REJECTED` on its own line.
💭 Also need to compute the audit score:
💭 ```
💭 AUDIT_SCORE: 6/6
💭 ```
💭 All 6 dimensions pass - no critical or warning findings.
💭 Let me compose the PR body with the structured summary.
All tests pass. Let me verify the implementation once more against the architecture and edge cases.
🔧 read {"path":"/home/miria/git/worktree-git-issue-247-bug-lsp-auditor-withtimeout-causes-unhandled-promi/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts"}
✓ read
📋 read: /**
    * Tests for lsp-auditor withTimeout fix.
    *
    * Unit tests: pure promise logic, zero I/O, runs <100ms.
    * Verifies the withTimeout helper properly absorbs post-timeout rejections
    * to prevent unhandled promise rejections (issue #247).
💭 Everything looks solid. Let me compose my final response.
💭 Key strengths of the implementation:
💭 1. Better than the Architecture suggestion — uses settled flag instead of `.catch(() => {})`, preserving pre-timeout rejection propagation
💭 2. All 11 tests pass including the critical regression test for unhandled rejection
💭 3. No TODOs, no dead code, no security concerns
💭 4. Zero changes to other files
💭 5. Clean, well-commented code
💭 All 6 dimensions pass without any critical or warning findings. Score: 6/6.
🔧 bash {"command":"cd /home/miria/git/worktree-git-issue-247-bug-lsp-auditor-withtimeout-causes-unhandled-promi && node --experimental-strip-types --test --test-timeout=30000 .pi/extensions/lsp-auditor/test/
✓ bash
📋 bash: TAP version 13
   # Subtest: withTimeout
       # Subtest: returns null when timeout wins
       ok 1 - returns null when timeout wins
         ---
💭 All tests passed. Let me now compose the structured output.
💭 Let me also check: the instructions say OUTPUT the decision markers. The pipeline reads them. Let me structure this correctly.
💭 Now let me check whether the PR_TITLE should be "feat(#247): ..." or what. The instructions say:
💭 ```
💭 PR_TITLE: feat(#247): Bug: lsp-auditor - withTimeout() causes unhandled promise rejection on LSP timeout
💭 ```
💭 Let me use the format from the structured output section.
💭 Actually wait, I need to check the format more carefully:
💭 **IF APPROVE:**
💭 ```
💭 AUDIT_DECISION: APPROVED
💭 PR_TITLE: feat(#247): Bug: lsp-auditor - withTimeout() causes unhandled promise rejection on LSP timeout
💭 PR_BODY:
💭 ## Audit Approved
💭 ...PR body content...
💭 COMMENT_BODY:
💭 ## Audit Approved
💭 ...comment body...
💭 ```
💭 Then at the end, output AUDIT_APPROVED on its own line.
💭 Also need AUDIT_SCORE: 6/6
All 11 tests pass. No TODOs, no dead code, no README changes needed (internal fix). Implementation is clean and correct.
Let me now evaluate systematically across all six dimensions:
**Architecture Compliance:** Fix exactly where specified (`lsp-client.ts:withTimeout`). Signature unchanged. Only export added. Zero changes to domain/data types. Implementation actually **improves** on the Architect's suggestion — uses settled flag instead of `.catch(() => {})`, preserving pre-timeout rejection propagation that the simpler approach would silently swallow.
**Test Quality:** 11 unit tests covering all scenarios from test plan: happy paths (timeout wins, promise wins), error path (rejection before timeout), the critical bug-fix regression test (no `unhandledRejection` after timeout), and all edge cases (ms=0, ms negative, already resolved, already rejected, type preservation). Tests use clean Arrange-Act-Assert pattern with proper cleanup.
**Ticket Fulfillment:** Root cause fixed (orphaned promise from `Promise.race` with no `.catch()`). Both call sites (initialize, shutdown) benefit. Behavior matches expected: timeout returns `null` gracefully, post-timeout rejections absorbed.
**Correctness & Safety:** No security concerns. No resource leaks. Pre-timeout rejection propagation preserved (superior to `.catch(() => {})` approach). Post-timeout rejections silently absorbed via `settled` flag.
**Code Quality:** Clean, minimal change. Comment explains rationale. Function small and focused. No duplication.
**Completeness:** All edge cases handled. No TODOs. No dead code.