### PR TITLE
feat(#326): Bug: piignore - stale cache does not reload on cwd change

### DIFF
--- a/.pi/extensions/piignore.ts
+++ b/.pi/extensions/piignore.ts
@@ -291,11 +291,13 @@ function checkBashCommand(command: string, entries: IgnoreEntry[], cwd: string):
 
 export default function (pi: ExtensionAPI): void {
 	// Defer sync I/O — load on first use, not at module init
+	let cachedCwd: string | null = null;
 	let entries: IgnoreEntry[] | null = null;
 
 	function getEntries(cwd: string): IgnoreEntry[] {
-		if (!entries) {
+		if (!entries || cachedCwd !== cwd) {
 			entries = loadPiIgnore(cwd);
+			cachedCwd = cwd;
 		}
 		return entries;
 	}
@@ -303,6 +305,7 @@ export default function (pi: ExtensionAPI): void {
 	// Reload patterns on /reload
 	pi.on("resources_discover", (_event, ctx) => {
 		entries = loadPiIgnore(ctx.cwd);
+		cachedCwd = ctx.cwd;
 	});
 
 	// Tools that take a direct path parameter

--- a/.pi/extensions/piignore.ts
+++ b/.pi/extensions/piignore.ts
@@ -304,8 +304,14 @@ export default function (pi: ExtensionAPI): void {
 
 	// Reload patterns on /reload
 	pi.on("resources_discover", (_event, ctx) => {
-		entries = loadPiIgnore(ctx.cwd);
-		cachedCwd = ctx.cwd;
+		try {
+			entries = loadPiIgnore(ctx.cwd);
+			cachedCwd = ctx.cwd;
+		} catch (err) {
+			console.error("[piignore] resources_discover error:", err);
+			entries = null;
+			cachedCwd = null;
+		}
 	});
 
 	// Tools that take a direct path parameter
@@ -316,30 +322,38 @@ export default function (pi: ExtensionAPI): void {
 	const commandTools = ["bash"];
 
 	pi.on("tool_call", async (event, ctx) => {
-		const ignoreEntries = getEntries(ctx.cwd);
-		let blockedPath: string | null = null;
+		try {
+			const ignoreEntries = getEntries(ctx.cwd);
+			let blockedPath: string | null = null;
 
-		if (pathTools.includes(event.toolName)) {
-			blockedPath = checkPath((event.input as { path?: string }).path, ignoreEntries, ctx.cwd);
-		} else if (optPathTools.includes(event.toolName)) {
-			blockedPath = checkPath((event.input as { path?: string }).path, ignoreEntries, ctx.cwd);
-		} else if (commandTools.includes(event.toolName)) {
-			blockedPath = checkBashCommand(
-				(event.input as { command?: string }).command ?? "",
-				ignoreEntries,
-				ctx.cwd,
-			);
-		} else {
-			return;
-		}
-
-		if (blockedPath) {
-			if (ctx.hasUI) {
-				ctx.ui.notify(`Blocked by .piignore: ${blockedPath}`, "warning");
+			if (pathTools.includes(event.toolName)) {
+				blockedPath = checkPath((event.input as { path?: string }).path, ignoreEntries, ctx.cwd);
+			} else if (optPathTools.includes(event.toolName)) {
+				blockedPath = checkPath((event.input as { path?: string }).path, ignoreEntries, ctx.cwd);
+			} else if (commandTools.includes(event.toolName)) {
+				blockedPath = checkBashCommand(
+					(event.input as { command?: string }).command ?? "",
+					ignoreEntries,
+					ctx.cwd,
+				);
+			} else {
+				return;
 			}
+
+			if (blockedPath) {
+				if (ctx.hasUI) {
+					ctx.ui.notify(`Blocked by .piignore: ${blockedPath}`, "warning");
+				}
+				return {
+					block: true,
+					reason: `Path "${blockedPath}" matches .piignore patterns`,
+				};
+			}
+		} catch (err) {
+			console.error("[piignore] Internal error:", err);
 			return {
 				block: true,
-				reason: `Path "${blockedPath}" matches .piignore patterns`,
+				reason: "Piignore internal error — blocked for safety",
 			};
 		}
 	});

--- a/test/piignore.test.mts
+++ b/test/piignore.test.mts
@@ -15,7 +15,9 @@ import assert from "node:assert";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it, beforeEach, afterEach } from "node:test";
+import { describe, it, beforeEach, afterEach, mock } from "node:test";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import piignoreFactory from "../.pi/extensions/piignore.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
 // Types (match source at .pi/extensions/piignore.ts)
@@ -150,6 +152,69 @@ function createGetEntries_fixed(): {
 		},
 		getCallCount: () => _loadCount,
 	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Helpers for Phase 2 tests (mock ExtensionAPI)
+// ═══════════════════════════════════════════════════════════════════════
+
+interface HandlerStore {
+	resources_discover?: (
+		event: { type: "resources_discover"; cwd: string; reason: "startup" | "reload" },
+		ctx: { cwd: string },
+	) => void | Promise<void>;
+	tool_call?: (
+		event: { toolName: string; input: Record<string, unknown> },
+		ctx: { cwd: string; hasUI: boolean; ui: { notify: Function } },
+	) => unknown;
+}
+
+function createMockPi(): { pi: ExtensionAPI; handlers: HandlerStore } {
+	const handlers: HandlerStore = {};
+
+	const pi = {
+		on(event: string, handler: Function) {
+			(handlers as any)[event] = handler;
+		},
+		registerTool: () => {},
+		registerCommand: () => {},
+		registerShortcut: () => {},
+		registerFlag: () => {},
+		getFlag: () => undefined,
+		registerMessageRenderer: () => {},
+		sendMessage: () => {},
+		sendUserMessage: () => {},
+		appendEntry: () => {},
+		setSessionName: () => {},
+		getSessionName: () => undefined,
+		setLabel: () => {},
+		exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		getActiveTools: () => [],
+		getAllTools: () => [],
+		setActiveTools: () => {},
+		getCommands: () => [],
+		setModel: async () => false,
+		getThinkingLevel: () => "normal",
+		setThinkingLevel: () => {},
+		registerProvider: () => {},
+		unregisterProvider: () => {},
+		events: { on: () => {}, emit: () => {}, off: () => {} },
+	} as unknown as ExtensionAPI;
+
+	return { pi, handlers };
+}
+
+/**
+ * Simulate a tool_call event on the extension's handler.
+ * Creates a minimal mock ctx with the given cwd.
+ */
+async function simulateToolCall(
+	handler: Function,
+	toolName: string,
+	input: Record<string, unknown>,
+	cwd: string,
+): Promise<unknown> {
+	return await handler({ toolName, input }, { cwd, hasUI: false, ui: { notify: () => {} } });
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -422,5 +487,289 @@ describe("getEntries caching (Phase 1)", () => {
 		assert.strictEqual(isIgnored("child.txt", entries, dirA), true);
 		// Verify parent's patterns also work
 		assert.strictEqual(isIgnored("parent.txt", entries, dirA), true);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2: ExtensionAPI integration — tool_call dispatch per cwd
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("tool_call dispatch (Phase 2)", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "piignore-phase2-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("registers resources_discover and tool_call handlers on init", () => {
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		assert.ok(
+			typeof handlers.resources_discover === "function",
+			"should register resources_discover handler",
+		);
+		assert.ok(typeof handlers.tool_call === "function", "should register tool_call handler");
+	});
+
+	it("tool_call with read path matching .piignore in current cwd returns block", async () => {
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), "secret.txt\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		// Notify resources_discover to load entries for tmpRoot
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: tmpRoot, reason: "startup" },
+			{ cwd: tmpRoot },
+		);
+
+		const result = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "secret.txt" },
+			tmpRoot,
+		);
+
+		assert.ok(result, "should return a result");
+		assert.strictEqual((result as any).block, true, "should block secret.txt");
+	});
+
+	it("tool_call with read path NOT matching .piignore returns undefined (no block)", async () => {
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), "secret.txt\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: tmpRoot, reason: "startup" },
+			{ cwd: tmpRoot },
+		);
+
+		const result = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "public.txt" },
+			tmpRoot,
+		);
+
+		assert.strictEqual(result, undefined, "public.txt should NOT be blocked");
+	});
+
+	it("tool_call with bash command containing ignored path returns block", async () => {
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), ".env\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: tmpRoot, reason: "startup" },
+			{ cwd: tmpRoot },
+		);
+
+		const result = await simulateToolCall(
+			handlers.tool_call!,
+			"bash",
+			{ command: "cat .env" },
+			tmpRoot,
+		);
+
+		assert.ok(result, "should return a result");
+		assert.strictEqual((result as any).block, true, "should block .env access via bash");
+	});
+
+	it("bash command with safe paths returns undefined (no block)", async () => {
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), ".env\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: tmpRoot, reason: "startup" },
+			{ cwd: tmpRoot },
+		);
+
+		const result = await simulateToolCall(
+			handlers.tool_call!,
+			"bash",
+			{ command: "ls -la" },
+			tmpRoot,
+		);
+
+		assert.strictEqual(result, undefined, "safe bash commands should NOT be blocked");
+	});
+
+	it("cwd change triggers reload: paths blocked by new cwd's .piignore, not old one", async () => {
+		const dirA = path.join(tmpRoot, "projectA");
+		const dirB = path.join(tmpRoot, "projectB");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.mkdirSync(dirB, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "only-a.txt\n");
+		// dirB has NO .piignore
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		// Load entries for dirA
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: dirA, reason: "startup" },
+			{ cwd: dirA },
+		);
+
+		// Call tool with dirA cwd — only-a.txt should be blocked
+		const resultA = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "only-a.txt" },
+			dirA,
+		);
+		assert.strictEqual((resultA as any)?.block, true, "only-a.txt blocked in dirA");
+
+		// Call tool with dirB cwd — only-a.txt should NOT be blocked (dirB has no .piignore)
+		const resultB = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "only-a.txt" },
+			dirB,
+		);
+		assert.strictEqual(resultB, undefined, "only-a.txt NOT blocked in dirB (different cwd)");
+	});
+
+	it("cwd change then back reloads fresh entries for original cwd", async () => {
+		const dirA = path.join(tmpRoot, "projectA");
+		const dirB = path.join(tmpRoot, "projectB");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.mkdirSync(dirB, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "secret.txt\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		// Load entries for dirB (no .piignore)
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: dirB, reason: "startup" },
+			{ cwd: dirB },
+		);
+
+		// Call with dirB — nothing blocked
+		const resultB = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "secret.txt" },
+			dirB,
+		);
+		assert.strictEqual(resultB, undefined, "secret.txt NOT blocked in dirB (no .piignore)");
+
+		// Call with dirA — dirA's .piignore should block secret.txt
+		const resultA = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "secret.txt" },
+			dirA,
+		);
+		assert.strictEqual((resultA as any)?.block, true, "secret.txt blocked in dirA");
+	});
+
+	it("unhandled tool (not in path/bash lists) returns undefined (no-op)", async () => {
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), "secret.txt\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: tmpRoot, reason: "startup" },
+			{ cwd: tmpRoot },
+		);
+
+		// An unknown tool should just return undefined (no action)
+		const result = await simulateToolCall(handlers.tool_call!, "unknown-tool" as any, {}, tmpRoot);
+		assert.strictEqual(result, undefined, "unhandled tool should be no-op");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2b: Try/catch safety net (fail-closed on unexpected errors)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("try/catch safety net (Phase 2b)", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "piignore-safety-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("returns safe block result when loadPiIgnore throws (unreadable .piignore)", async () => {
+		// Write a .piignore then make it unreadable
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), "secret.txt\n");
+		fs.chmodSync(path.join(tmpRoot, ".piignore"), 0o000);
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		// Trigger resources_discover to load entries
+		// This should fail but be caught by the try/catch
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: tmpRoot, reason: "startup" },
+			{ cwd: tmpRoot },
+		);
+
+		// Now call read — loadPiIgnore might throw or succeed depending on caching
+		const result = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "secret.txt" },
+			tmpRoot,
+		);
+
+		// The extension should either block the path (if .piignore loaded) or
+		// return a safe block on error (fail-closed). Either way, result exists.
+		if (result) {
+			assert.strictEqual((result as any).block, true, "should return block on error");
+		}
+	});
+
+	it("returns safe block when .piignore file has permission error during tool_call", async () => {
+		// Write .piignore then make directory unreadable so readFileSync fails
+		const subDir = path.join(tmpRoot, "sub");
+		fs.mkdirSync(subDir, { recursive: true });
+		fs.writeFileSync(path.join(subDir, ".piignore"), "secret.txt\n");
+
+		const { pi, handlers } = createMockPi();
+		piignoreFactory(pi);
+
+		// Initial load succeeds
+		await handlers.resources_discover!(
+			{ type: "resources_discover", cwd: subDir, reason: "startup" },
+			{ cwd: subDir },
+		);
+
+		// Now make the .piignore unreadable and change cwd to force a reload
+		fs.chmodSync(path.join(subDir, ".piignore"), 0o000);
+		// Also invalidate the cache by changing to a different dir and back
+
+		const otherDir = path.join(tmpRoot, "other");
+		fs.mkdirSync(otherDir, { recursive: true });
+
+		// Call tool with otherDir first (no .piignore), then back to subDir
+		await simulateToolCall(handlers.tool_call!, "read", { path: "foo.txt" }, otherDir);
+
+		// Now call with subDir — should trigger reload which hits permission error
+		const result = await simulateToolCall(
+			handlers.tool_call!,
+			"read",
+			{ path: "secret.txt" },
+			subDir,
+		);
+
+		assert.ok(result, "should return a result on error");
+		assert.strictEqual((result as any).block, true);
 	});
 });

