### PR TITLE
feat(#167): Add skills field to agent frontmatter for supervisor

### DIFF
--- a/.pi/extensions/supervisor/agent-runner.ts
+++ b/.pi/extensions/supervisor/agent-runner.ts
@@ -8,7 +8,7 @@
 import type { AgentRunResult, AgentRunState, AgentPhase, ParsedAgent } from "./types";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { spawn } from "node:child_process";
-import { resolveTools, resolveExtensions } from "./extensions";
+import { resolveTools, resolveExtensions, resolveSkillPaths } from "./extensions";
 import { formatDuration, extractSummaryLine, formatTokens } from "./formatting";
 import { resolveTimeoutMs, DEFAULT_AGENT_TIMEOUT_MS } from "./config";
 import {
@@ -64,6 +64,7 @@ export async function runAgentSubprocess(
 	const tools = resolveTools(rawTools, agent.config.extensions, effectiveCwd);
 	const model = agent.config.model || "";
 	const extFlags = resolveExtensions(agent.config.extensions);
+	const skillPaths = resolveSkillPaths(agent.config.skills, effectiveCwd);
 
 	const args: string[] = [
 		"-p",
@@ -76,6 +77,7 @@ export async function runAgentSubprocess(
 		tools,
 		...extFlags,
 		"--no-skills",
+		...skillPaths.flatMap((p) => ["--skill", p]),
 		"--no-context-files",
 	];
 	if (model) args.push("--model", model);

--- a/.pi/extensions/supervisor/agents/architect.md
+++ b/.pi/extensions/supervisor/agents/architect.md
@@ -5,6 +5,7 @@ tools: read, bash, structural_search, ripgrep_search, ranked_map
 model: opencode-go/deepseek-v4-flash
 thinking: high
 extensions: "agent-harness,caveman,crawl4ai,piignore,ranked-map,ripgrep-search,structural-analyzer"
+skills: extension-spec
 ---
 
 🛠 Tool Discipline — Architect

--- a/.pi/extensions/supervisor/agents/developer.md
+++ b/.pi/extensions/supervisor/agents/developer.md
@@ -5,6 +5,7 @@ tools: read, bash, write, edit, structural_search, ripgrep_search, ranked_map
 model: opencode-go/deepseek-v4-flash
 thinking: medium
 extensions: "agent-harness,caveman,crawl4ai,format-on-save,piignore,ranked-map,ripgrep-search,tsc-checkpoint,structural-analyzer,worktree-sandbox"
+skills: extension-spec
 ---
 
 🛠 Tool Discipline — Developer

--- a/.pi/extensions/supervisor/extensions.test.mts
+++ b/.pi/extensions/supervisor/extensions.test.mts
@@ -1,0 +1,140 @@
+// ─── Tests: extensions.ts — resolveSkillPaths() ──────────────────
+// Pure function tests — use dependency injection for existsSync.
+
+import { describe, it, afterEach, mock } from "node:test";
+import assert from "node:assert/strict";
+import * as fs from "node:fs";
+import { resolveSkillPaths, resolveSkillPathsWithFs } from "./extensions.ts";
+
+// ─── resolveSkillPaths (uses real fs) ────────────────────────────
+
+describe("resolveSkillPaths", () => {
+	it("returns empty array for undefined", () => {
+		assert.deepEqual(resolveSkillPaths(undefined), []);
+	});
+
+	it("returns empty array for empty string", () => {
+		assert.deepEqual(resolveSkillPaths(""), []);
+	});
+
+	it("returns empty array for whitespace-only string", () => {
+		assert.deepEqual(resolveSkillPaths("   "), []);
+	});
+
+	it("resolves extension-spec (real SKILL.md exists)", () => {
+		const result = resolveSkillPaths("extension-spec");
+		assert.equal(result.length, 1);
+		assert.ok(result[0]!.endsWith(".pi/skills/extension-spec/SKILL.md"));
+	});
+
+	it("throws for nonexistent skill", () => {
+		assert.throws(() => resolveSkillPaths("nonexistent-skill-xyz"), /nonexistent-skill-xyz/);
+	});
+
+	it("throw message includes both attempted paths", () => {
+		try {
+			resolveSkillPaths("nosuchskill");
+			assert.fail("Expected error");
+		} catch (e: unknown) {
+			const msg = e instanceof Error ? e.message : String(e);
+			assert.ok(msg.includes("nosuchskill"), `Message should include skill name: ${msg}`);
+			assert.ok(
+				msg.includes("nosuchskill.md") || msg.includes("nosuchskill.md"),
+				`Message should include .md path: ${msg}`,
+			);
+			assert.ok(
+				msg.includes("SKILL.md") || msg.includes("nosuchskill/SKILL.md"),
+				`Message should include SKILL.md path: ${msg}`,
+			);
+		}
+	});
+});
+
+// ─── resolveSkillPathsWithFs (injected existsSync) ─────────────
+
+describe("resolveSkillPathsWithFs", () => {
+	it("resolves single skill via .md file", () => {
+		const mockExists = (p: string): boolean => {
+			return p.includes(".pi/skills/my-skill.md");
+		};
+		const result = resolveSkillPathsWithFs("my-skill", "/root", mockExists);
+		assert.equal(result.length, 1);
+		assert.ok(result[0]!.endsWith(".pi/skills/my-skill.md"));
+	});
+
+	it("falls back to SKILL.md when .md missing", () => {
+		const mockExists = (p: string): boolean => {
+			return p.includes(".pi/skills/my-skill/SKILL.md");
+		};
+		const result = resolveSkillPathsWithFs("my-skill", "/root", mockExists);
+		assert.equal(result.length, 1);
+		assert.ok(result[0]!.endsWith(".pi/skills/my-skill/SKILL.md"));
+	});
+
+	it(".md takes priority when both exist", () => {
+		const mockExists = (p: string): boolean => {
+			return p.includes(".pi/skills/my-skill.md") || p.includes(".pi/skills/my-skill/SKILL.md");
+		};
+		const result = resolveSkillPathsWithFs("my-skill", "/root", mockExists);
+		assert.equal(result.length, 1);
+		assert.ok(result[0]!.endsWith(".pi/skills/my-skill.md"));
+	});
+
+	it("throws when neither path exists", () => {
+		const mockExists = (): boolean => false;
+		assert.throws(() => resolveSkillPathsWithFs("bad-skill", "/root", mockExists), /bad-skill/);
+	});
+
+	it("throw message includes both paths", () => {
+		const mockExists = (): boolean => false;
+		try {
+			resolveSkillPathsWithFs("bad-skill", "/root", mockExists);
+			assert.fail("Expected error");
+		} catch (e: unknown) {
+			const msg = e instanceof Error ? e.message : String(e);
+			assert.ok(msg.includes("bad-skill"));
+			assert.ok(msg.includes("bad-skill.md"));
+			assert.ok(msg.includes("SKILL.md"));
+		}
+	});
+
+	it("resolves multiple skills", () => {
+		const existing = new Set(["skill-a", "skill-b"]);
+		const mockExists = (p: string): boolean => {
+			for (const name of existing) {
+				if (p.includes(`.pi/skills/${name}.md`)) return true;
+			}
+			return false;
+		};
+		const result = resolveSkillPathsWithFs("skill-a, skill-b", "/root", mockExists);
+		assert.equal(result.length, 2);
+		assert.ok(result[0]!.endsWith("skill-a.md"));
+		assert.ok(result[1]!.endsWith("skill-b.md"));
+	});
+
+	it("throws on missing skill in multiple (fail-fast)", () => {
+		const mockExists = (p: string): boolean => {
+			return p.includes(".pi/skills/skill-a.md");
+		};
+		assert.throws(
+			() => resolveSkillPathsWithFs("skill-a, missing-skill", "/root", mockExists),
+			/missing-skill/,
+		);
+	});
+
+	it("respects custom cwd parameter", () => {
+		const mockExists = (p: string): boolean => {
+			return p === "/custom/path/.pi/skills/my-skill.md";
+		};
+		const result = resolveSkillPathsWithFs("my-skill", "/custom/path", mockExists);
+		assert.equal(result.length, 1);
+		assert.equal(result[0], "/custom/path/.pi/skills/my-skill.md");
+	});
+
+	it("empty/undefined returns empty array regardless of mock", () => {
+		const mockExists = (): boolean => true;
+		assert.deepEqual(resolveSkillPathsWithFs(undefined, "/root", mockExists), []);
+		assert.deepEqual(resolveSkillPathsWithFs("", "/root", mockExists), []);
+		assert.deepEqual(resolveSkillPathsWithFs("   ", "/root", mockExists), []);
+	});
+});

--- a/.pi/extensions/supervisor/extensions.ts
+++ b/.pi/extensions/supervisor/extensions.ts
@@ -56,6 +56,73 @@ export function resolveExtensions(extensionsRaw: string | undefined): string[] {
 	return result;
 }
 
+// ─── Skill path resolution ───────────────────────────────────────────
+
+/**
+ * Resolve comma-separated skill names from agent frontmatter to absolute
+ * file paths suitable for --skill CLI flags.
+ *
+ * Resolution order:
+ * 1. Try `.pi/skills/<name>.md` first
+ * 2. Fall back to `.pi/skills/<name>/SKILL.md`
+ * 3. If neither exists, throw an error with skill name and both paths
+ *
+ * Empty/undefined input returns empty array (noop).
+ */
+/**
+ * Internal version of resolveSkillPaths that accepts a custom existsSync
+ * function for testing. Public API wraps this with real existsSync.
+ */
+export function resolveSkillPathsWithFs(
+	skillsRaw: string | undefined,
+	cwd: string,
+	existsSyncFn: (path: string) => boolean,
+): string[] {
+	if (!skillsRaw || !skillsRaw.trim()) {
+		return [];
+	}
+
+	const skills = skillsRaw
+		.split(",")
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+
+	if (skills.length === 0) {
+		return [];
+	}
+
+	const result: string[] = [];
+	for (const name of skills) {
+		const mdPath = resolvePath(cwd, `.pi/skills/${name}.md`);
+		const skillDirPath = resolvePath(cwd, `.pi/skills/${name}/SKILL.md`);
+
+		if (existsSyncFn(mdPath)) {
+			result.push(mdPath);
+		} else if (existsSyncFn(skillDirPath)) {
+			result.push(skillDirPath);
+		} else {
+			throw new Error(`Skill "${name}" not found: tried "${mdPath}" and "${skillDirPath}"`);
+		}
+	}
+
+	return result;
+}
+
+/**
+ * Resolve comma-separated skill names from agent frontmatter to absolute
+ * file paths suitable for --skill CLI flags.
+ *
+ * Resolution order:
+ * 1. Try `.pi/skills/<name>.md` first
+ * 2. Fall back to `.pi/skills/<name>/SKILL.md`
+ * 3. If neither exists, throw an error with skill name and both paths
+ *
+ * Empty/undefined input returns empty array (noop).
+ */
+export function resolveSkillPaths(skillsRaw: string | undefined, cwd?: string): string[] {
+	return resolveSkillPathsWithFs(skillsRaw, cwd || process.cwd(), existsSync);
+}
+
 // ─── Tool discovery ────────────────────────────────────────────────
 
 let _extToolsCache: Map<string, string[]> | null = null;

--- a/.pi/extensions/supervisor/types.ts
+++ b/.pi/extensions/supervisor/types.ts
@@ -32,6 +32,7 @@ export interface AgentFrontmatter {
 	model?: string;
 	extensions?: string;
 	thinking?: string;
+	skills?: string;
 	[key: string]: unknown;
 }
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #167

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 32s | 889.4K | 40 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 3m 17s | 691.8K | 28 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 43s | 456.3K | 41 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 11s | 2.9M | 70 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 32s | 417.2K | 26 | deepseek-v4-flash |

**Total:** 5 agents · 13m 16s · 5.3M tokens · 205 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/167