### PR TITLE
Fix piignore precedence for nested ignores

### DIFF
--- a/.pi/extensions/piignore.ts
+++ b/.pi/extensions/piignore.ts
@@ -116,11 +116,13 @@ function isIgnored(targetPath: string, entries: IgnoreEntry[], cwd: string): boo
 
 	let ignored = false;
 
-	for (const entry of entries) {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
 		const rel = path.relative(entry.root, absPath);
 		if (rel === "" || (rel && !rel.startsWith("..") && !path.isAbsolute(rel))) {
+			const relForMatch = rel.replace(/\\/g, "/");
 			for (const pat of entry.patterns) {
-				if (pat.regex.test(rel)) {
+				if (pat.regex.test(relForMatch)) {
 					ignored = !pat.negate;
 				}
 			}

--- a/test/piignore-helpers.test.mts
+++ b/test/piignore-helpers.test.mts
@@ -93,11 +93,13 @@ function isIgnored(targetPath: string, entries: IgnoreEntry[], cwd: string): boo
 
 	let ignored = false;
 
-	for (const entry of entries) {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
 		const rel = path.relative(entry.root, absPath);
 		if (rel === "" || (rel && !rel.startsWith("..") && !path.isAbsolute(rel))) {
+			const relForMatch = rel.replace(/\\/g, "/");
 			for (const pat of entry.patterns) {
-				if (pat.regex.test(rel)) {
+				if (pat.regex.test(relForMatch)) {
 					ignored = !pat.negate;
 				}
 			}

--- a/test/piignore.test.mts
+++ b/test/piignore.test.mts
@@ -111,11 +111,13 @@ function isIgnored(targetPath: string, entries: IgnoreEntry[], cwd: string): boo
 
 	let ignored = false;
 
-	for (const entry of entries) {
+	for (let i = entries.length - 1; i >= 0; i--) {
+		const entry = entries[i];
 		const rel = path.relative(entry.root, absPath);
 		if (rel === "" || (rel && !rel.startsWith("..") && !path.isAbsolute(rel))) {
+			const relForMatch = rel.replace(/\\/g, "/");
 			for (const pat of entry.patterns) {
-				if (pat.regex.test(rel)) {
+				if (pat.regex.test(relForMatch)) {
 					ignored = !pat.negate;
 				}
 			}
@@ -199,6 +201,16 @@ describe("piignore extension", () => {
 
 			assert.strictEqual(isIgnored("local.txt", entries, nonCwdDir), true);
 			assert.strictEqual(isIgnored("global.txt", entries, nonCwdDir), true);
+		});
+
+		it("should let child .piignore negation override parent ignore patterns", () => {
+			fs.writeFileSync(path.join(tmpRoot, ".piignore"), "*.env\n", "utf-8");
+			fs.writeFileSync(path.join(nonCwdDir, ".piignore"), "!important.env\n", "utf-8");
+
+			const entries = loadPiIgnore(nonCwdDir);
+
+			assert.strictEqual(isIgnored("important.env", entries, nonCwdDir), false);
+			assert.strictEqual(isIgnored("debug.env", entries, nonCwdDir), true);
 		});
 	});
 


### PR DESCRIPTION
﻿## Summary
- evaluate parent `.piignore` entries before child entries so deeper rules can override parent rules
- normalize Windows path separators before matching ignore patterns
- add regression coverage for child `.piignore` negations overriding parent ignore patterns

Closes #324

## Validation
- `node --experimental-strip-types --test test/piignore.test.mts test/piignore-helpers.test.mts`
- `npm.cmd run tsc:extensions`
- `git diff --check HEAD~1..HEAD`
