### PR TITLE
feat(#304): Refactor: supervisor - duplicate event processing code in agent-stream.ts and session-events.ts

### DIFF
--- a/.pi/extensions/supervisor/agent-stream.ts
+++ b/.pi/extensions/supervisor/agent-stream.ts
@@ -1,10 +1,18 @@
 // ─── Agent Stream Helpers ──────────────────────────────────────────
-// Pure functions for JSON event parsing, phase tracking.
-// Widget building moved to session-widget.ts.
-// No side effects, no subprocess imports — fully testable.
+// Thin wrapper: delegates event processing to shared adapter + handlers.
+// Maintains backward-compatible exports for agent-runner.ts and others.
+//
+// Owns: filterStderr(), pushLog(), constants, getPhaseFromEvent().
+// Delegates: processJsonLine() → jsonLineToNormalizedEvent() + processNormalizedEvent().
 
 import type { AgentRunState, AgentPhase } from "./types";
-import { formatTokens, extractTextFromContent } from "./formatting.ts";
+import { formatTokens } from "./formatting.ts";
+import { jsonLineToNormalizedEvent, processNormalizedEvent } from "./event-adapter.ts";
+import { phasePriority } from "./event-types.ts";
+
+// ─── Re-exports for backward compat ───────────────────────────────
+
+export { phasePriority } from "./event-types.ts";
 
 // ─── Constants ──────────────────────────────────────────────────────
 
@@ -44,26 +52,19 @@ export function filterStderr(raw: string): string {
 		.trim();
 }
 
-/** Numeric priority for phase ordering. Higher = more important. */
-export function phasePriority(phase: AgentPhase): number {
-	switch (phase) {
-		case "tool":
-			return 3;
-		case "thinking":
-			return 2;
-		case "text":
-			return 1;
-		case "idle":
-			return 0;
-	}
-}
-
+/**
+ * Push a log entry to state.fullLog with bounded size.
+ * Kept here for backward compat — used by event-handlers and session-events.
+ */
 export function pushLog(state: AgentRunState, entry: string): void {
 	state.fullLog.push(entry);
 	if (state.fullLog.length > MAX_FULL_LOG) state.fullLog.shift();
 }
 
-/** Determine phase from a JSON event. Tool > thinking > text > idle. */
+/**
+ * Determine phase from a JSON event. Tool > thinking > text > idle.
+ * Preserved for backward compat (used by agent-runner.ts).
+ */
 export function getPhaseFromEvent(ev: any): AgentPhase {
 	if (!ev) return "idle";
 
@@ -96,6 +97,7 @@ export function getPhaseFromEvent(ev: any): AgentPhase {
 
 /**
  * Process a single JSON line from pi's stdout.
+ * Thin wrapper: converts to NormalizedEvent and delegates to shared processor.
  * Mutates state in place. Returns flush + workingChange flags.
  */
 export function processJsonLine(
@@ -104,205 +106,9 @@ export function processJsonLine(
 ): { flush: boolean; workingChange: boolean } {
 	if (!line.trim()) return { flush: false, workingChange: false };
 	try {
-		const ev = JSON.parse(line);
-		switch (ev.type) {
-			case "session":
-				break;
-
-			case "context_info": {
-				const tokens = ev.contextTokens;
-				const window = ev.contextWindow;
-				if (typeof tokens === "number" && typeof window === "number" && window > 0) {
-					state.contextTokens = tokens;
-					state.contextWindow = window;
-					state.contextInfoReceived = true;
-					pushLog(state, `📊 Context: ${formatTokens(tokens)}/${formatTokens(window)} (initial)`);
-					return { flush: true, workingChange: false };
-				}
-				break;
-			}
-
-			case "tool_execution_start": {
-				const prevPhase = state.phase;
-				state.currentTool = ev.toolName || "tool";
-				state.currentToolArgs = ev.args ? JSON.stringify(ev.args).slice(0, 200) : undefined;
-				state.lastToolName = ev.toolName;
-				state.phase = "tool";
-				const logArgs = ev.args ? JSON.stringify(ev.args).slice(0, 200) : "";
-				pushLog(state, `🔧 ${ev.toolName}${logArgs ? ` ${logArgs}` : ""}`);
-				return { flush: true, workingChange: prevPhase !== "tool" };
-			}
-
-			case "tool_execution_end": {
-				state.toolCount++;
-				state.currentTool = undefined;
-				state.currentToolArgs = undefined;
-				state.phase = "idle";
-				pushLog(state, `${ev.isError ? "✗" : "✓"} ${ev.toolName}`);
-				return { flush: true, workingChange: true };
-			}
-
-			case "message_update": {
-				const delta = ev.delta;
-				if (!delta) break;
-
-				const prevPhase = state.phase;
-				const eventPhase = getPhaseFromEvent(ev);
-				if (eventPhase !== "idle" && phasePriority(eventPhase) >= phasePriority(state.phase)) {
-					state.phase = eventPhase;
-				}
-
-				switch (delta.type) {
-					case "thinking_start": {
-						state.thinkingPushedThisTurn = false;
-						return { flush: true, workingChange: prevPhase !== "thinking" };
-					}
-					case "text_start": {
-						state.textPushedThisTurn = false;
-						return { flush: true, workingChange: prevPhase !== "text" };
-					}
-					case "thinking_delta": {
-						const td = delta.thinking_delta;
-						if (typeof td === "string" && td.length > 0) {
-							state.liveThinking += td;
-							if (state.liveThinking.length > MAX_LIVE_THINKING * 2) {
-								state.liveThinking = state.liveThinking.slice(-MAX_LIVE_THINKING);
-							}
-							// Push complete thinking lines to log immediately
-							let nlIdx;
-							while ((nlIdx = state.liveThinking.indexOf("\n")) !== -1) {
-								const line = state.liveThinking.slice(0, nlIdx);
-								state.liveThinking = state.liveThinking.slice(nlIdx + 1);
-								if (line.trim()) pushLog(state, `💭 ${line}`);
-							}
-							return { flush: true, workingChange: prevPhase !== "thinking" };
-						}
-						break;
-					}
-
-					case "text_delta": {
-						const td = delta.text_delta;
-						if (typeof td === "string" && td.length > 0) {
-							state.liveText += td;
-							if (state.liveText.length > 10_000) {
-								state.liveText = state.liveText.slice(-8_000);
-							}
-							// Push complete lines to log immediately for persistent display
-							let nlIdx;
-							while ((nlIdx = state.liveText.indexOf("\n")) !== -1) {
-								const line = state.liveText.slice(0, nlIdx);
-								state.liveText = state.liveText.slice(nlIdx + 1);
-								if (line.trim()) pushLog(state, line);
-							}
-							return { flush: true, workingChange: prevPhase !== "text" };
-						}
-						break;
-					}
-
-					case "thinking_end": {
-						if (state.liveThinking.trim()) {
-							state.thinkingOutputLines.push(state.liveThinking.trim());
-							for (const t of state.liveThinking.split("\n")) {
-								const trimmed = t.trim();
-								if (trimmed) pushLog(state, `💭 ${trimmed.slice(0, 500)}`);
-							}
-						}
-						state.thinkingPushedThisTurn = true;
-						state.liveThinking = "";
-						state.phase = "idle";
-						return { flush: true, workingChange: true };
-					}
-
-					case "text_end": {
-						if (state.liveText.trim()) {
-							state.textOutputLines.push(state.liveText.trim());
-							for (const t of state.liveText.split("\n")) {
-								const trimmed = t.trim();
-								if (trimmed) pushLog(state, trimmed);
-							}
-						}
-						state.textPushedThisTurn = true;
-						if (ev.usage) {
-							state.tokenCount =
-								ev.usage.totalTokens || ev.usage.input + ev.usage.output || state.tokenCount;
-						}
-						state.liveText = "";
-						state.phase = "idle";
-						return { flush: true, workingChange: true };
-					}
-				}
-				break;
-			}
-
-			case "message_end": {
-				const msg = ev.message;
-				if (!msg) break;
-
-				if (msg.role === "assistant") {
-					if (!state.thinkingPushedThisTurn && Array.isArray(msg.content)) {
-						for (const block of msg.content) {
-							if (block.type === "thinking" && block.thinking) {
-								const thinkingText =
-									typeof block.thinking === "string"
-										? block.thinking
-										: JSON.stringify(block.thinking).slice(0, 500);
-								for (const t of thinkingText.split("\n")) {
-									if (t.trim()) pushLog(state, `💭 ${t.slice(0, 500)}`);
-								}
-							}
-						}
-						state.thinkingPushedThisTurn = true;
-					}
-					if (!state.textPushedThisTurn) {
-						const text = extractTextFromContent(msg.content);
-						if (text && text.trim()) {
-							state.textOutputLines.push(text.trim());
-							state.textPushedThisTurn = true;
-							for (const t of text.split("\n")) {
-								if (t.trim()) pushLog(state, t);
-							}
-						}
-					}
-					if (msg.usage) {
-						state.tokenCount = msg.usage.totalTokens || msg.usage.input + msg.usage.output;
-					}
-				} else if (msg.role === "toolResult") {
-					const resultText = extractTextFromContent(msg.content);
-					const label = msg.toolName || state.lastToolName || "tool";
-					if (resultText && resultText.trim()) {
-						const resultLines = resultText.split("\n");
-						pushLog(state, `📋 ${label}: ${resultLines[0]?.slice(0, 300) || "(no output)"}`);
-						for (let i = 1; i < Math.min(resultLines.length, 6); i++) {
-							if (resultLines[i].trim()) pushLog(state, `   ${resultLines[i].slice(0, 200)}`);
-						}
-					} else {
-						pushLog(state, `📋 ${label}: (no output)`);
-					}
-					state.lastToolName = undefined;
-				}
-				// Budget check: tool call limit
-				if (state.maxToolCalls > 0 && state.toolCount >= state.maxToolCalls) {
-					state.budgetExceeded = true;
-					state.budgetExceededReason = `Tool call limit reached: ${state.toolCount}/${state.maxToolCalls}`;
-				}
-				// Budget check: token budget
-				if (state.agentTokenBudget > 0 && state.tokenCount >= state.agentTokenBudget) {
-					state.budgetExceeded = true;
-					const reason = `Token budget exceeded: ${state.tokenCount}/${state.agentTokenBudget}`;
-					state.budgetExceededReason = state.budgetExceededReason
-						? `${state.budgetExceededReason}; ${reason}`
-						: reason;
-				}
-				state.phase = "idle";
-				state.thinkingPushedThisTurn = false;
-				state.textPushedThisTurn = false;
-				return { flush: true, workingChange: true };
-			}
-
-			case "agent_end":
-			case "turn_end":
-				break;
-		}
+		const normalized = jsonLineToNormalizedEvent(line);
+		if (!normalized) return { flush: false, workingChange: false };
+		return processNormalizedEvent(normalized, state);
 	} catch (parseErr: unknown) {
 		const preview = line.length > 200 ? line.slice(0, 200) + "…" : line;
 		if (line.trim()) {
@@ -310,6 +116,6 @@ export function processJsonLine(
 				`[supervisor] JSON parse error: ${String(parseErr).slice(0, 200)} | line: ${preview}`,
 			);
 		}
+		return { flush: false, workingChange: false };
 	}
-	return { flush: false, workingChange: false };
 }

--- a/.pi/extensions/supervisor/event-adapter.test.mts
+++ b/.pi/extensions/supervisor/event-adapter.test.mts
@@ -1,0 +1,563 @@
+// ─── Tests: event-adapter.ts — adapters + processNormalizedEvent ──
+// Phase 3+4: JSON line adapter, session event adapter, unified processor.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { AgentRunState } from "./types";
+import {
+	jsonLineToNormalizedEvent,
+	sessionEventToNormalizedEvent,
+	processNormalizedEvent,
+} from "./event-adapter.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function createState(overrides?: Partial<AgentRunState>): AgentRunState {
+	return {
+		currentTool: undefined,
+		currentToolArgs: undefined,
+		toolCount: 0,
+		tokenCount: 0,
+		fullLog: [],
+		liveThinking: "",
+		liveText: "",
+		textOutputLines: [],
+		thinkingOutputLines: [],
+		lastToolName: undefined,
+		phase: "idle",
+		startedAt: Date.now(),
+		contextTokens: undefined,
+		contextWindow: undefined,
+		contextInfoReceived: false,
+		thinkingPushedThisTurn: false,
+		textPushedThisTurn: false,
+		budgetExceeded: false,
+		budgetExceededReason: undefined,
+		maxToolCalls: 0,
+		agentTokenBudget: 0,
+		...overrides,
+	};
+}
+
+// ─── Phase 3: jsonLineToNormalizedEvent ───────────────────────────
+
+describe("jsonLineToNormalizedEvent", () => {
+	it("converts tool_execution_start", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "tool_execution_start", toolName: "read", args: { path: "/x" } }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "tool_execution_start");
+		if (result!.kind === "tool_execution_start") {
+			assert.equal(result!.toolName, "read");
+			assert.deepEqual(result!.args, { path: "/x" });
+		}
+	});
+
+	it("converts tool_execution_end", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "tool_execution_end", toolName: "read", isError: true }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "tool_execution_end");
+		if (result!.kind === "tool_execution_end") {
+			assert.equal(result!.toolName, "read");
+			assert.equal(result!.isError, true);
+		}
+	});
+
+	it("converts context_info", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "context_info", contextTokens: 5000, contextWindow: 10000 }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "context_info");
+		if (result!.kind === "context_info") {
+			assert.equal(result!.contextTokens, 5000);
+			assert.equal(result!.contextWindow, 10000);
+		}
+	});
+
+	it("converts message_update thinking_start", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "message_update", delta: { type: "thinking_start" } }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "thinking_start");
+	});
+
+	it("converts message_update thinking_delta", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "message_update",
+				delta: { type: "thinking_delta", thinking_delta: "step" },
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "thinking_delta");
+		if (result!.kind === "thinking_delta") {
+			assert.equal(result!.delta, "step");
+		}
+	});
+
+	it("converts message_update thinking_end", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "message_update", delta: { type: "thinking_end" } }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "thinking_end");
+	});
+
+	it("converts message_update text_start", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "message_update", delta: { type: "text_start" } }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "text_start");
+	});
+
+	it("converts message_update text_delta", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "message_update",
+				delta: { type: "text_delta", text_delta: "hello" },
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "text_delta");
+		if (result!.kind === "text_delta") {
+			assert.equal(result!.delta, "hello");
+		}
+	});
+
+	it("converts message_update text_end with usage", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "message_update",
+				delta: { type: "text_end" },
+				usage: { totalTokens: 100, input: 40, output: 60 },
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "text_end");
+		if (result!.kind === "text_end") {
+			assert.equal(result!.usage?.totalTokens, 100);
+		}
+	});
+
+	it("converts message_update text_end without usage", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({ type: "message_update", delta: { type: "text_end" } }),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "text_end");
+	});
+
+	it("converts message_end", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "message_end",
+				message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "message_end");
+		if (result!.kind === "message_end") {
+			assert.equal(result!.message.role, "assistant");
+		}
+	});
+
+	it("converts session event", () => {
+		const result = jsonLineToNormalizedEvent(JSON.stringify({ type: "session" }));
+		assert.ok(result);
+		assert.equal(result!.kind, "session");
+	});
+
+	it("converts turn_start and turn_end", () => {
+		assert.equal(
+			jsonLineToNormalizedEvent(JSON.stringify({ type: "turn_start" }))!.kind,
+			"turn_start",
+		);
+		assert.equal(jsonLineToNormalizedEvent(JSON.stringify({ type: "turn_end" }))!.kind, "turn_end");
+	});
+
+	it("converts agent_start and agent_end", () => {
+		assert.equal(
+			jsonLineToNormalizedEvent(JSON.stringify({ type: "agent_start" }))!.kind,
+			"agent_start",
+		);
+		assert.equal(
+			jsonLineToNormalizedEvent(JSON.stringify({ type: "agent_end" }))!.kind,
+			"agent_end",
+		);
+	});
+
+	it("returns null for unknown event types", () => {
+		const result = jsonLineToNormalizedEvent(JSON.stringify({ type: "unknown_xyz" }));
+		assert.equal(result, null);
+	});
+
+	it("returns null for empty line", () => {
+		assert.equal(jsonLineToNormalizedEvent(""), null);
+	});
+
+	it("returns null for invalid JSON", () => {
+		assert.equal(jsonLineToNormalizedEvent("{invalid}"), null);
+	});
+});
+
+// ─── Phase 3: sessionEventToNormalizedEvent ──────────────────────
+
+describe("sessionEventToNormalizedEvent", () => {
+	it("converts tool_execution_start", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "tool_execution_start",
+			toolName: "read",
+			args: { path: "/x" },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "tool_execution_start");
+		if (result!.kind === "tool_execution_start") {
+			assert.equal(result!.toolName, "read");
+		}
+	});
+
+	it("converts tool_execution_end", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "tool_execution_end",
+			toolName: "read",
+			isError: false,
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "tool_execution_end");
+		assert.equal((result as any).isError, false);
+	});
+
+	it("converts message_update thinking_start", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_start" },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "thinking_start");
+	});
+
+	it("converts message_update thinking_delta", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_delta", delta: "step" },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "thinking_delta");
+		if (result!.kind === "thinking_delta") {
+			assert.equal(result!.delta, "step");
+		}
+	});
+
+	it("converts message_update thinking_end", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: { type: "thinking_end" },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "thinking_end");
+	});
+
+	it("converts message_update text_start", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_start" },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "text_start");
+	});
+
+	it("converts message_update text_delta", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_delta", delta: "hello" },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "text_delta");
+		if (result!.kind === "text_delta") {
+			assert.equal(result!.delta, "hello");
+		}
+	});
+
+	it("converts message_update text_end", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_end" },
+			message: { usage: { totalTokens: 50, input: 20, output: 30 } },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "text_end");
+		if (result!.kind === "text_end") {
+			assert.equal(result!.usage?.totalTokens, 50);
+		}
+	});
+
+	it("converts message_update done", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_update",
+			assistantMessageEvent: {
+				type: "done",
+				message: { content: [{ type: "text", text: "done" }], usage: { input: 10, output: 5 } },
+			},
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.[0]?.type, "text");
+		}
+	});
+
+	it("converts message_end", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "message_end",
+			message: { role: "assistant", content: [] },
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "message_end");
+		if (result!.kind === "message_end") {
+			assert.equal(result!.message.role, "assistant");
+		}
+	});
+
+	it("returns null for context_info (handled differently for sessions)", () => {
+		const result = sessionEventToNormalizedEvent({ type: "context_info" });
+		assert.equal(result, null);
+	});
+
+	it("converts turn_start/end and agent_start/end", () => {
+		assert.equal(sessionEventToNormalizedEvent({ type: "turn_start" })!.kind, "turn_start");
+		assert.equal(sessionEventToNormalizedEvent({ type: "turn_end" })!.kind, "turn_end");
+		assert.equal(sessionEventToNormalizedEvent({ type: "agent_start" })!.kind, "agent_start");
+		assert.equal(sessionEventToNormalizedEvent({ type: "agent_end" })!.kind, "agent_end");
+	});
+
+	it("returns null for unknown event types", () => {
+		const result = sessionEventToNormalizedEvent({ type: "unknown_xyz" });
+		assert.equal(result, null);
+	});
+});
+
+// ─── Phase 4: processNormalizedEvent ──────────────────────────────
+
+describe("processNormalizedEvent", () => {
+	it("handles tool_execution_start", () => {
+		const state = createState();
+		const result = processNormalizedEvent(
+			{ kind: "tool_execution_start", toolName: "read" },
+			state,
+		);
+		assert.equal(state.phase, "tool");
+		assert.equal(result.flush, true);
+	});
+
+	it("handles tool_execution_end", () => {
+		const state = createState({ toolCount: 0 });
+		const result = processNormalizedEvent(
+			{ kind: "tool_execution_end", toolName: "read", isError: false },
+			state,
+		);
+		assert.equal(state.toolCount, 1);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles thinking_start", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "thinking_start" }, state);
+		assert.equal(state.thinkingPushedThisTurn, false);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles thinking_delta", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "thinking_delta", delta: "step\n" }, state);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles thinking_end", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "thinking_end" }, state);
+		assert.equal(state.thinkingPushedThisTurn, true);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles text_start", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "text_start" }, state);
+		assert.equal(state.textPushedThisTurn, false);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles text_delta", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "text_delta", delta: "hello\n" }, state);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles text_end", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "text_end" }, state);
+		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(result.flush, true);
+	});
+
+	it("handles message_end", () => {
+		const state = createState();
+		const result = processNormalizedEvent(
+			{ kind: "message_end", message: { role: "assistant", content: [] } },
+			state,
+		);
+		assert.equal(result.flush, true);
+		assert.equal(state.phase, "idle");
+	});
+
+	it("handles message_end with budget check", () => {
+		const state = createState({ toolCount: 10, maxToolCalls: 10 });
+		processNormalizedEvent(
+			{ kind: "message_end", message: { role: "assistant", content: [] } },
+			state,
+		);
+		assert.equal(state.budgetExceeded, true);
+	});
+
+	it("handles done", () => {
+		const state = createState();
+		const result = processNormalizedEvent(
+			{ kind: "done", message: { content: [{ type: "text", text: "result" }] } },
+			state,
+		);
+		assert.equal(result.flush, true);
+		assert.equal(state.textPushedThisTurn, true);
+	});
+
+	it("handles context_info", () => {
+		const state = createState();
+		const result = processNormalizedEvent(
+			{ kind: "context_info", contextTokens: 5000, contextWindow: 10000 },
+			state,
+		);
+		assert.equal(result.flush, true);
+		assert.equal(state.contextInfoReceived, true);
+	});
+
+	it("returns {flush:false, workingChange:false} for no-op events", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "turn_start" }, state);
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+
+	it("returns {flush:false, workingChange:false} for turn_end", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "turn_end" }, state);
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+
+	it("returns {flush:false, workingChange:false} for agent_start", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "agent_start" }, state);
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+
+	it("returns {flush:false, workingChange:false} for agent_end", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "agent_end" }, state);
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+
+	it("returns {flush:false, workingChange:false} for session", () => {
+		const state = createState();
+		const result = processNormalizedEvent({ kind: "session" }, state);
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+
+	it("processes the full JSON-based streaming chain without duplicates", () => {
+		const state = createState();
+
+		// text streaming via normalized events
+		processNormalizedEvent({ kind: "text_start" }, state);
+		processNormalizedEvent({ kind: "text_delta", delta: "A\nB\n" }, state);
+		processNormalizedEvent({ kind: "text_end" }, state);
+		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(state.liveText, "");
+
+		// message_end should not push duplicates
+		const before = state.fullLog.length;
+		processNormalizedEvent(
+			{
+				kind: "message_end",
+				message: { role: "assistant", content: [{ type: "text", text: "A\nB" }] },
+			},
+			state,
+		);
+		assert.equal(state.fullLog.length, before, "no duplicate push");
+	});
+
+	it("processes the full session-based streaming chain without duplicates", () => {
+		const state = createState();
+
+		// thinking streaming via normalized events
+		processNormalizedEvent({ kind: "thinking_start" }, state);
+		processNormalizedEvent({ kind: "thinking_delta", delta: "t1\nt2\n" }, state);
+		processNormalizedEvent({ kind: "thinking_end" }, state);
+		assert.equal(state.thinkingPushedThisTurn, true);
+
+		// text streaming
+		processNormalizedEvent({ kind: "text_start" }, state);
+		processNormalizedEvent({ kind: "text_delta", delta: "r1\nr2\n" }, state);
+		processNormalizedEvent({ kind: "text_end" }, state);
+		assert.equal(state.textPushedThisTurn, true);
+
+		// message_end — both flags set, should be no-op for content
+		const before = state.fullLog.length;
+		processNormalizedEvent(
+			{
+				kind: "message_end",
+				message: { role: "assistant", content: [{ type: "text", text: "r1\nr2" }] },
+			},
+			state,
+		);
+		assert.equal(state.fullLog.length, before, "no duplicates");
+	});
+
+	it("multi-turn processing works correctly", () => {
+		const state = createState();
+
+		// Turn 1
+		processNormalizedEvent({ kind: "text_start" }, state);
+		processNormalizedEvent({ kind: "text_delta", delta: "A\nB\n" }, state);
+		processNormalizedEvent({ kind: "text_end" }, state);
+		processNormalizedEvent(
+			{
+				kind: "message_end",
+				message: { role: "assistant", content: [{ type: "text", text: "A\nB" }] },
+			},
+			state,
+		);
+
+		// Turn 2
+		processNormalizedEvent({ kind: "text_start" }, state);
+		processNormalizedEvent({ kind: "text_delta", delta: "C\nD\n" }, state);
+		processNormalizedEvent({ kind: "text_end" }, state);
+		processNormalizedEvent(
+			{
+				kind: "message_end",
+				message: { role: "assistant", content: [{ type: "text", text: "C\nD" }] },
+			},
+			state,
+		);
+
+		assert.equal(state.fullLog.filter((l) => l === "A").length, 1, "'A' once");
+		assert.equal(state.fullLog.filter((l) => l === "B").length, 1, "'B' once");
+		assert.equal(state.fullLog.filter((l) => l === "C").length, 1, "'C' once");
+		assert.equal(state.fullLog.filter((l) => l === "D").length, 1, "'D' once");
+	});
+});