--- a/test/piignore.test.mts
+++ b/test/piignore.test.mts
@@ -128,6 +128,31 @@ function isIgnored(targetPath: string, entries: IgnoreEntry[], cwd: string): boo
 }
 
 // ═══════════════════════════════════════════════════════════════════════
+// Fixed getEntries (cwd-aware caching — matches the fix)
+// ═══════════════════════════════════════════════════════════════════════
+
+function createGetEntries_fixed(): {
+	getEntries: (cwd: string) => IgnoreEntry[];
+	getCallCount: () => number;
+} {
+	let _cachedCwd: string | null = null;
+	let _entries: IgnoreEntry[] | null = null;
+	let _loadCount = 0;
+
+	return {
+		getEntries(cwd: string): IgnoreEntry[] {
+			if (!_entries || _cachedCwd !== cwd) {
+				_entries = loadPiIgnore(cwd);
+				_cachedCwd = cwd;
+				_loadCount++;
+			}
+			return _entries;
+		},
+		getCallCount: () => _loadCount,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════
 // Tests
 // ═══════════════════════════════════════════════════════════════════════
 
@@ -241,5 +266,161 @@ describe("piignore extension", () => {
 			const absPath = path.join(nonCwdDir, "secret.txt");
 			assert.strictEqual(isIgnored(absPath, entries, nonCwdDir), true);
 		});
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 1: getEntries caching behavior (cwd-aware cache with reload)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("getEntries caching (Phase 1)", () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "piignore-phase1-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it("first call with cwd=/a loads from /a and caches result", () => {
+		const dirA = path.join(tmpRoot, "a");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "secret.txt\n");
+
+		const { getEntries, getCallCount } = createGetEntries_fixed();
+		const entries = getEntries(dirA);
+
+		assert.strictEqual(getCallCount(), 1, "should load on first call");
+		assert.strictEqual(entries.length >= 1, true, "should find .piignore entries");
+		assert.strictEqual(isIgnored("secret.txt", entries, dirA), true);
+	});
+
+	it("second call with same cwd=/a returns cached (no re-read from disk)", () => {
+		const dirA = path.join(tmpRoot, "a");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "secret.txt\n");
+
+		const { getEntries, getCallCount } = createGetEntries_fixed();
+
+		getEntries(dirA); // first call — loads
+		assert.strictEqual(getCallCount(), 1, "should load once");
+
+		getEntries(dirA); // second call — cached
+		assert.strictEqual(getCallCount(), 1, "should NOT re-read from disk");
+	});
+
+	it("call with cwd=/b after /a detects cwd change and reloads fresh entries", () => {
+		const dirA = path.join(tmpRoot, "a");
+		const dirB = path.join(tmpRoot, "b");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.mkdirSync(dirB, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "only-a.txt\n");
+		fs.writeFileSync(path.join(dirB, ".piignore"), "only-b.txt\n");
+
+		const { getEntries, getCallCount } = createGetEntries_fixed();
+
+		getEntries(dirA); // load /a entries
+		assert.strictEqual(getCallCount(), 1, "first load");
+
+		const entriesB = getEntries(dirB); // should reload for /b
+		// With fixed version: cache detects cwd change, reloads from /b
+		// So only-b.txt IS matched (entries are from dirB)
+		assert.strictEqual(
+			isIgnored("only-b.txt", entriesB, dirB),
+			true,
+			"only-b.txt should be blocked by dirB's .piignore",
+		);
+	});
+
+	it("call with cwd=/a again after /b reloads fresh from /a (not stale cache)", () => {
+		const dirA = path.join(tmpRoot, "a");
+		const dirB = path.join(tmpRoot, "b");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.mkdirSync(dirB, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "only-a.txt\n");
+		fs.writeFileSync(path.join(dirB, ".piignore"), "only-b.txt\n");
+
+		const { getEntries } = createGetEntries_fixed();
+
+		getEntries(dirA); // load /a — caches from A
+
+		// Delete dirA/.piignore to detect stale cache
+		fs.rmSync(path.join(dirA, ".piignore"));
+
+		getEntries(dirB); // triggers reload for /b
+
+		const entriesA = getEntries(dirA);
+		// With fixed version: detects cwd change back to /a, reloads fresh
+		// So only-a.txt is NOT blocked because .piignore was deleted
+		assert.strictEqual(
+			isIgnored("only-a.txt", entriesA, dirA),
+			false,
+			"only-a.txt should NOT be blocked after .piignore deleted in dirA",
+		);
+	});
+
+	it("call with cwd=/b (no .piignore) returns empty; switch to /c (with .piignore) returns /c entries", () => {
+		const dirB = path.join(tmpRoot, "b");
+		const dirC = path.join(tmpRoot, "c");
+		fs.mkdirSync(dirB, { recursive: true });
+		fs.mkdirSync(dirC, { recursive: true });
+		// dirB has NO .piignore
+		fs.writeFileSync(path.join(dirC, ".piignore"), "secret.txt\n");
+
+		const { getEntries, getCallCount } = createGetEntries_fixed();
+
+		const entriesB = getEntries(dirB); // no .piignore in dirB → empty
+		assert.strictEqual(entriesB.length, 0, "dirB should have no entries");
+		assert.strictEqual(getCallCount(), 1, "loaded once for dirB");
+
+		const entriesC = getEntries(dirC); // should reload for dirC
+		// With fixed version: detects cwd change, reloads from dirC
+		// entriesC contains dirC's .piignore patterns
+		assert.strictEqual(
+			entriesC.length >= 1,
+			true,
+			"dirC should have .piignore entries (stale cache returns empty)",
+		);
+		assert.strictEqual(isIgnored("secret.txt", entriesC, dirC), true);
+	});
+
+	it("no .piignore tree at all returns empty array for any cwd", () => {
+		const dirEmpty = path.join(tmpRoot, "empty");
+		fs.mkdirSync(dirEmpty, { recursive: true });
+
+		const { getEntries, getCallCount } = createGetEntries_fixed();
+
+		const entries1 = getEntries(dirEmpty);
+		assert.strictEqual(entries1.length, 0, "first cwd: no .piignore");
+		assert.strictEqual(getCallCount(), 1, "loaded once");
+
+		const dirEmpty2 = path.join(tmpRoot, "empty2");
+		fs.mkdirSync(dirEmpty2, { recursive: true });
+
+		const entries2 = getEntries(dirEmpty2);
+		assert.strictEqual(entries2.length, 0, "second cwd: still no .piignore");
+	});
+
+	it("getEntries with cwd=/a returns only /a patterns when /a has its own .piignore", () => {
+		// Create parent dir with .piignore
+		fs.writeFileSync(path.join(tmpRoot, ".piignore"), "parent.txt\n");
+		const dirA = path.join(tmpRoot, "a");
+		fs.mkdirSync(dirA, { recursive: true });
+		fs.writeFileSync(path.join(dirA, ".piignore"), "child.txt\n");
+
+		const { getEntries } = createGetEntries_fixed();
+
+		const entries = getEntries(dirA);
+		// Should have both parent and child entries (walks up from cwd)
+		const roots = entries.map((e) => e.root);
+		assert.ok(roots.includes(dirA), "should include child dirA");
+		assert.ok(roots.includes(tmpRoot), "should include parent tmpRoot");
+
+		// Verify child's own patterns work
+		assert.strictEqual(isIgnored("child.txt", entries, dirA), true);
+		// Verify parent's patterns also work
+		assert.strictEqual(isIgnored("parent.txt", entries, dirA), true);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #326

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 17s | 48.1K | 26 | — |
| researcher | ✓ SUCCESS | 1m 44s | 127.2K | 16 | — |
| test-designer | ✓ SUCCESS | 28s | 21.0K | 10 | — |
| developer | ✓ SUCCESS | 3m 57s | 77.7K | 48 | — |
| auditor | ✓ SUCCESS | 1m 16s | 55.9K | 18 | — |
| developer | ✓ SUCCESS | 4m 1s | 83.2K | 77 | — |
| auditor | ✓ SUCCESS | 1m 28s | 47.7K | 20 | — |

**Total:** 7 agents · 14m 11s · 460.9K tokens · 215 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/326