### PR TITLE
feat(#334): Bug: ranked-map - rg `./` prefix breaks keyword-to-symbol path matching

### DIFF
--- a/.pi/extensions/ranked-map/search.ts
+++ b/.pi/extensions/ranked-map/search.ts
@@ -5,6 +5,7 @@
  * Fully async with AbortSignal support.
  */
 
+import { normalize } from "node:path";
 import type { ExecFn } from "./types.ts";
 
 /**
@@ -39,10 +40,15 @@ export async function runKeywordSearch(
 		const matchedFiles = result.stdout.trim().split("\n").filter(Boolean);
 
 		for (const file of matchedFiles) {
-			if (!fileMatches[file]) {
-				fileMatches[file] = [];
+			// Normalize path to strip ./ prefix and resolve .. segments.
+			// rg with target directory '.' returns paths as ./src/foo.ts,
+			// while ctags and git return paths without prefix (src/foo.ts).
+			// Normalizing ensures consistent keys across all sources.
+			const normalizedPath = normalize(file);
+			if (!fileMatches[normalizedPath]) {
+				fileMatches[normalizedPath] = [];
 			}
-			fileMatches[file]!.push(term);
+			fileMatches[normalizedPath]!.push(term);
 		}
 	}
 

--- a/.pi/extensions/ranked-map/test/scoring.test.ts
+++ b/.pi/extensions/ranked-map/test/scoring.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for rankFiles — key alignment between keywordScores and symbolEntries
+ *
+ * Phase 1 (Characterization): Documents the bug where ./-prefixed keys from
+ * rg don't match unprefixed keys from ctags, causing split entries.
+ *
+ * Phase 2 (Fix verification): After path normalization in runKeywordSearch,
+ * keys are consistent, producing single entries with both scores and symbols.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { rankFiles, computeKeywordScores, computeRecencyScores } from "../scoring.ts";
+import type { SymbolEntry } from "../types.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const defaultWeights = { keyword: 1.0, recency: 0.0 };
+const highBudget = 10_000;
+
+function makeSymbols(names: string[]): SymbolEntry[] {
+	return names.map((name) => ({ type: "function", name, line: 1 }));
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Characterization — key mismatch bug
+// ---------------------------------------------------------------------------
+
+describe("rankFiles — Phase 1: key mismatch characterization", () => {
+	it("mismatched ./ prefix keys produce two separate entries", () => {
+		const keywordScores: Record<string, number> = { "./src/foo.ts": 1.0 };
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/foo.ts": makeSymbols(["hello"]),
+		};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+
+		// Bug: two entries for what should be the same file
+		const paths = result.files.map((f) => f.path);
+		assert.ok(paths.includes("./src/foo.ts"), "should include ./src/foo.ts entry");
+		assert.ok(paths.includes("src/foo.ts"), "should include src/foo.ts entry");
+
+		// The ./src/foo.ts entry should have score but no symbols
+		const prefixedEntry = result.files.find((f) => f.path === "./src/foo.ts");
+		assert.equal(prefixedEntry?.score, 1.0);
+		assert.ok(prefixedEntry?.symbols.includes("(no symbols)"), "prefixed entry has no symbols");
+
+		// The src/foo.ts entry should have symbols but 0 score
+		const unprefixedEntry = result.files.find((f) => f.path === "src/foo.ts");
+		assert.equal(unprefixedEntry?.score, 0.0);
+		assert.ok(unprefixedEntry?.symbols.includes("hello"), "unprefixed entry has symbols");
+	});
+
+	it("consistent keys produce single entry with both score and symbols", () => {
+		const keywordScores: Record<string, number> = { "src/foo.ts": 1.0 };
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/foo.ts": makeSymbols(["hello"]),
+		};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+
+		// One entry with both score and symbols
+		assert.equal(result.files.length, 1);
+		assert.equal(result.files[0]!.path, "src/foo.ts");
+		assert.equal(result.files[0]!.score, 1.0);
+		assert.ok(result.files[0]!.symbols.includes("hello"), "entry should have symbols");
+	});
+
+	it("multiple files with mixed key formats produce duplicate-like entries", () => {
+		const keywordScores: Record<string, number> = {
+			"./src/a.ts": 0.5,
+			"./src/b.ts": 1.0,
+		};
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/a.ts": makeSymbols(["foo"]),
+			"src/b.ts": makeSymbols(["bar"]),
+			"src/c.ts": makeSymbols(["baz"]),
+		};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+
+		// Should be 5 entries (2 mismatched + 3 regular)
+		assert.equal(result.files.length, 5);
+	});
+
+	it("no keyword matches — all entries come from symbolEntries", () => {
+		const keywordScores: Record<string, number> = {};
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/a.ts": makeSymbols(["foo"]),
+		};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+		assert.equal(result.files.length, 1);
+		assert.equal(result.files[0]!.path, "src/a.ts");
+	});
+
+	it("no symbolEntries — all entries come from keywordScores", () => {
+		const keywordScores: Record<string, number> = { "./src/a.ts": 1.0 };
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+		assert.equal(result.files.length, 1);
+		assert.equal(result.files[0]!.path, "./src/a.ts");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2: After fix — consistent keys produce correct rankings
+// ---------------------------------------------------------------------------
+
+describe("rankFiles — Phase 2: consistent key behavior", () => {
+	it("single file with keyword score and symbols — single entry with both", () => {
+		const keywordScores: Record<string, number> = { "src/foo.ts": 1.0 };
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/foo.ts": makeSymbols(["hello"]),
+		};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+		assert.equal(result.files.length, 1);
+		assert.equal(result.files[0]!.path, "src/foo.ts");
+		assert.equal(result.files[0]!.score, 1.0);
+		assert.ok(result.files[0]!.symbols.includes("hello"));
+	});
+
+	it("multiple files sorted by score descending", () => {
+		const keywordScores: Record<string, number> = {
+			"src/a.ts": 0.5,
+			"src/b.ts": 1.0,
+			"src/c.ts": 0.0,
+		};
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/a.ts": makeSymbols(["a"]),
+			"src/b.ts": makeSymbols(["b"]),
+			"src/c.ts": makeSymbols(["c"]),
+		};
+
+		const result = rankFiles(
+			keywordScores,
+			recencyScores,
+			defaultWeights,
+			highBudget,
+			symbolEntries,
+		);
+		assert.equal(result.files.length, 3);
+		assert.equal(result.files[0]!.path, "src/b.ts");
+		assert.equal(result.files[1]!.path, "src/a.ts");
+		assert.equal(result.files[2]!.path, "src/c.ts");
+	});
+
+	it("token budget truncation works correctly", () => {
+		const keywordScores: Record<string, number> = {
+			"src/a.ts": 1.0,
+			"src/b.ts": 0.5,
+		};
+		const recencyScores: Record<string, number> = {};
+		const symbolEntries: Record<string, SymbolEntry[]> = {
+			"src/a.ts": makeSymbols(["a"]),
+			"src/b.ts": makeSymbols(["b"]),
+		};
+
+		// Very small budget should only fit first (highest-ranked) entry
+		const result = rankFiles(keywordScores, recencyScores, defaultWeights, 1, symbolEntries);
+		assert.equal(result.files.length, 1);
+		assert.equal(result.files[0]!.path, "src/a.ts");
+		assert.ok(result.truncated);
+	});
+
+	it("computeKeywordScores works correctly", () => {
+		const fileMatches = {
+			"src/foo.ts": ["hello", "world"],
+			"src/bar.ts": ["hello"],
+		};
+		const terms = ["hello", "world"];
+		const scores = computeKeywordScores(fileMatches, terms);
+		assert.equal(scores["src/foo.ts"], 1.0);
+		assert.equal(scores["src/bar.ts"], 0.5);
+	});
+
+	it("computeRecencyScores works correctly", () => {
+		const now = new Date("2026-06-01T00:00:00Z");
+		const fileDates = {
+			"src/new.ts": "2026-06-01T00:00:00Z",
+			"src/old.ts": "2026-05-01T00:00:00Z",
+		};
+		const scores = computeRecencyScores(fileDates, 30, now);
+		assert.equal(scores["src/new.ts"], 1.0);
+		assert.equal(scores["src/old.ts"], 0.0);
+	});
+});

--- a/.pi/extensions/ranked-map/test/search.test.ts
+++ b/.pi/extensions/ranked-map/test/search.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for runKeywordSearch — path normalization from rg output
+ *
+ * Phase 1 (Characterization): Documents current bug where rg ./ prefix
+ * creates key mismatch with ctags/symbol entries.
+ *
+ * Phase 2 (Fix verification): After normalization in runKeywordSearch,
+ * path keys are consistent regardless of rg directory argument.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { runKeywordSearch } from "../search.ts";
+
+// ---------------------------------------------------------------------------
+// Mock exec helper
+// ---------------------------------------------------------------------------
+
+function mockExec(stdout: string, code = 0) {
+	return async () => ({
+		stdout,
+		stderr: "",
+		code,
+		killed: false,
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1: Characterization — prove the mismatch
+// ---------------------------------------------------------------------------
+
+describe("runKeywordSearch — Phase 1: characterization (current bug)", () => {
+	it("rg with directory '.' returns normalized paths (no ./ prefix)", async () => {
+		// When rg target directory is '.', paths come back with './' prefix.
+		// After fix: normalized to remove ./ prefix for key consistency.
+		const exec = mockExec("./src/foo.ts\n./api/routes.py\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		assert.deepEqual(Object.keys(result.fileMatches).sort(), ["api/routes.py", "src/foo.ts"]);
+	});
+
+	it("rg with explicit src/ dir returns paths without ./ prefix", async () => {
+		const exec = mockExec("src/foo.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", "src", "/tmp");
+		assert.deepEqual(Object.keys(result.fileMatches), ["src/foo.ts"]);
+	});
+
+	it("rg returns non-zero exit when no matches — returns empty fileMatches", async () => {
+		const exec = mockExec("", 1);
+		const result = await runKeywordSearch(exec as any, "nonexistent", ".", "/tmp");
+		assert.deepEqual(result.fileMatches, {});
+	});
+
+	it("empty query returns empty terms and fileMatches", async () => {
+		const exec = mockExec("");
+		const result = await runKeywordSearch(exec as any, "", ".", "/tmp");
+		assert.deepEqual(result.terms, []);
+		assert.deepEqual(result.fileMatches, {});
+	});
+
+	it("whitespace-only query returns empty terms and fileMatches", async () => {
+		const exec = mockExec("");
+		const result = await runKeywordSearch(exec as any, "   ", ".", "/tmp");
+		assert.deepEqual(result.terms, []);
+		assert.deepEqual(result.fileMatches, {});
+	});
+
+	it("matched file has the correct terms associated", async () => {
+		const exec = mockExec("src/foo.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello world", ".", "/tmp");
+		// Only first term matched (rg mock returns same stdout for both calls)
+		assert.deepEqual(result.terms, ["hello", "world"]);
+		// Both terms call rg, so src/foo.ts appears twice
+		assert.deepEqual(result.fileMatches["src/foo.ts"], ["hello", "world"]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2: After fix — path normalization
+// ---------------------------------------------------------------------------
+
+describe("runKeywordSearch — Phase 2: path normalization (desired behavior)", () => {
+	it("strips ./ prefix from rg output paths", async () => {
+		const exec = mockExec("./src/foo.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		assert.ok(Object.keys(result.fileMatches).includes("src/foo.ts"));
+	});
+
+	it("resolves .. segments via path.normalize", async () => {
+		const exec = mockExec("./bar/baz/../qux.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		assert.ok(Object.keys(result.fileMatches).includes("bar/qux.ts"));
+	});
+
+	it("leaves paths without ./ prefix unchanged", async () => {
+		const exec = mockExec("src/foo.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", "src", "/tmp");
+		assert.deepEqual(Object.keys(result.fileMatches), ["src/foo.ts"]);
+	});
+
+	it("normalizes mixed ./ and bare paths consistently", async () => {
+		const exec = mockExec("./src/foo.ts\n./src/bar.ts\nsrc/baz.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		const keys = Object.keys(result.fileMatches).sort();
+		assert.deepEqual(keys, ["src/bar.ts", "src/baz.ts", "src/foo.ts"]);
+	});
+
+	it("handles empty stdout (no matches)", async () => {
+		const exec = mockExec("");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		assert.deepEqual(result.fileMatches, {});
+	});
+
+	it("handles single ./ path", async () => {
+		const exec = mockExec("./single.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		assert.deepEqual(Object.keys(result.fileMatches), ["single.ts"]);
+	});
+
+	it("handles paths with multiple ./ prefix occurrences (rg output edge case)", async () => {
+		const exec = mockExec("./src/./foo.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		// path.normalize resolves ./ in the middle too
+		assert.ok(Object.keys(result.fileMatches).includes("src/foo.ts"));
+	});
+
+	it("handles deeply nested ./ prefix", async () => {
+		const exec = mockExec("./a/b/c/d/e.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", ".", "/tmp");
+		assert.deepEqual(Object.keys(result.fileMatches), ["a/b/c/d/e.ts"]);
+	});
+
+	it("does not strip non-leading ./ (e.g. ../foo.ts should remain ../foo.ts)", async () => {
+		const exec = mockExec("../foo.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello", "..", "/tmp");
+		// ../foo.ts doesn't start with ./ so it should remain as-is
+		// But path.normalize will keep it as ../foo.ts
+		assert.ok(Object.keys(result.fileMatches).includes("../foo.ts"));
+	});
+
+	it("handles all terms matched correctly after normalization", async () => {
+		const exec = mockExec("./file.ts\n");
+		const result = await runKeywordSearch(exec as any, "hello world", ".", "/tmp");
+		assert.deepEqual(result.fileMatches["file.ts"], ["hello", "world"]);
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #334

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 51s | 35.4K | 17 | — |
| researcher | ✓ SUCCESS | 1m 51s | 115.7K | 30 | — |
| test-designer | ✓ SUCCESS | 46s | 36.2K | 15 | — |
| developer | ✓ SUCCESS | 2m 15s | 54.3K | 39 | — |
| auditor | ✓ SUCCESS | 56s | 47.8K | 19 | — |

**Total:** 5 agents · 6m 40s · 289.4K tokens · 120 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/334