--- a/.pi/extensions/supervisor/event-adapter.ts
+++ b/.pi/extensions/supervisor/event-adapter.ts
@@ -1,0 +1,228 @@
+// ─── Event Adapters ──────────────────────────────────────────────
+// Converts JSON lines (from pi --mode json subprocess stdout) and
+// SDK session events (from session.subscribe()) into NormalizedEvent.
+// Provides processNormalizedEvent() which delegates to shared handlers.
+
+import type { AgentRunState } from "./types";
+import type { NormalizedEvent, HandlerResult } from "./event-types.ts";
+import {
+	handleToolExecutionStart,
+	handleToolExecutionEnd,
+	handleThinkingStart,
+	handleThinkingDelta,
+	handleThinkingEnd,
+	handleTextStart,
+	handleTextDelta,
+	handleTextEnd,
+	handleMessageEnd,
+	handleDone,
+	handleContextInfo,
+} from "./event-handlers.ts";
+
+// ─── JSON Line → NormalizedEvent ─────────────────────────────────
+
+/**
+ * Convert a JSON line from pi --mode json stdout to a NormalizedEvent.
+ * Returns null if the line is empty, invalid JSON, or an unrecognized event type.
+ */
+export function jsonLineToNormalizedEvent(line: string): NormalizedEvent | null {
+	if (!line.trim()) return null;
+	try {
+		const ev = JSON.parse(line);
+		switch (ev.type) {
+			case "session":
+				return { kind: "session" };
+
+			case "context_info":
+				return {
+					kind: "context_info",
+					contextTokens: ev.contextTokens,
+					contextWindow: ev.contextWindow,
+				};
+
+			case "tool_execution_start":
+				return { kind: "tool_execution_start", toolName: ev.toolName || "tool", args: ev.args };
+
+			case "tool_execution_end":
+				return {
+					kind: "tool_execution_end",
+					toolName: ev.toolName || "tool",
+					isError: !!ev.isError,
+				};
+
+			case "message_update": {
+				const delta = ev.delta;
+				if (!delta) return null;
+				switch (delta.type) {
+					case "thinking_start":
+						return { kind: "thinking_start" };
+					case "thinking_delta":
+						return { kind: "thinking_delta", delta: delta.thinking_delta || "" };
+					case "thinking_end":
+						return { kind: "thinking_end" };
+					case "text_start":
+						return { kind: "text_start" };
+					case "text_delta":
+						return { kind: "text_delta", delta: delta.text_delta || "" };
+					case "text_end":
+						return { kind: "text_end", usage: ev.usage };
+					default:
+						return null;
+				}
+			}
+
+			case "message_end":
+				return { kind: "message_end", message: ev.message };
+
+			case "turn_start":
+				return { kind: "turn_start" };
+			case "turn_end":
+				return { kind: "turn_end" };
+			case "agent_start":
+				return { kind: "agent_start" };
+			case "agent_end":
+				return { kind: "agent_end" };
+
+			default:
+				return null;
+		}
+	} catch {
+		return null;
+	}
+}
+
+// ─── Session Event → NormalizedEvent ─────────────────────────────
+
+/**
+ * Convert an SDK session event to a NormalizedEvent.
+ * Returns null for unrecognized event types or events that should be skipped.
+ */
+export function sessionEventToNormalizedEvent(ev: Record<string, unknown>): NormalizedEvent | null {
+	if (!ev || !ev.type) return null;
+	const type = ev.type as string;
+
+	switch (type) {
+		case "context_info":
+			// context_info event removed in new agent-core — skip
+			return null;
+
+		case "tool_execution_start":
+			return {
+				kind: "tool_execution_start",
+				toolName: (ev.toolName as string) || "tool",
+				args: ev.args,
+			};
+
+		case "tool_execution_end":
+			return {
+				kind: "tool_execution_end",
+				toolName: (ev.toolName as string) || "tool",
+				isError: !!ev.isError,
+			};
+
+		case "message_update": {
+			const ae = ev.assistantMessageEvent as Record<string, unknown> | undefined;
+			if (!ae) return null;
+			const aeType = ae.type as string;
+			switch (aeType) {
+				case "thinking_start":
+					return { kind: "thinking_start" };
+				case "thinking_delta":
+					return { kind: "thinking_delta", delta: (ae.delta as string) || "" };
+				case "thinking_end":
+					return { kind: "thinking_end" };
+				case "text_start":
+					return { kind: "text_start" };
+				case "text_delta":
+					return { kind: "text_delta", delta: (ae.delta as string) || "" };
+				case "text_end": {
+					const msg = ev.message as Record<string, unknown> | undefined;
+					return { kind: "text_end", usage: msg?.usage as any };
+				}
+				case "done": {
+					const doneMsg = ae.message as Record<string, unknown> | undefined;
+					return {
+						kind: "done",
+						message: {
+							content: doneMsg?.content as any[],
+							usage: doneMsg?.usage as any,
+						},
+					};
+				}
+				default:
+					return null;
+			}
+		}
+
+		case "message_end":
+			return { kind: "message_end", message: ev.message as any };
+
+		case "turn_start":
+			return { kind: "turn_start" };
+		case "turn_end":
+			return { kind: "turn_end" };
+		case "agent_start":
+			return { kind: "agent_start" };
+		case "agent_end":
+			return { kind: "agent_end" };
+		case "session":
+			return { kind: "session" };
+
+		default:
+			return null;
+	}
+}
+
+// ─── processNormalizedEvent — single dispatch point ───────────────
+
+/**
+ * Process a NormalizedEvent by dispatching to the appropriate handler.
+ * This is the single unified event processor — both processJsonLine and
+ * processSessionEvent delegate to this function.
+ *
+ * Mutates state in place. Returns flush + workingChange flags.
+ */
+export function processNormalizedEvent(ev: NormalizedEvent, state: AgentRunState): HandlerResult {
+	switch (ev.kind) {
+		case "tool_execution_start":
+			return handleToolExecutionStart(state, ev);
+
+		case "tool_execution_end":
+			return handleToolExecutionEnd(state, ev);
+
+		case "thinking_start":
+			return handleThinkingStart(state, ev);
+
+		case "thinking_delta":
+			return handleThinkingDelta(state, ev);
+
+		case "thinking_end":
+			return handleThinkingEnd(state, ev);
+
+		case "text_start":
+			return handleTextStart(state, ev);
+
+		case "text_delta":
+			return handleTextDelta(state, ev);
+
+		case "text_end":
+			return handleTextEnd(state, ev);
+
+		case "message_end":
+			return handleMessageEnd(state, ev);
+
+		case "done":
+			return handleDone(state, ev);
+
+		case "context_info":
+			return handleContextInfo(state, ev);
+
+		case "turn_start":
+		case "turn_end":
+		case "agent_start":
+		case "agent_end":
+		case "session":
+			// No-op events — handled by returning flush=false
+			return { flush: false, workingChange: false };
+	}
+}

--- a/.pi/extensions/supervisor/event-handlers.test.mts
+++ b/.pi/extensions/supervisor/event-handlers.test.mts
@@ -1,0 +1,437 @@
+// ─── Tests: event-handlers.ts — shared handler functions ──────────
+// Phase 2: Each handler is a standalone pure function.
+// Tests mirror the scenarios from agent-stream.test.mts and
+// session-events.test.mts but target the shared handlers directly.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { AgentRunState } from "./types";
+import {
+	handleToolExecutionStart,
+	handleToolExecutionEnd,
+	handleThinkingStart,
+	handleThinkingDelta,
+	handleThinkingEnd,
+	handleTextStart,
+	handleTextDelta,
+	handleTextEnd,
+	handleMessageEnd,
+	handleDone,
+	handleContextInfo,
+	phasePriority,
+} from "./event-handlers.ts";
+
+// ─── Helpers ──────────────────────────────────────────────────────
+
+function createState(overrides?: Partial<AgentRunState>): AgentRunState {
+	return {
+		currentTool: undefined,
+		currentToolArgs: undefined,
+		toolCount: 0,
+		tokenCount: 0,
+		fullLog: [],
+		liveThinking: "",
+		liveText: "",
+		textOutputLines: [],
+		thinkingOutputLines: [],
+		lastToolName: undefined,
+		phase: "idle",
+		startedAt: Date.now(),
+		contextTokens: undefined,
+		contextWindow: undefined,
+		contextInfoReceived: false,
+		thinkingPushedThisTurn: false,
+		textPushedThisTurn: false,
+		budgetExceeded: false,
+		budgetExceededReason: undefined,
+		maxToolCalls: 0,
+		agentTokenBudget: 0,
+		...overrides,
+	};
+}
+
+// ─── phasePriority ────────────────────────────────────────────────
+
+describe("phasePriority", () => {
+	it("returns numeric priority: tool > thinking > text > idle", () => {
+		assert.equal(phasePriority("tool"), 3);
+		assert.equal(phasePriority("thinking"), 2);
+		assert.equal(phasePriority("text"), 1);
+		assert.equal(phasePriority("idle"), 0);
+	});
+});
+
+// ─── handleToolExecutionStart ─────────────────────────────────────
+
+describe("handleToolExecutionStart", () => {
+	it("sets phase to tool, records tool name and args", () => {
+		const state = createState();
+		const result = handleToolExecutionStart(state, {
+			kind: "tool_execution_start",
+			toolName: "read_file",
+			args: { path: "/x" },
+		});
+		assert.equal(state.phase, "tool");
+		assert.equal(state.currentTool, "read_file");
+		assert.ok(state.currentToolArgs);
+		assert.equal(state.lastToolName, "read_file");
+		assert.ok(state.fullLog.some((l) => l.includes("read_file")));
+		assert.equal(result.flush, true);
+		assert.equal(result.workingChange, true);
+	});
+
+	it("returns workingChange=false when already in tool phase", () => {
+		const state = createState({ phase: "tool" });
+		const result = handleToolExecutionStart(state, {
+			kind: "tool_execution_start",
+			toolName: "bash",
+		});
+		assert.equal(result.workingChange, false);
+	});
+});
+
+// ─── handleToolExecutionEnd ───────────────────────────────────────
+
+describe("handleToolExecutionEnd", () => {
+	it("increments toolCount, resets tool state, sets phase idle", () => {
+		const state = createState({ toolCount: 5, lastToolName: "read_file" });
+		const result = handleToolExecutionEnd(state, {
+			kind: "tool_execution_end",
+			toolName: "read_file",
+			isError: false,
+		});
+		assert.equal(state.toolCount, 6);
+		assert.equal(state.currentTool, undefined);
+		assert.equal(state.currentToolArgs, undefined);
+		assert.equal(state.phase, "idle");
+		assert.ok(state.fullLog.some((l) => l.includes("✓")));
+		assert.equal(result.flush, true);
+		assert.equal(result.workingChange, true);
+	});
+
+	it("marks error with ✗", () => {
+		const state = createState();
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
+		assert.ok(state.fullLog.some((l) => l.includes("✗")));
+	});
+});
+
+// ─── handleThinkingStart ──────────────────────────────────────────
+
+describe("handleThinkingStart", () => {
+	it("resets thinkingPushedThisTurn flag", () => {
+		const state = createState({ thinkingPushedThisTurn: true });
+		const result = handleThinkingStart(state, { kind: "thinking_start" });
+		assert.equal(state.thinkingPushedThisTurn, false);
+		assert.equal(result.flush, true);
+		assert.equal(result.workingChange, true);
+	});
+});
+
+// ─── handleTextStart ──────────────────────────────────────────────
+
+describe("handleTextStart", () => {
+	it("resets textPushedThisTurn flag", () => {
+		const state = createState({ textPushedThisTurn: true });
+		const result = handleTextStart(state, { kind: "text_start" });
+		assert.equal(state.textPushedThisTurn, false);
+		assert.equal(result.flush, true);
+		assert.equal(result.workingChange, true);
+	});
+});
+
+// ─── handleThinkingDelta ──────────────────────────────────────────
+
+describe("handleThinkingDelta", () => {
+	it("appends delta to liveThinking and pushes complete lines to log", () => {
+		const state = createState();
+		const result = handleThinkingDelta(state, {
+			kind: "thinking_delta",
+			delta: "step 1\nstep 2\n",
+		});
+		assert.equal(state.liveThinking, "");
+		assert.ok(state.fullLog.some((l) => l.includes("step 1")));
+		assert.ok(state.fullLog.some((l) => l.includes("step 2")));
+		assert.equal(result.flush, true);
+	});
+
+	it("does nothing with empty delta", () => {
+		const state = createState();
+		const result = handleThinkingDelta(state, { kind: "thinking_delta", delta: "" });
+		assert.equal(state.liveThinking, "");
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+});
+
+// ─── handleThinkingEnd ────────────────────────────────────────────
+
+describe("handleThinkingEnd", () => {
+	it("sets flag even when liveThinking is empty", () => {
+		const state = createState();
+		const result = handleThinkingEnd(state, { kind: "thinking_end" });
+		assert.equal(state.thinkingPushedThisTurn, true);
+		assert.equal(state.liveThinking, "");
+		assert.equal(result.flush, true);
+		assert.equal(result.workingChange, true);
+	});
+
+	it("pushes content when liveThinking has data", () => {
+		const state = createState({ liveThinking: "deep thought" });
+		handleThinkingEnd(state, { kind: "thinking_end" });
+		assert.equal(state.thinkingPushedThisTurn, true);
+		assert.equal(state.liveThinking, "");
+		assert.ok(state.thinkingOutputLines.length > 0);
+	});
+});
+
+// ─── handleTextDelta ──────────────────────────────────────────────
+
+describe("handleTextDelta", () => {
+	it("appends delta and pushes complete lines to log", () => {
+		const state = createState();
+		const result = handleTextDelta(state, { kind: "text_delta", delta: "Hello\nWorld\n" });
+		assert.equal(state.liveText, "");
+		assert.ok(state.fullLog.some((l) => l === "Hello"));
+		assert.ok(state.fullLog.some((l) => l === "World"));
+		assert.equal(result.flush, true);
+	});
+
+	it("does nothing with empty delta", () => {
+		const state = createState();
+		const result = handleTextDelta(state, { kind: "text_delta", delta: "" });
+		assert.equal(result.flush, false);
+		assert.equal(result.workingChange, false);
+	});
+});
+
+// ─── handleTextEnd ────────────────────────────────────────────────
+
+describe("handleTextEnd", () => {
+	it("sets flag even when liveText is empty", () => {
+		const state = createState();
+		const result = handleTextEnd(state, { kind: "text_end" });
+		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(state.liveText, "");
+		assert.equal(result.flush, true);
+		assert.equal(result.workingChange, true);
+	});
+
+	it("pushes content when liveText has data", () => {
+		const state = createState({ liveText: "some output" });
+		handleTextEnd(state, { kind: "text_end" });
+		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(state.textOutputLines[0], "some output");
+	});
+
+	it("updates tokenCount from usage", () => {
+		const state = createState();
+		handleTextEnd(state, {
+			kind: "text_end",
+			usage: { totalTokens: 100, input: 40, output: 60 },
+		});
+		assert.equal(state.tokenCount, 100);
+	});
+
+	it("handles usage via input+output fallback", () => {
+		const state = createState();
+		handleTextEnd(state, {
+			kind: "text_end",
+			usage: { input: 30, output: 20 },
+		});
+		assert.equal(state.tokenCount, 50);
+	});
+});
+
+// ─── handleMessageEnd ─────────────────────────────────────────────
+
+describe("handleMessageEnd", () => {
+	it("processes assistant role: pushes thinking to fullLog and text to textOutputLines", () => {
+		const state = createState();
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "thinking", thinking: "deep" },
+					{ type: "text", text: "answer" },
+				],
+			},
+		});
+		assert.equal(state.textOutputLines[0], "answer");
+		// thinking at message_end goes to fullLog (with 💭 prefix), not thinkingOutputLines
+		assert.ok(state.fullLog.some((l) => l.includes("💭") && l.includes("deep")));
+		// Flags are RESET at the end of message_end (end of turn)
+		assert.equal(state.thinkingPushedThisTurn, false);
+		assert.equal(state.textPushedThisTurn, false);
+	});
+
+	it("processes toolResult role: pushes tool result log", () => {
+		const state = createState({ lastToolName: "read_file" });
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: {
+				role: "toolResult",
+				content: [{ type: "text", text: "file content" }],
+				toolName: "read_file",
+			},
+		});
+		assert.ok(state.fullLog.some((l) => l.includes("📋")));
+	});
+
+	it("checks budget: tool call limit", () => {
+		const state = createState({ toolCount: 30, maxToolCalls: 30 });
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: { role: "assistant", content: [] },
+		});
+		assert.equal(state.budgetExceeded, true);
+		assert.ok(state.budgetExceededReason?.includes("30"));
+	});
+
+	it("checks budget: token budget", () => {
+		const state = createState({ tokenCount: 500000, agentTokenBudget: 500000 });
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: { role: "assistant", content: [] },
+		});
+		assert.equal(state.budgetExceeded, true);
+		assert.ok(state.budgetExceededReason?.includes("500000"));
+	});
+
+	it("does not set budgetExceeded when both limits are 0", () => {
+		const state = createState({ toolCount: 100, tokenCount: 999999 });
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: { role: "assistant", content: [] },
+		});
+		assert.equal(state.budgetExceeded, false);
+	});
+
+	it("resets turn flags and phase to idle", () => {
+		const state = createState({
+			thinkingPushedThisTurn: true,
+			textPushedThisTurn: true,
+			phase: "tool",
+		});
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: { role: "assistant", content: [] },
+		});
+		assert.equal(state.thinkingPushedThisTurn, false);
+		assert.equal(state.textPushedThisTurn, false);
+		assert.equal(state.phase, "idle");
+	});
+
+	it("updates tokenCount from usage", () => {
+		const state = createState();
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: {
+				role: "assistant",
+				content: [],
+				usage: { totalTokens: 200, input: 100, output: 100 },
+			},
+		});
+		assert.equal(state.tokenCount, 200);
+	});
+});
+
+// ─── handleDone ───────────────────────────────────────────────────
+
+describe("handleDone", () => {
+	it("processes text content and sets textPushedThisTurn", () => {
+		const state = createState();
+		handleDone(state, {
+			kind: "done",
+			message: {
+				content: [{ type: "text", text: "final answer" }],
+			},
+		});
+		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(state.textOutputLines[0], "final answer");
+	});
+
+	it("processes thinking content and sets thinkingPushedThisTurn", () => {
+		const state = createState();
+		handleDone(state, {
+			kind: "done",
+			message: {
+				content: [{ type: "thinking", thinking: "deep thought" }],
+			},
+		});
+		assert.equal(state.thinkingPushedThisTurn, true);
+		assert.ok(state.thinkingOutputLines[0]?.includes("deep thought"));
+	});
+
+	it("updates tokenCount from usage", () => {
+		const state = createState();
+		handleDone(state, {
+			kind: "done",
+			message: {
+				usage: { input: 100, output: 50 },
+			},
+		});
+		assert.equal(state.tokenCount, 150);
+	});
+
+	it("skips text push when textPushedThisTurn is already true", () => {
+		const state = createState({ thinkingPushedThisTurn: true, textPushedThisTurn: true });
+		handleDone(state, {
+			kind: "done",
+			message: {
+				content: [{ type: "text", text: "should not appear" }],
+			},
+		});
+		assert.equal(state.textOutputLines.length, 0);
+	});
+
+	it("clears liveText and liveThinking", () => {
+		const state = createState({ liveText: "buffer", liveThinking: "thought" });
+		handleDone(state, {
+			kind: "done",
+			message: {
+				content: [{ type: "text", text: "result" }],
+			},
+		});
+		assert.equal(state.liveText, "");
+		assert.equal(state.liveThinking, "");
+	});
+
+	it("sets phase to idle", () => {
+		const state = createState({ phase: "tool" });
+		handleDone(state, {
+			kind: "done",
+			message: { content: [{ type: "text", text: "result" }] },
+		});
+		assert.equal(state.phase, "idle");
+	});
+});
+
+// ─── handleContextInfo ────────────────────────────────────────────
+
+describe("handleContextInfo", () => {
+	it("sets context tokens and window", () => {
+		const state = createState();
+		const result = handleContextInfo(state, {
+			kind: "context_info",
+			contextTokens: 5000,
+			contextWindow: 10000,
+		});
+		assert.equal(state.contextTokens, 5000);
+		assert.equal(state.contextWindow, 10000);
+		assert.equal(state.contextInfoReceived, true);
+		assert.equal(result.flush, true);
+	});
+
+	it("returns flush=false when values are invalid (window=0)", () => {
+		const state = createState();
+		const result = handleContextInfo(state, {
+			kind: "context_info",
+			contextTokens: 0,
+			contextWindow: 0,
+		});
+		assert.equal(result.flush, false);
+		assert.equal(state.contextInfoReceived, false);
+	});
+});

--- a/.pi/extensions/supervisor/event-handlers.ts
+++ b/.pi/extensions/supervisor/event-handlers.ts
@@ -1,0 +1,306 @@
+// ─── Shared Event Handlers ──────────────────────────────────────────
+// Standalone pure functions that process NormalizedEvent kinds.
+// Each function maps to one NormalizedEvent kind and mutates AgentRunState.
+//
+// These are the "single source of truth" for event processing logic.
+// Both processJsonLine and processSessionEvent delegate to these via
+// processNormalizedEvent in event-adapter.ts.
+
+import type { AgentRunState } from "./types";
+import type { NormalizedEvent, HandlerResult } from "./event-types.ts";
+import { phasePriority } from "./event-types.ts";
+import { pushLog } from "./agent-stream.ts";
+import { extractTextFromContent } from "./formatting.ts";
+
+// ─── Re-export phasePriority for backward compat ─────────────────
+
+export { phasePriority } from "./event-types.ts";
+
+// ─── Constants ────────────────────────────────────────────────────
+
+const MAX_FULL_LOG = 500;
+const MAX_LIVE_THINKING = 500;
+const MAX_LIVE_TEXT = 10_000;
+const LIVE_TEXT_TRIM = 8_000;
+
+// ─── Handler Functions ────────────────────────────────────────────
+
+export function handleToolExecutionStart(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "tool_execution_start" },
+): HandlerResult {
+	const prevPhase = state.phase;
+	state.currentTool = ev.toolName || "tool";
+	state.currentToolArgs = ev.args ? JSON.stringify(ev.args).slice(0, 200) : undefined;
+	state.lastToolName = ev.toolName;
+	state.phase = "tool";
+	const logArgs = ev.args ? JSON.stringify(ev.args).slice(0, 200) : "";
+	pushLog(state, `🔧 ${ev.toolName}${logArgs ? ` ${logArgs}` : ""}`);
+	return { flush: true, workingChange: prevPhase !== "tool" };
+}
+
+export function handleToolExecutionEnd(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "tool_execution_end" },
+): HandlerResult {
+	state.toolCount++;
+	state.currentTool = undefined;
+	state.currentToolArgs = undefined;
+	state.phase = "idle";
+	pushLog(state, `${ev.isError ? "✗" : "✓"} ${ev.toolName}`);
+	return { flush: true, workingChange: true };
+}
+
+export function handleThinkingStart(
+	state: AgentRunState,
+	_ev: NormalizedEvent & { kind: "thinking_start" },
+): HandlerResult {
+	const prevPhase = state.phase;
+	if (phasePriority("thinking") >= phasePriority(state.phase)) {
+		state.phase = "thinking";
+	}
+	state.thinkingPushedThisTurn = false;
+	return { flush: true, workingChange: prevPhase !== "thinking" };
+}
+
+export function handleThinkingDelta(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "thinking_delta" },
+): HandlerResult {
+	const td = ev.delta;
+	if (typeof td === "string" && td.length > 0) {
+		const prevPhase = state.phase;
+		if (phasePriority("thinking") >= phasePriority(state.phase)) {
+			state.phase = "thinking";
+		}
+		state.liveThinking += td;
+		if (state.liveThinking.length > MAX_LIVE_THINKING * 2) {
+			state.liveThinking = state.liveThinking.slice(-MAX_LIVE_THINKING);
+		}
+		// Push complete thinking lines to log immediately
+		let nlIdx;
+		while ((nlIdx = state.liveThinking.indexOf("\n")) !== -1) {
+			const line = state.liveThinking.slice(0, nlIdx);
+			state.liveThinking = state.liveThinking.slice(nlIdx + 1);
+			if (line.trim()) pushLog(state, `💭 ${line}`);
+		}
+		return { flush: true, workingChange: prevPhase !== "thinking" };
+	}
+	return { flush: false, workingChange: false };
+}
+
+export function handleThinkingEnd(
+	state: AgentRunState,
+	_ev: NormalizedEvent & { kind: "thinking_end" },
+): HandlerResult {
+	if (state.liveThinking.trim()) {
+		state.thinkingOutputLines.push(state.liveThinking.trim());
+		for (const t of state.liveThinking.split("\n")) {
+			const trimmed = t.trim();
+			if (trimmed) pushLog(state, `💭 ${trimmed.slice(0, 500)}`);
+		}
+	}
+	state.thinkingPushedThisTurn = true;
+	state.liveThinking = "";
+	state.phase = "idle";
+	return { flush: true, workingChange: true };
+}
+
+export function handleTextStart(
+	state: AgentRunState,
+	_ev: NormalizedEvent & { kind: "text_start" },
+): HandlerResult {
+	const prevPhase = state.phase;
+	if (phasePriority("text") >= phasePriority(state.phase)) {
+		state.phase = "text";
+	}
+	state.textPushedThisTurn = false;
+	return { flush: true, workingChange: prevPhase !== "text" };
+}
+
+export function handleTextDelta(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "text_delta" },
+): HandlerResult {
+	const td = ev.delta;
+	if (typeof td === "string" && td.length > 0) {
+		const prevPhase = state.phase;
+		if (phasePriority("text") >= phasePriority(state.phase)) {
+			state.phase = "text";
+		}
+		state.liveText += td;
+		if (state.liveText.length > MAX_LIVE_TEXT) {
+			state.liveText = state.liveText.slice(-LIVE_TEXT_TRIM);
+		}
+		// Push complete lines to log immediately
+		let nlIdx;
+		while ((nlIdx = state.liveText.indexOf("\n")) !== -1) {
+			const line = state.liveText.slice(0, nlIdx);
+			state.liveText = state.liveText.slice(nlIdx + 1);
+			if (line.trim()) pushLog(state, line);
+		}
+		return { flush: true, workingChange: prevPhase !== "text" };
+	}
+	return { flush: false, workingChange: false };
+}
+
+export function handleTextEnd(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "text_end" },
+): HandlerResult {
+	if (state.liveText.trim()) {
+		state.textOutputLines.push(state.liveText.trim());
+		for (const t of state.liveText.split("\n")) {
+			const trimmed = t.trim();
+			if (trimmed) pushLog(state, trimmed);
+		}
+	}
+	state.textPushedThisTurn = true;
+	if (ev.usage) {
+		state.tokenCount =
+			ev.usage.totalTokens || ev.usage.input! + ev.usage.output! || state.tokenCount;
+	}
+	state.liveText = "";
+	state.phase = "idle";
+	return { flush: true, workingChange: true };
+}
+
+export function handleMessageEnd(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "message_end" },
+): HandlerResult {
+	const msg = ev.message;
+	if (!msg) return { flush: false, workingChange: false };
+
+	if (msg.role === "assistant") {
+		if (!state.thinkingPushedThisTurn && Array.isArray(msg.content)) {
+			for (const block of msg.content) {
+				if (block.type === "thinking" && block.thinking) {
+					const thinkingText =
+						typeof block.thinking === "string"
+							? block.thinking
+							: JSON.stringify(block.thinking).slice(0, 500);
+					for (const t of thinkingText.split("\n")) {
+						if (t.trim()) pushLog(state, `💭 ${t.slice(0, 500)}`);
+					}
+				}
+			}
+			state.thinkingPushedThisTurn = true;
+		}
+		if (!state.textPushedThisTurn) {
+			const text = extractTextFromContent(msg.content);
+			if (text && text.trim()) {
+				state.textOutputLines.push(text.trim());
+				state.textPushedThisTurn = true;
+				for (const t of text.split("\n")) {
+					if (t.trim()) pushLog(state, t);
+				}
+			}
+		}
+		if (msg.usage) {
+			state.tokenCount = msg.usage.totalTokens || msg.usage.input! + msg.usage.output!;
+		}
+	} else if (msg.role === "toolResult") {
+		const resultText = extractTextFromContent(msg.content);
+		const label = msg.toolName || state.lastToolName || "tool";
+		if (resultText && resultText.trim()) {
+			const resultLines = resultText.split("\n");
+			pushLog(state, `📋 ${label}: ${resultLines[0]?.slice(0, 300) || "(no output)"}`);
+			for (let i = 1; i < Math.min(resultLines.length, 6); i++) {
+				if (resultLines[i].trim()) pushLog(state, `   ${resultLines[i].slice(0, 200)}`);
+			}
+		} else {
+			pushLog(state, `📋 ${label}: (no output)`);
+		}
+		state.lastToolName = undefined;
+	}
+
+	// Budget check: tool call limit
+	if (state.maxToolCalls > 0 && state.toolCount >= state.maxToolCalls) {
+		state.budgetExceeded = true;
+		state.budgetExceededReason = `Tool call limit reached: ${state.toolCount}/${state.maxToolCalls}`;
+	}
+	// Budget check: token budget
+	if (state.agentTokenBudget > 0 && state.tokenCount >= state.agentTokenBudget) {
+		state.budgetExceeded = true;
+		const reason = `Token budget exceeded: ${state.tokenCount}/${state.agentTokenBudget}`;
+		state.budgetExceededReason = state.budgetExceededReason
+			? `${state.budgetExceededReason}; ${reason}`
+			: reason;
+	}
+
+	state.phase = "idle";
+	state.thinkingPushedThisTurn = false;
+	state.textPushedThisTurn = false;
+	return { flush: true, workingChange: true };
+}
+
+export function handleDone(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "done" },
+): HandlerResult {
+	const msg = ev.message;
+	if (msg?.usage) {
+		state.tokenCount =
+			msg.usage.totalTokens || (msg.usage.input ?? 0) + (msg.usage.output ?? 0) || state.tokenCount;
+	}
+
+	if (msg?.content && Array.isArray(msg.content)) {
+		const textParts: string[] = [];
+		const thinkingParts: string[] = [];
+		for (const block of msg.content) {
+			if (block.type === "text" && block.text) {
+				textParts.push(block.text);
+			}
+			if (block.type === "thinking" && block.thinking) {
+				const t =
+					typeof block.thinking === "string" ? block.thinking : JSON.stringify(block.thinking);
+				thinkingParts.push(t);
+			}
+		}
+		if (!state.textPushedThisTurn && textParts.length > 0) {
+			const allText = textParts.join("\n").trim();
+			if (allText) {
+				state.textOutputLines.push(allText);
+				state.textPushedThisTurn = true;
+				for (const t of allText.split("\n")) {
+					if (t.trim()) pushLog(state, t);
+				}
+			}
+		}
+		if (!state.thinkingPushedThisTurn && thinkingParts.length > 0) {
+			const allThinking = thinkingParts.join("\n").trim();
+			if (allThinking) {
+				state.thinkingOutputLines.push(allThinking);
+				state.thinkingPushedThisTurn = true;
+				for (const t of allThinking.split("\n")) {
+					if (t.trim()) pushLog(state, `💭 ${t}`);
+				}
+			}
+		}
+	}
+
+	state.liveText = "";
+	state.liveThinking = "";
+	state.phase = "idle";
+	return { flush: true, workingChange: true };
+}
+
+export function handleContextInfo(
+	state: AgentRunState,
+	ev: NormalizedEvent & { kind: "context_info" },
+): HandlerResult {
+	const tokens = ev.contextTokens;
+	const window = ev.contextWindow;
+	if (typeof tokens === "number" && typeof window === "number" && window > 0) {
+		state.contextTokens = tokens;
+		state.contextWindow = window;
+		state.contextInfoReceived = true;
+		pushLog(
+			state,
+			`📊 Context: ${(tokens / 1000).toFixed(1)}K/${(window / 1000).toFixed(1)}K (initial)`,
+		);
+		return { flush: true, workingChange: false };
+	}
+	return { flush: false, workingChange: false };
+}

--- a/.pi/extensions/supervisor/event-types.test.mts
+++ b/.pi/extensions/supervisor/event-types.test.mts
@@ -1,0 +1,249 @@
+// ─── Tests: event-types.ts — NormalizedEvent discriminated union ──
+// Phase 1: Compile-time verification of the NormalizedEvent type.
+// Most checks are structural — we verify the discriminated union works
+// by constructing objects of each kind and exhaustively switching.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { NormalizedEvent } from "./event-types.ts";
+
+// ─── Compile-time check helpers ──────────────────────────────────
+
+/**
+ * Exhaustive switch helper — the `never` default ensures all kinds handled.
+ * This function is the compile-time proof that the NormalizedEvent type
+ * is correctly constructed.
+ */
+function kindNames(): string[] {
+	// We can't enumerate a type at runtime, but we verify at test level
+	// by constructing every kind and checking discriminant.
+	return ["done"];
+}
+
+// ─── NormalizedEvent construction tests ──────────────────────────
+// Each test constructs one NormalizedEvent kind and verifies its shape.
+
+describe("NormalizedEvent discriminated union", () => {
+	it("tool_execution_start carries toolName and args", () => {
+		const ev: NormalizedEvent = {
+			kind: "tool_execution_start",
+			toolName: "read_file",
+			args: { path: "./file.ts" },
+		};
+		assert.equal(ev.kind, "tool_execution_start");
+		assert.equal(ev.toolName, "read_file");
+		assert.deepEqual(ev.args, { path: "./file.ts" });
+	});
+
+	it("tool_execution_start works without args", () => {
+		const ev: NormalizedEvent = {
+			kind: "tool_execution_start",
+			toolName: "read_file",
+		};
+		assert.equal(ev.kind, "tool_execution_start");
+		assert.equal(ev.toolName, "read_file");
+		assert.equal((ev as any).args, undefined);
+	});
+
+	it("tool_execution_end carries toolName and isError", () => {
+		const ev: NormalizedEvent = {
+			kind: "tool_execution_end",
+			toolName: "read_file",
+			isError: false,
+		};
+		assert.equal(ev.kind, "tool_execution_end");
+		assert.equal(ev.toolName, "read_file");
+		assert.equal(ev.isError, false);
+	});
+
+	it("thinking_start has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "thinking_start" };
+		assert.equal(ev.kind, "thinking_start");
+	});
+
+	it("thinking_end has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "thinking_end" };
+		assert.equal(ev.kind, "thinking_end");
+	});
+
+	it("thinking_delta carries delta string", () => {
+		const ev: NormalizedEvent = { kind: "thinking_delta", delta: "step 1" };
+		assert.equal(ev.kind, "thinking_delta");
+		assert.equal(ev.delta, "step 1");
+	});
+
+	it("text_start has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "text_start" };
+		assert.equal(ev.kind, "text_start");
+	});
+
+	it("text_end carries optional usage", () => {
+		const ev: NormalizedEvent = {
+			kind: "text_end",
+			usage: { totalTokens: 100, input: 50, output: 50 },
+		};
+		assert.equal(ev.kind, "text_end");
+		assert.equal(ev.usage?.totalTokens, 100);
+	});
+
+	it("text_end works without usage", () => {
+		const ev: NormalizedEvent = { kind: "text_end" };
+		assert.equal(ev.kind, "text_end");
+	});
+
+	it("text_delta carries delta string", () => {
+		const ev: NormalizedEvent = { kind: "text_delta", delta: "hello" };
+		assert.equal(ev.kind, "text_delta");
+		assert.equal(ev.delta, "hello");
+	});
+
+	it("message_end carries message with role and optional content", () => {
+		const ev: NormalizedEvent = {
+			kind: "message_end",
+			message: {
+				role: "assistant",
+				content: [{ type: "text", text: "hello" }],
+			},
+		};
+		assert.equal(ev.kind, "message_end");
+		assert.equal(ev.message.role, "assistant");
+		assert.ok(Array.isArray(ev.message.content));
+	});
+
+	it("done carries message with content and optional usage", () => {
+		const ev: NormalizedEvent = {
+			kind: "done",
+			message: {
+				content: [{ type: "text", text: "done" }],
+				usage: { input: 10, output: 5 },
+			},
+		};
+		assert.equal(ev.kind, "done");
+		assert.equal(ev.message.content?.[0]?.type, "text");
+		assert.equal(ev.message.usage?.input, 10);
+	});
+
+	it("context_info carries contextTokens and contextWindow", () => {
+		const ev: NormalizedEvent = {
+			kind: "context_info",
+			contextTokens: 5000,
+			contextWindow: 10000,
+		};
+		assert.equal(ev.kind, "context_info");
+		assert.equal(ev.contextTokens, 5000);
+		assert.equal(ev.contextWindow, 10000);
+	});
+
+	it("turn_start has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "turn_start" };
+		assert.equal(ev.kind, "turn_start");
+	});
+
+	it("turn_end has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "turn_end" };
+		assert.equal(ev.kind, "turn_end");
+	});
+
+	it("agent_start has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "agent_start" };
+		assert.equal(ev.kind, "agent_start");
+	});
+
+	it("agent_end has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "agent_end" };
+		assert.equal(ev.kind, "agent_end");
+	});
+
+	it("session has no extra payload", () => {
+		const ev: NormalizedEvent = { kind: "session" };
+		assert.equal(ev.kind, "session");
+	});
+
+	it("message_end with role=toolResult carries tool info", () => {
+		const ev: NormalizedEvent = {
+			kind: "message_end",
+			message: {
+				role: "toolResult",
+				content: [{ type: "text", text: "result" }],
+				toolName: "read_file",
+			},
+		};
+		assert.equal(ev.kind, "message_end");
+		assert.equal(ev.message.role, "toolResult");
+		assert.equal(ev.message.toolName, "read_file");
+	});
+});
+
+// ─── Exhaustive switch compile-time check ────────────────────────
+
+describe("exhaustive switch (compile-time proof)", () => {
+	it("handles all kinds without TypeScript error — runtime check via text_end", () => {
+		function handle(ev: NormalizedEvent): string {
+			switch (ev.kind) {
+				case "tool_execution_start":
+					return `tool_start:${ev.toolName}`;
+				case "tool_execution_end":
+					return `tool_end:${ev.toolName}`;
+				case "thinking_start":
+					return "thinking_start";
+				case "thinking_end":
+					return "thinking_end";
+				case "thinking_delta":
+					return `thinking_delta:${ev.delta}`;
+				case "text_start":
+					return "text_start";
+				case "text_end":
+					return `text_end${ev.usage ? `:${ev.usage.totalTokens}` : ""}`;
+				case "text_delta":
+					return `text_delta:${ev.delta}`;
+				case "message_end":
+					return `message_end:${ev.message.role}`;
+				case "done":
+					return "done";
+				case "context_info":
+					return `context:${ev.contextTokens}`;
+				case "turn_start":
+					return "turn_start";
+				case "turn_end":
+					return "turn_end";
+				case "agent_start":
+					return "agent_start";
+				case "agent_end":
+					return "agent_end";
+				case "session":
+					return "session";
+				default:
+					// exhaustive check: if a new kind is added without a case, this won't compile
+					const _exhaustive: never = ev;
+					return _exhaustive;
+			}
+		}
+
+		assert.equal(handle({ kind: "tool_execution_start", toolName: "read" }), "tool_start:read");
+		assert.equal(
+			handle({ kind: "tool_execution_end", toolName: "read", isError: false }),
+			"tool_end:read",
+		);
+		assert.equal(handle({ kind: "thinking_start" }), "thinking_start");
+		assert.equal(handle({ kind: "thinking_end" }), "thinking_end");
+		assert.equal(handle({ kind: "thinking_delta", delta: "t" }), "thinking_delta:t");
+		assert.equal(handle({ kind: "text_start" }), "text_start");
+		assert.equal(handle({ kind: "text_end", usage: { totalTokens: 100 } }), "text_end:100");
+		assert.equal(handle({ kind: "text_end" }), "text_end");
+		assert.equal(handle({ kind: "text_delta", delta: "h" }), "text_delta:h");
+		assert.equal(
+			handle({ kind: "message_end", message: { role: "assistant" } }),
+			"message_end:assistant",
+		);
+		assert.equal(handle({ kind: "done", message: {} }), "done");
+		assert.equal(
+			handle({ kind: "context_info", contextTokens: 500, contextWindow: 1000 }),
+			"context:500",
+		);
+		assert.equal(handle({ kind: "turn_start" }), "turn_start");
+		assert.equal(handle({ kind: "turn_end" }), "turn_end");
+		assert.equal(handle({ kind: "agent_start" }), "agent_start");
+		assert.equal(handle({ kind: "agent_end" }), "agent_end");
+		assert.equal(handle({ kind: "session" }), "session");
+	});
+});

--- a/.pi/extensions/supervisor/event-types.ts
+++ b/.pi/extensions/supervisor/event-types.ts
@@ -1,0 +1,67 @@
+// ─── NormalizedEvent — discriminated union for unified event processing ──
+// Both JSON-line events (from agent-stream) and SDK session events
+// (from session-events) are converted to this common representation.
+// The discriminant `kind` enables exhaustive type narrowing.
+
+import type { AgentPhase } from "./types";
+
+// ─── NormalizedEvent ─────────────────────────────────────────────
+
+export type NormalizedEvent =
+	| { kind: "tool_execution_start"; toolName: string; args?: unknown }
+	| { kind: "tool_execution_end"; toolName: string; isError?: boolean }
+	| { kind: "thinking_start" }
+	| { kind: "thinking_end" }
+	| { kind: "thinking_delta"; delta: string }
+	| { kind: "text_start" }
+	| { kind: "text_end"; usage?: { totalTokens?: number; input?: number; output?: number } }
+	| { kind: "text_delta"; delta: string }
+	| {
+			kind: "message_end";
+			message: {
+				role: string;
+				content?: Array<
+					Record<string, unknown> & { type: string; text?: string; thinking?: string }
+				>;
+				toolName?: string;
+				usage?: { totalTokens?: number; input?: number; output?: number };
+			};
+	  }
+	| {
+			kind: "done";
+			message: {
+				content?: Array<
+					Record<string, unknown> & { type: string; text?: string; thinking?: string }
+				>;
+				usage?: { totalTokens?: number; input?: number; output?: number };
+			};
+	  }
+	| { kind: "context_info"; contextTokens: number; contextWindow: number }
+	| { kind: "turn_start" }
+	| { kind: "turn_end" }
+	| { kind: "agent_start" }
+	| { kind: "agent_end" }
+	| { kind: "session" };
+
+// ─── Return type for event handlers ──────────────────────────────
+
+export interface HandlerResult {
+	flush: boolean;
+	workingChange: boolean;
+}
+
+// ─── phasePriority ───────────────────────────────────────────────
+
+/** Numeric priority for phase ordering. Higher = more important. */
+export function phasePriority(phase: AgentPhase): number {
+	switch (phase) {
+		case "tool":
+			return 3;
+		case "thinking":
+			return 2;
+		case "text":
+			return 1;
+		case "idle":
+			return 0;
+	}
+}

--- a/.pi/extensions/supervisor/session-events.ts
+++ b/.pi/extensions/supervisor/session-events.ts
@@ -1,10 +1,18 @@
 // ─── Session Event Processors ────────────────────────────────────
-// Event processing for both in-process SDK events and subprocess JSON lines.
-// Extracted from agent-session-runner.ts to keep files modular.
+// Thin wrapper: converts SDK session events to NormalizedEvent and
+// delegates to the shared processNormalizedEvent.
+//
+// Owns: SessionEvent type, getEventPhase() (backward compat).
+// Delegates: processSessionEvent() → sessionEventToNormalizedEvent() + processNormalizedEvent().
 
 import type { AgentRunState, AgentPhase } from "./types";
 import { pushLog } from "./agent-stream.ts";
-import { extractTextFromContent } from "./formatting.ts";
+import { sessionEventToNormalizedEvent, processNormalizedEvent } from "./event-adapter.ts";
+import { phasePriority } from "./event-types.ts";
+
+// ─── Re-exports for backward compat ───────────────────────────────
+
+export { phasePriority } from "./event-types.ts";
 
 // ─── Session Event Types ───────────────────────────────────────────
 
@@ -36,269 +44,22 @@ export type SessionEvent = Record<string, unknown> & {
 // ─── Event → State Mapping ─────────────────────────────────────────
 
 /**
- * Process a single session event — mirrors processJsonLine logic
- * but receives typed SDK events instead of parsed JSON lines.
+ * Process a single session event — thin wrapper that converts to
+ * NormalizedEvent and delegates to the shared processor.
  */
 export function processSessionEvent(
 	ev: SessionEvent,
 	state: AgentRunState,
 ): { flush: boolean; workingChange: boolean } {
-	const prevPhase = state.phase;
-
-	switch (ev.type) {
-		case "context_info":
-			// context_info event removed in new agent-core — skip
-			break;
-
-		case "tool_execution_start": {
-			state.currentTool = ev.toolName || "tool";
-			state.currentToolArgs = ev.args ? JSON.stringify(ev.args).slice(0, 200) : undefined;
-			state.lastToolName = ev.toolName;
-			state.phase = "tool";
-			const logArgs = ev.args ? JSON.stringify(ev.args).slice(0, 200) : "";
-			pushLog(state, `🔧 ${ev.toolName}${logArgs ? ` ${logArgs}` : ""}`);
-			return { flush: true, workingChange: prevPhase !== "tool" };
-		}
-
-		case "tool_execution_end": {
-			state.toolCount++;
-			state.currentTool = undefined;
-			state.currentToolArgs = undefined;
-			state.phase = "idle";
-			pushLog(state, `${ev.isError ? "✗" : "✓"} ${ev.toolName}`);
-			return { flush: true, workingChange: true };
-		}
-
-		case "message_update": {
-			const ae = ev.assistantMessageEvent;
-			if (!ae) break;
-
-			const eventPhase = getEventPhase(ev);
-			if (eventPhase !== "idle" && phasePriority(eventPhase) >= phasePriority(state.phase)) {
-				state.phase = eventPhase;
-			}
-
-			switch (ae.type) {
-				case "thinking_start": {
-					state.thinkingPushedThisTurn = false;
-					return { flush: true, workingChange: prevPhase !== "thinking" };
-				}
-				case "text_start": {
-					state.textPushedThisTurn = false;
-					return { flush: true, workingChange: prevPhase !== "text" };
-				}
-				case "thinking_delta": {
-					const td = ae.delta;
-					if (typeof td === "string" && td.length > 0) {
-						state.liveThinking += td;
-						if (state.liveThinking.length > 1000) {
-							state.liveThinking = state.liveThinking.slice(-1000);
-						}
-						let nlIdx;
-						while ((nlIdx = state.liveThinking.indexOf("\n")) !== -1) {
-							const line = state.liveThinking.slice(0, nlIdx);
-							state.liveThinking = state.liveThinking.slice(nlIdx + 1);
-							if (line.trim()) pushLog(state, `💭 ${line}`);
-						}
-						return { flush: true, workingChange: prevPhase !== "thinking" };
-					}
-					break;
-				}
-				case "text_delta": {
-					const td = ae.delta;
-					if (typeof td === "string" && td.length > 0) {
-						state.liveText += td;
-						if (state.liveText.length > 10_000) {
-							state.liveText = state.liveText.slice(-8_000);
-						}
-						let nlIdx;
-						while ((nlIdx = state.liveText.indexOf("\n")) !== -1) {
-							const line = state.liveText.slice(0, nlIdx);
-							state.liveText = state.liveText.slice(nlIdx + 1);
-							if (line.trim()) pushLog(state, line);
-						}
-						return { flush: true, workingChange: prevPhase !== "text" };
-					}
-					break;
-				}
-				case "thinking_end": {
-					if (state.liveThinking.trim()) {
-						state.thinkingOutputLines.push(state.liveThinking.trim());
-						for (const t of state.liveThinking.split("\n")) {
-							const trimmed = t.trim();
-							if (trimmed) pushLog(state, `💭 ${trimmed}`);
-						}
-					}
-					state.thinkingPushedThisTurn = true;
-					state.liveThinking = "";
-					state.phase = "idle";
-					return { flush: true, workingChange: true };
-				}
-				case "text_end": {
-					if (state.liveText.trim()) {
-						state.textOutputLines.push(state.liveText.trim());
-						for (const t of state.liveText.split("\n")) {
-							const trimmed = t.trim();
-							if (trimmed) pushLog(state, trimmed);
-						}
-					}
-					state.textPushedThisTurn = true;
-					if (ev.message?.usage) {
-						state.tokenCount =
-							ev.message.usage.totalTokens ||
-							(ev.message.usage.input ?? 0) + (ev.message.usage.output ?? 0) ||
-							state.tokenCount;
-					}
-					state.liveText = "";
-					state.phase = "idle";
-					return { flush: true, workingChange: true };
-				}
-				case "done": {
-					const msg = ae.message;
-					if (msg?.usage) {
-						state.tokenCount =
-							msg.usage.totalTokens ||
-							(msg.usage.input ?? 0) + (msg.usage.output ?? 0) ||
-							state.tokenCount;
-					}
-					if (msg?.content && Array.isArray(msg.content)) {
-						const textParts: string[] = [];
-						const thinkingParts: string[] = [];
-						for (const block of msg.content) {
-							if (block.type === "text" && block.text) {
-								textParts.push(block.text);
-							}
-							if (block.type === "thinking" && block.thinking) {
-								const t =
-									typeof block.thinking === "string"
-										? block.thinking
-										: JSON.stringify(block.thinking);
-								thinkingParts.push(t);
-							}
-						}
-						if (!state.textPushedThisTurn && textParts.length > 0) {
-							const allText = textParts.join("\n").trim();
-							if (allText) {
-								state.textOutputLines.push(allText);
-								state.textPushedThisTurn = true;
-								for (const t of allText.split("\n")) {
-									if (t.trim()) pushLog(state, t);
-								}
-								state.textPushedThisTurn = true;
-							}
-						}
-						if (!state.thinkingPushedThisTurn && thinkingParts.length > 0) {
-							const allThinking = thinkingParts.join("\n").trim();
-							if (allThinking) {
-								state.thinkingOutputLines.push(allThinking);
-								state.thinkingPushedThisTurn = true;
-								for (const t of allThinking.split("\n")) {
-									if (t.trim()) pushLog(state, `💭 ${t}`);
-								}
-								state.thinkingPushedThisTurn = true;
-							}
-						}
-					}
-					state.liveText = "";
-					state.liveThinking = "";
-					state.phase = "idle";
-					return { flush: true, workingChange: true };
-				}
-			}
-			break;
-		}
-
-		case "message_end": {
-			const msg = ev.message;
-			if (!msg) break;
-
-			if (msg.role === "assistant") {
-				if (!state.thinkingPushedThisTurn && Array.isArray(msg.content)) {
-					for (const block of msg.content) {
-						if (block.type === "thinking" && block.thinking) {
-							const thinkingText =
-								typeof block.thinking === "string"
-									? block.thinking
-									: JSON.stringify(block.thinking);
-							for (const t of thinkingText.split("\n")) {
-								if (t.trim()) pushLog(state, `💭 ${t.trim()}`);
-							}
-						}
-					}
-					state.thinkingPushedThisTurn = true;
-				}
-				if (!state.textPushedThisTurn) {
-					const text = extractTextFromContent(msg.content);
-					if (text && text.trim()) {
-						state.textOutputLines.push(text.trim());
-						state.textPushedThisTurn = true;
-						for (const t of text.split("\n")) {
-							if (t.trim()) pushLog(state, t);
-						}
-					}
-				}
-				if (msg.usage) {
-					state.tokenCount =
-						msg.usage.totalTokens || (msg.usage.input ?? 0) + (msg.usage.output ?? 0);
-				}
-			} else if (msg.role === "toolResult") {
-				const resultText = extractTextFromContent(msg.content);
-				const label = msg.toolName || state.lastToolName || "tool";
-				if (resultText && resultText.trim()) {
-					const resultLines = resultText.split("\n");
-					pushLog(state, `📋 ${label}: ${resultLines[0]?.slice(0, 300) || "(no output)"}`);
-					for (let i = 1; i < Math.min(resultLines.length, 6); i++) {
-						if (resultLines[i].trim()) pushLog(state, `   ${resultLines[i].slice(0, 200)}`);
-					}
-				} else {
-					pushLog(state, `📋 ${label}: (no output)`);
-				}
-				state.lastToolName = undefined;
-			}
-			// Budget check: tool call limit
-			if (state.maxToolCalls > 0 && state.toolCount >= state.maxToolCalls) {
-				state.budgetExceeded = true;
-				state.budgetExceededReason = `Tool call limit reached: ${state.toolCount}/${state.maxToolCalls}`;
-			}
-			// Budget check: token budget
-			if (state.agentTokenBudget > 0 && state.tokenCount >= state.agentTokenBudget) {
-				state.budgetExceeded = true;
-				const reason = `Token budget exceeded: ${state.tokenCount}/${state.agentTokenBudget}`;
-				state.budgetExceededReason = state.budgetExceededReason
-					? `${state.budgetExceededReason}; ${reason}`
-					: reason;
-			}
-			state.phase = "idle";
-			state.thinkingPushedThisTurn = false;
-			state.textPushedThisTurn = false;
-			return { flush: true, workingChange: true };
-		}
-
-		case "turn_start":
-		case "turn_end":
-		case "agent_start":
-		case "agent_end":
-			break;
-	}
-
-	return { flush: false, workingChange: false };
+	const normalized = sessionEventToNormalizedEvent(ev);
+	if (!normalized) return { flush: false, workingChange: false };
+	return processNormalizedEvent(normalized, state);
 }
 
-/** Numeric priority for phase ordering. Higher = more important. */
-export function phasePriority(phase: AgentPhase): number {
-	switch (phase) {
-		case "tool":
-			return 3;
-		case "thinking":
-			return 2;
-		case "text":
-			return 1;
-		case "idle":
-			return 0;
-	}
-}
-
-/** Determine phase from a session event */
+/**
+ * Determine phase from a session event.
+ * Preserved for backward compat.
+ */
 export function getEventPhase(ev: SessionEvent): AgentPhase {
 	if (!ev) return "idle";
 	if (ev.type === "tool_execution_start") return "tool";


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #304

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 46s | 37.7K | 31 | — |
| researcher | ✓ SUCCESS | 55s | 89.9K | 11 | — |
| test-designer | ✓ SUCCESS | 1m 8s | 41.3K | 23 | — |
| developer | ✓ SUCCESS | 7m 0s | 97.4K | 95 | — |
| auditor | ✓ SUCCESS | 2m 41s | 65.6K | 37 | — |

**Total:** 5 agents · 13m 31s · 332.0K tokens · 197 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/304