### PR TITLE
feat(#311): Add LLM prompt cache stats to status bar and subagent footer

### DIFF
--- a/.pi/extensions/context-info/config.ts
+++ b/.pi/extensions/context-info/config.ts
@@ -44,6 +44,7 @@ export function loadConfig(): ContextStatusBarConfig | null {
 		thresholds: DEFAULT_THRESHOLDS,
 		showTimer: true,
 		showTps: true,
+		showCache: true,
 	};
 	const settingsPath = ".pi/settings.json";
 	if (!existsSync(settingsPath)) return defaults;
@@ -95,5 +96,11 @@ export function loadConfig(): ContextStatusBarConfig | null {
 		showTps = cfg.showTps;
 	}
 
-	return { enabled, thresholds, showTimer, showTps };
+	// Parse showCache
+	let showCache = true;
+	if ("showCache" in cfg && typeof cfg.showCache === "boolean") {
+		showCache = cfg.showCache;
+	}
+
+	return { enabled, thresholds, showTimer, showTps, showCache };
 }

--- a/.pi/extensions/context-info/footer.ts
+++ b/.pi/extensions/context-info/footer.ts
@@ -16,6 +16,7 @@ import {
 	thinkingIcon,
 	thinkingColor,
 	formatTps,
+	formatCacheStats,
 	computeTps,
 } from "./formatting.js";
 
@@ -32,6 +33,8 @@ export function installFooter(
 	lastContextWindow: { value: number | undefined },
 	lastSampledOutput: { value: number | undefined },
 	toolCallCount: { value: number },
+	cacheReadRef?: { value: number | undefined },
+	cacheWriteRef?: { value: number | undefined },
 ): void {
 	if (!config || config.enabled === false) {
 		ctx.ui.setFooter(undefined);
@@ -170,14 +173,21 @@ export function installFooter(
 
 				row1 = truncateToWidth(row1, width);
 
-				// ── Build row 2 (ext statuses left, TPS right) ──
-				if (extStr || config.showTps) {
+				// ── Build row 2 (ext statuses left, TPS + cache right) ──
+				if (extStr || config.showTps || config.showCache) {
 					const left2 = extStr || "";
-					let right2 = "";
+					const rightParts: string[] = [];
 					if (config.showTps) {
 						const tpsDisplay = formatTps(lastComputedTps.value);
-						right2 = theme.fg("dim", tpsDisplay);
+						rightParts.push(theme.fg("dim", tpsDisplay));
 					}
+					if (config.showCache) {
+						const cacheRead = cacheReadRef?.value;
+						const cacheWrite = cacheWriteRef?.value;
+						const cacheStr = formatCacheStats(cacheRead, cacheWrite);
+						rightParts.push(theme.fg("dim", cacheStr));
+					}
+					const right2 = rightParts.join(" " + sep + " ");
 					const lw = visibleWidth(left2);
 					const rw = visibleWidth(right2);
 					const gap = Math.max(0, width - lw - rw);

--- a/.pi/extensions/context-info/formatting.ts
+++ b/.pi/extensions/context-info/formatting.ts
@@ -129,3 +129,19 @@ export function formatTps(tps: number | null): string {
 	if (tps > 999.9) return `${Math.round(tps)} t/s`;
 	return `${tps.toFixed(1)} t/s`;
 }
+
+/** Format cache stats: 📦 cacheRead/cacheWrite */
+export function formatCacheStats(
+	cacheRead: number | undefined | null,
+	cacheWrite: number | undefined | null,
+): string {
+	if (
+		cacheRead === undefined ||
+		cacheRead === null ||
+		cacheWrite === undefined ||
+		cacheWrite === null
+	) {
+		return "\u{1F4E6} --/--";
+	}
+	return `\u{1F4E6} ${formatTokens(cacheRead)}/${formatTokens(cacheWrite)}`;
+}

--- a/.pi/extensions/context-info/index.ts
+++ b/.pi/extensions/context-info/index.ts
@@ -41,6 +41,10 @@ export default function contextInfo(pi: ExtensionAPI): void {
 	const lastContextWindowRef: { value: number | undefined } = { value: undefined };
 	const telemetryState: { emitted: boolean; lastContextWindow?: number } = { emitted: false };
 
+	// ── Cache stats state ─────────────────────────────────────────
+	const cacheReadRef: { value: number | undefined } = { value: undefined };
+	const cacheWriteRef: { value: number | undefined } = { value: undefined };
+
 	function syncTelemetryState() {
 		telemetryState.lastContextWindow = lastContextWindow;
 	}
@@ -76,6 +80,8 @@ export default function contextInfo(pi: ExtensionAPI): void {
 					lastContextWindowRef,
 					{ value: lastSampledOutput },
 					toolCallCount,
+					cacheReadRef,
+					cacheWriteRef,
 				);
 			}
 		}, 1000);
@@ -293,6 +299,9 @@ export default function contextInfo(pi: ExtensionAPI): void {
 		lastComputedTps.value = null;
 		lastSampledOutput = undefined;
 		toolCallCount.value = 0;
+		// Reset cache stats
+		cacheReadRef.value = undefined;
+		cacheWriteRef.value = undefined;
 
 		// Detect worktree each session — git worktree can change across sessions
 		worktreeName = getWorktreeName(ctx.cwd);
@@ -328,6 +337,8 @@ export default function contextInfo(pi: ExtensionAPI): void {
 			lastContextWindowRef,
 			{ value: lastSampledOutput },
 			toolCallCount,
+			cacheReadRef,
+			cacheWriteRef,
 		);
 
 		// Start live timer
@@ -382,6 +393,8 @@ export default function contextInfo(pi: ExtensionAPI): void {
 				lastContextWindowRef,
 				{ value: lastSampledOutput },
 				toolCallCount,
+				cacheReadRef,
+				cacheWriteRef,
 			);
 	});
 
@@ -403,6 +416,8 @@ export default function contextInfo(pi: ExtensionAPI): void {
 				lastContextWindowRef,
 				{ value: lastSampledOutput },
 				toolCallCount,
+				cacheReadRef,
+				cacheWriteRef,
 			);
 		tryEmit(ctx, telemetryState);
 	});
@@ -419,12 +434,22 @@ export default function contextInfo(pi: ExtensionAPI): void {
 				lastContextWindowRef,
 				{ value: lastSampledOutput },
 				toolCallCount,
+				cacheReadRef,
+				cacheWriteRef,
 			);
 	});
 
 	pi.on("message_end", async (event, ctx: ExtensionContext) => {
 		const msg = event.message;
 		if (!msg || msg.role !== "assistant") return;
+		// Capture cache stats from raw event usage
+		const eventUsage = msg.usage;
+		if (eventUsage && typeof eventUsage.cacheRead === "number") {
+			cacheReadRef.value = eventUsage.cacheRead;
+		}
+		if (eventUsage && typeof eventUsage.cacheWrite === "number") {
+			cacheWriteRef.value = eventUsage.cacheWrite;
+		}
 		syncTelemetryState();
 		const usage = ctx.getContextUsage();
 		if (usage && typeof usage.tokens === "number" && usage.tokens > 0) {

--- a/.pi/extensions/context-info/types.ts
+++ b/.pi/extensions/context-info/types.ts
@@ -16,4 +16,5 @@ export interface ContextStatusBarConfig {
 	thresholds: ThresholdEntry[];
 	showTimer: boolean;
 	showTps: boolean;
+	showCache: boolean;
 }

--- a/.pi/extensions/supervisor/event-handlers.test.mts
+++ b/.pi/extensions/supervisor/event-handlers.test.mts
@@ -3,6 +3,24 @@
 // Tests mirror the scenarios from agent-stream.test.mts and
 // session-events.test.mts but target the shared handlers directly.
 
+// Augment AgentRunState with cache fields for test compilation
+// These are local to this test file - the real AgentRunState will have them after implementation
+interface AgentRunStateWithCache {
+	cacheRead?: number;
+	cacheWrite?: number;
+}
+
+type FullAgentRunState = AgentRunState & AgentRunStateWithCache;
+
+function createStateWithCache(overrides?: Partial<FullAgentRunState>): FullAgentRunState {
+	return {
+		...createState(overrides),
+		cacheRead: undefined,
+		cacheWrite: undefined,
+		...(overrides as any),
+	};
+}
+
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import type { AgentRunState } from "./types";
@@ -433,5 +451,74 @@ describe("handleContextInfo", () => {
 		});
 		assert.equal(result.flush, false);
 		assert.equal(state.contextInfoReceived, false);
+	});
+});
+
+// ─── handleMessageEnd — cache stats ──────────────────────────────
+
+describe("handleMessageEnd — cache stats", () => {
+	it("extracts cacheRead and cacheWrite from message usage", () => {
+		const state = createStateWithCache() as any;
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: {
+				role: "assistant",
+				content: [],
+				usage: { cacheRead: 76288, cacheWrite: 0 },
+			},
+		});
+		assert.equal(state.cacheRead, 76288);
+		assert.equal(state.cacheWrite, 0);
+	});
+
+	it("does not set cacheRead/cacheWrite when usage is absent", () => {
+		const state = createStateWithCache() as any;
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: { role: "assistant", content: [] },
+		});
+		assert.equal(state.cacheRead, undefined);
+		assert.equal(state.cacheWrite, undefined);
+	});
+
+	it("does not set cacheRead/cacheWrite when usage has no cache fields", () => {
+		const state = createStateWithCache() as any;
+		handleMessageEnd(state, {
+			kind: "message_end",
+			message: {
+				role: "assistant",
+				content: [],
+				usage: { totalTokens: 100, input: 50, output: 50 },
+			},
+		});
+		assert.equal(state.cacheRead, undefined);
+		assert.equal(state.cacheWrite, undefined);
+	});
+});
+
+// ─── handleDone — cache stats ─────────────────────────────────────
+
+describe("handleDone — cache stats", () => {
+	it("extracts cacheRead and cacheWrite from message usage", () => {
+		const state = createStateWithCache() as any;
+		handleDone(state, {
+			kind: "done",
+			message: {
+				content: [{ type: "text", text: "final" }],
+				usage: { cacheRead: 50000, cacheWrite: 1000 },
+			},
+		});
+		assert.equal(state.cacheRead, 50000);
+		assert.equal(state.cacheWrite, 1000);
+	});
+
+	it("does not set cacheRead/cacheWrite when usage is absent", () => {
+		const state = createStateWithCache() as any;
+		handleDone(state, {
+			kind: "done",
+			message: { content: [{ type: "text", text: "final" }] },
+		});
+		assert.equal(state.cacheRead, undefined);
+		assert.equal(state.cacheWrite, undefined);
 	});
 });

--- a/.pi/extensions/supervisor/event-handlers.ts
+++ b/.pi/extensions/supervisor/event-handlers.ts
@@ -199,6 +199,9 @@ export function handleMessageEnd(
 		}
 		if (msg.usage) {
 			state.tokenCount = msg.usage.totalTokens || msg.usage.input! + msg.usage.output!;
+			// Capture cache stats
+			if (typeof msg.usage.cacheRead === "number") state.cacheRead = msg.usage.cacheRead;
+			if (typeof msg.usage.cacheWrite === "number") state.cacheWrite = msg.usage.cacheWrite;
 		}
 	} else if (msg.role === "toolResult") {
 		const resultText = extractTextFromContent(msg.content);
@@ -243,6 +246,9 @@ export function handleDone(
 	if (msg?.usage) {
 		state.tokenCount =
 			msg.usage.totalTokens || (msg.usage.input ?? 0) + (msg.usage.output ?? 0) || state.tokenCount;
+		// Capture cache stats
+		if (typeof msg.usage.cacheRead === "number") state.cacheRead = msg.usage.cacheRead;
+		if (typeof msg.usage.cacheWrite === "number") state.cacheWrite = msg.usage.cacheWrite;
 	}
 
 	if (msg?.content && Array.isArray(msg.content)) {

--- a/.pi/extensions/supervisor/event-types.ts
+++ b/.pi/extensions/supervisor/event-types.ts
@@ -14,7 +14,16 @@ export type NormalizedEvent =
 	| { kind: "thinking_end" }
 	| { kind: "thinking_delta"; delta: string }
 	| { kind: "text_start" }
-	| { kind: "text_end"; usage?: { totalTokens?: number; input?: number; output?: number } }
+	| {
+			kind: "text_end";
+			usage?: {
+				totalTokens?: number;
+				input?: number;
+				output?: number;
+				cacheRead?: number;
+				cacheWrite?: number;
+			};
+	  }
 	| { kind: "text_delta"; delta: string }
 	| {
 			kind: "message_end";
@@ -24,7 +33,13 @@ export type NormalizedEvent =
 					Record<string, unknown> & { type: string; text?: string; thinking?: string }
 				>;
 				toolName?: string;
-				usage?: { totalTokens?: number; input?: number; output?: number };
+				usage?: {
+					totalTokens?: number;
+					input?: number;
+					output?: number;
+					cacheRead?: number;
+					cacheWrite?: number;
+				};
 			};
 	  }
 	| {
@@ -33,7 +48,13 @@ export type NormalizedEvent =
 				content?: Array<
 					Record<string, unknown> & { type: string; text?: string; thinking?: string }
 				>;
-				usage?: { totalTokens?: number; input?: number; output?: number };
+				usage?: {
+					totalTokens?: number;
+					input?: number;
+					output?: number;
+					cacheRead?: number;
+					cacheWrite?: number;
+				};
 			};
 	  }
 	| { kind: "context_info"; contextTokens: number; contextWindow: number }

--- a/.pi/extensions/supervisor/session-widget.ts
+++ b/.pi/extensions/supervisor/session-widget.ts
@@ -60,11 +60,22 @@ export function buildWidgetLines(
 	// ── Idle warning (optional, shown when no events for >15s) ──
 	const idleLine = idleWarning ? `  ${idleWarning}` : undefined;
 
+	// ── Cache stats helper ──
+	function fmtCacheVal(n: number | undefined | null): string {
+		if (n === undefined || n === null) return "--";
+		return formatTokens(n);
+	}
+
 	// ── Stats footer (always included) ──
 	const shortModel = model ? model.split("/").pop() || model : undefined;
 	const statsParts: string[] = [`subagent:${agentName}`];
 	if (shortModel) statsParts.push(`🧠 ${shortModel}`);
 	if (state.tokenCount > 0) statsParts.push(`📊 ${formatTokens(state.tokenCount)} tokens`);
+	const cacheRead = state.cacheRead;
+	const cacheWrite = state.cacheWrite;
+	if (cacheRead !== undefined || cacheWrite !== undefined) {
+		statsParts.push(`📦 ${fmtCacheVal(cacheRead)}/${fmtCacheVal(cacheWrite)}`);
+	}
 	if (state.toolCount > 0) statsParts.push(`🔧 ${state.toolCount} tools`);
 	statsParts.push(`⏱ ${formatDuration(now - state.startedAt)}`);
 	const footer = `  ${statsParts.join(" · ")}`;
@@ -189,12 +200,23 @@ export function buildWidgetComponent(
 		c.addChild(new Text(fit(theme.fg("warning", `  ${idleWarning}`)), 1, 0));
 	}
 
+	// ── Cache stats helper ──
+	function fmtCacheVal(n: number | undefined | null): string {
+		if (n === undefined || n === null) return "--";
+		return formatTokens(n);
+	}
+
 	// ── Stats footer ──
 	const statsParts: string[] = [];
 	const shortModel = model ? model.split("/").pop() || model : undefined;
 	statsParts.push(`subagent:${agentName}`);
 	if (shortModel) statsParts.push(`🧠 ${shortModel}`);
 	if (state.tokenCount > 0) statsParts.push(`📊 ${formatTokens(state.tokenCount)} tokens`);
+	const cacheRead = state.cacheRead;
+	const cacheWrite = state.cacheWrite;
+	if (cacheRead !== undefined || cacheWrite !== undefined) {
+		statsParts.push(`📦 ${fmtCacheVal(cacheRead)}/${fmtCacheVal(cacheWrite)}`);
+	}
 	if (state.toolCount > 0) statsParts.push(`🔧 ${state.toolCount} tools`);
 	const elapsed = formatDuration(now - state.startedAt);
 	statsParts.push(`⏱ ${elapsed}`);

--- a/.pi/extensions/supervisor/types.ts
+++ b/.pi/extensions/supervisor/types.ts
@@ -117,6 +117,10 @@ export interface AgentRunState {
 	maxToolCalls: number;
 	/** Max tokens allowed (0 = unlimited, populated from config) */
 	agentTokenBudget: number;
+	/** LLM prompt cache read tokens (from message usage) */
+	cacheRead?: number;
+	/** LLM prompt cache write tokens (from message usage) */
+	cacheWrite?: number;
 }
 
 // ─── Message renderer details type ───────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ AgentCastle is a **Kanban-centred AI agent** built on the [Pi coding agent](http
 - **Structural search** — `structural_search` via ast-grep: AST-aware pattern matching
 - **Text search** — `ripgrep_search` via ripgrep: fast literal/regex code search
 - **Web crawling** — `web_crawl`: local crawl4ai → Apify cloud → HTTP fallback
-- **Rich TUI** — Custom status bar (branch, model, token usage, TPS), welcome banner
+- **Rich TUI** — Custom status bar (branch, model, token usage, TPS, cache stats), welcome banner
 - **Session logging** — Every conversation saved as JSONL, queryable with jq
 - **Multi-agent pipeline** — Autonomous Kanban: Researcher → Architect → TestDesigner → Developer → Auditor
 - **LSP pre-audit** — Real LSP diagnostics before merge, auto-retry on errors
@@ -190,7 +190,7 @@ This project deliberately avoids the [Model Context Protocol (MCP)](https://mode
 | `.pi/extensions/ripgrep-search/` | `ripgrep_search` tool via ripgrep (modular: args, config, parse, temp, validate) |
 | `.pi/extensions/crawl4ai/` | `web_crawl` tool: local crawl4ai → Apify → HTTP fallback |
 | `.pi/extensions/supervisor/` | Kanban-driven multi-agent orchestration |
-| `.pi/extensions/context-info/` | Rich TUI status bar, welcome banner, TPS |
+| `.pi/extensions/context-info/` | Rich TUI status bar (branch, model, tokens, TPS, cache), welcome banner |
 | `.pi/extensions/session-logger/` | Session logging to JSONL |
 | `.pi/extensions/agent-harness/` | Runtime tool call validation — blocks `bash | grep`, `cat` file reads, redundant reads, error retry loops, same-tool cascades |
 | `.pi/extensions/ask-user/` | Interactive MC questions + CSV logger |
@@ -242,7 +242,7 @@ Pi auto-discovers extensions from `.pi/extensions/` in the **project root**. No 
 | **Ripgrep Search** | `ripgrep_search` via ripgrep. Fast literal/regex code search, respects `.gitignore`. |
 | **Supervisor** | Kanban-driven multi-agent pipeline. Reads issue from GitHub project, dispatches agents in loop. Registers `/supervisor <issue-number>` command. |
 | **Web Crawler** | `web_crawl`: local crawl4ai → Apify cloud → HTTP fallback. Auto-installs venv + Chromium deps. |
-| **Context Info** | Rich TUI status bar (branch, model, tokens, TPS), welcome banner, animated working indicator. |
+| **Context Info** | Rich TUI status bar (branch, model, tokens, TPS, cache), welcome banner, animated working indicator. |
 | **Session Logger** | Logs sessions to `.pi/sessions/<id>.jsonl`. Generates `.md` reports with sub-agent output from supervisor pipeline. Toggle with `/session-logger`. Query with `scripts/session-query.sh`. |
 | **Session Advice** | Analyzes each session after shutdown for inefficient patterns. Generates `.advice.md` with fix recommendations. Post-hoc batch analysis via `scripts/session-advice.ts`. Report with `/session-advice report`. |
 | **Agent Harness** | Runtime tool call validation via `agent-harness` extension. Blocks `bash` with `grep`/`rg` (redirects to `ripgrep_search`), `bash` with `cat`/`head`/`tail` (redirects to `read`). Caches reads to prevent redundant file reads. Tracks errors per tool to block retry loops (2+ errors). Tracks consecutive same-tool calls to break cascades (8+) with sub-command-aware detection (`git status` vs `git diff` tracked separately). Cascade resets per conversation turn — each LLM response cycle starts fresh. Bash cascade suggestion is context-aware: commands already using `&&` get "Reduce per-turn call count", non-`&&` commands get "Combine bash calls with &&". Complements Session Advice (post-hoc) with runtime prevention. |
@@ -342,7 +342,7 @@ Empirical token consumption comparing tool configurations on a real audit task (
 
 Config 4 uses **27% fewer total tokens** and runs **33% faster** than mapper-only (config 2). The ripgrep fix resolved the earlier issue where ripgrep made token consumption worse.
 
-The agent footer also shows a **TPS (tokens-per-second)** gauge during streaming, computed from a rolling 30s window, plus worktree name in brackets next to the branch when inside a git worktree.
+The agent footer also shows a **TPS (tokens-per-second)** gauge during streaming, computed from a rolling 30s window, plus **LLM prompt cache** stats (`📦 cacheRead/cacheWrite`) on Row 2 — toggle with `contextStatusBar.showCache` in `.pi/settings.json` (default `true`). The supervisor subagent footer shows cache stats next to the token count. Shows `📦 --/--` before the first assistant response.
 
 > Run with `scripts/benchmark-tools.sh` (2 runs per config). Results saved to `scripts/benchmark-results/`.
 
@@ -460,6 +460,7 @@ Switch the project to **Board** layout in the browser and change **Group by** to
 | Quiz PR reviewer | `/quiz-master` |
 | View session logs | `ls .pi/sessions/` |
 | Reload config | `/reload` (after editing .piignore, settings.json, etc.) |
+| Toggle cache stats | `"contextStatusBar": { "showCache": false }` in `.pi/settings.json` |
 
 #### 7.3 Session Logger Details
 

--- a/test/context-info.test.mts
+++ b/test/context-info.test.mts
@@ -24,12 +24,20 @@ interface MockPi {
 	on: (event: string, handler: (...args: any[]) => void) => void;
 }
 
-function createContextInfoExtension(): { pi: MockPi; logCalls: string[]; mockCtx: MockCtx } {
+function createContextInfoExtension(): {
+	pi: MockPi;
+	logCalls: string[];
+	mockCtx: MockCtx;
+	getCacheRead: () => number | undefined;
+	getCacheWrite: () => number | undefined;
+} {
 	const logCalls: string[] = [];
 	const handlers = new Map<string, (...args: any[]) => void>();
 	const mockCtx: MockCtx = {
 		getContextUsage: () => undefined,
 	};
+	let _cacheRead: number | undefined;
+	let _cacheWrite: number | undefined;
 
 	const mockPi: MockPi = {
 		on(event, handler) {
@@ -60,6 +68,8 @@ function createContextInfoExtension(): { pi: MockPi; logCalls: string[]; mockCtx
 		contextWindow = undefined;
 		contextTokens = undefined;
 		emitted = false;
+		_cacheRead = undefined;
+		_cacheWrite = undefined;
 	});
 
 	handlers.set("model_select", (event: any) => {
@@ -71,12 +81,19 @@ function createContextInfoExtension(): { pi: MockPi; logCalls: string[]; mockCtx
 	});
 
 	// Match production: use ctx.getContextUsage() instead of event.message.usage
+	// Also capture cacheRead/cacheWrite from event.message.usage
 	handlers.set("message_end", (event: any) => {
 		const msg = event.message;
 		if (!msg || msg.role !== "assistant") return;
-		const usage = mockCtx.getContextUsage();
-		if (usage && typeof usage.tokens === "number" && usage.tokens > 0) {
-			contextTokens = usage.tokens;
+		// Capture cache stats from raw event usage
+		const usage = msg.usage;
+		if (usage) {
+			if (typeof usage.cacheRead === "number") _cacheRead = usage.cacheRead;
+			if (typeof usage.cacheWrite === "number") _cacheWrite = usage.cacheWrite;
+		}
+		const ctxUsage = mockCtx.getContextUsage();
+		if (ctxUsage && typeof ctxUsage.tokens === "number" && ctxUsage.tokens > 0) {
+			contextTokens = ctxUsage.tokens;
 			tryEmit();
 		}
 	});
@@ -90,12 +107,16 @@ function createContextInfoExtension(): { pi: MockPi; logCalls: string[]; mockCtx
 		pi: mockPi,
 		logCalls,
 		mockCtx,
+		getCacheRead: () => _cacheRead,
+		getCacheWrite: () => _cacheWrite,
 		_handlers: handlers,
 		_invoke: invoke,
 	} as unknown as {
 		pi: MockPi;
 		logCalls: string[];
 		mockCtx: MockCtx;
+		getCacheRead: () => number | undefined;
+		getCacheWrite: () => number | undefined;
 		_invoke: (e: string, ...a: any[]) => void;
 	};
 }
@@ -106,6 +127,14 @@ function setCtxUsage(ctx: TestCtx, tokens: number) {
 	ctx.mockCtx.getContextUsage = () => ({ tokens, contextWindow: 256000 });
 }
 
+function getCacheRead(ctx: TestCtx): number | undefined {
+	return ctx.getCacheRead();
+}
+
+function getCacheWrite(ctx: TestCtx): number | undefined {
+	return ctx.getCacheWrite();
+}
+
 function invoke(ctx: TestCtx, event: string, ...args: any[]) {
 	(ctx as any)._invoke(event, ...args);
 }
@@ -113,6 +142,29 @@ function invoke(ctx: TestCtx, event: string, ...args: any[]) {
 // ---------------------------------------------------------------------------
 // Duplicated helpers from .pi/extensions/context-info.ts (session timer)
 // ---------------------------------------------------------------------------
+
+/** Format token count: 1200 → "1.2K", 1200000 → "1.2M" */
+function formatTokens(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}
+
+/** Format cache stats: 📦 cacheRead/cacheWrite */
+function formatCacheStats(
+	cacheRead: number | undefined | null,
+	cacheWrite: number | undefined | null,
+): string {
+	if (
+		cacheRead === undefined ||
+		cacheRead === null ||
+		cacheWrite === undefined ||
+		cacheWrite === null
+	) {
+		return "\u{1F4E6} --/--";
+	}
+	return `\u{1F4E6} ${formatTokens(cacheRead)}/${formatTokens(cacheWrite)}`;
+}
 
 /** Format elapsed ms → "⏱ Xh Ym Zs" */
 function formatSessionTimer(ms: number): string {
@@ -387,5 +439,117 @@ describe("context-info extension — error resilience", () => {
 			message: { role: "assistant" },
 		});
 		assert.strictEqual(ctx.logCalls.length, 0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Cache stats capture tests
+// ---------------------------------------------------------------------------
+
+describe("context-info extension — cache stats capture", () => {
+	let ctx: TestCtx;
+
+	beforeEach(() => {
+		ctx = createContextInfoExtension();
+	});
+
+	it("message_end with usage.cacheRead=76288 cacheWrite=0 → captures values", () => {
+		invoke(ctx, "session_start", {});
+		invoke(ctx, "model_select", { model: { contextWindow: 256000 } });
+		invoke(ctx, "message_end", {
+			message: {
+				role: "assistant",
+				usage: { cacheRead: 76288, cacheWrite: 0 },
+			},
+		});
+		assert.strictEqual(getCacheRead(ctx), 76288);
+		assert.strictEqual(getCacheWrite(ctx), 0);
+	});
+
+	it("message_end without usage → cacheRead/cacheWrite remain undefined", () => {
+		invoke(ctx, "session_start", {});
+		invoke(ctx, "model_select", { model: { contextWindow: 256000 } });
+		invoke(ctx, "message_end", {
+			message: { role: "assistant", content: [] },
+		});
+		assert.strictEqual(getCacheRead(ctx), undefined);
+		assert.strictEqual(getCacheWrite(ctx), undefined);
+	});
+
+	it("message_end with usage but missing cacheRead → cacheRead stays undefined", () => {
+		invoke(ctx, "session_start", {});
+		invoke(ctx, "model_select", { model: { contextWindow: 256000 } });
+		invoke(ctx, "message_end", {
+			message: {
+				role: "assistant",
+				usage: { totalTokens: 100, input: 50, output: 50 },
+			},
+		});
+		assert.strictEqual(getCacheRead(ctx), undefined);
+		assert.strictEqual(getCacheWrite(ctx), undefined);
+	});
+
+	it("session_start resets cache stats", () => {
+		invoke(ctx, "session_start", {});
+		invoke(ctx, "model_select", { model: { contextWindow: 256000 } });
+		invoke(ctx, "message_end", {
+			message: {
+				role: "assistant",
+				usage: { cacheRead: 100, cacheWrite: 50 },
+			},
+		});
+		assert.strictEqual(getCacheRead(ctx), 100);
+
+		// New session resets
+		invoke(ctx, "session_start", {});
+		assert.strictEqual(getCacheRead(ctx), undefined);
+		assert.strictEqual(getCacheWrite(ctx), undefined);
+	});
+
+	it("message_end role is not assistant → does not capture cache stats", () => {
+		invoke(ctx, "session_start", {});
+		invoke(ctx, "model_select", { model: { contextWindow: 256000 } });
+		invoke(ctx, "message_end", {
+			message: {
+				role: "user",
+				usage: { cacheRead: 100, cacheWrite: 50 },
+			},
+		});
+		assert.strictEqual(getCacheRead(ctx), undefined);
+		assert.strictEqual(getCacheWrite(ctx), undefined);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatCacheStats tests
+// ---------------------------------------------------------------------------
+
+describe("formatCacheStats", () => {
+	it("formatCacheStats(76288, 0) → 📦 76.3K/0", () => {
+		assert.strictEqual(formatCacheStats(76288, 0), "\u{1F4E6} 76.3K/0");
+	});
+
+	it("formatCacheStats(1200000, 500) → 📦 1.2M/500", () => {
+		assert.strictEqual(formatCacheStats(1200000, 500), "\u{1F4E6} 1.2M/500");
+	});
+
+	it("formatCacheStats(0, 0) → 📦 0/0", () => {
+		assert.strictEqual(formatCacheStats(0, 0), "\u{1F4E6} 0/0");
+	});
+
+	it("formatCacheStats(undefined, undefined) → 📦 --/--", () => {
+		assert.strictEqual(formatCacheStats(undefined, undefined), "\u{1F4E6} --/--");
+	});
+
+	it("formatCacheStats(null, undefined) → 📦 --/--", () => {
+		assert.strictEqual(formatCacheStats(null, undefined), "\u{1F4E6} --/--");
+	});
+
+	it("formatCacheStats(0, undefined) → 📦 --/--", () => {
+		assert.strictEqual(formatCacheStats(0, undefined), "\u{1F4E6} --/--");
+	});
+
+	it("formatCacheStats(undefined, 0) → 📦 --/--", () => {
+		assert.strictEqual(formatCacheStats(undefined, 0), "\u{1F4E6} --/--");
 	});
 });

--- a/test/context-status-bar.test.mts
+++ b/test/context-status-bar.test.mts
@@ -112,6 +112,7 @@ interface ContextStatusBarConfig {
 	thresholds: ThresholdEntry[];
 	showTimer: boolean;
 	showTps: boolean;
+	showCache: boolean;
 }
 
 /** Compute tokens per second from rolling buffer (30s window) */
@@ -226,7 +227,17 @@ function loadConfig(rawSettings: Record<string, unknown> | null): {
 		}
 	}
 
-	return { config: { enabled, thresholds, showTimer, showTps }, warnings };
+	// Parse showCache
+	let showCache = true;
+	if ("showCache" in cfg) {
+		if (typeof cfg.showCache === "boolean") {
+			showCache = cfg.showCache;
+		} else {
+			warnings.push("contextStatusBar.showCache must be boolean; using true");
+		}
+	}
+
+	return { config: { enabled, thresholds, showTimer, showTps, showCache }, warnings };
 }
 
 // ---------------------------------------------------------------------------
@@ -695,5 +706,130 @@ describe("formatTps", () => {
 
 	it("1234.5 → 1235 t/s (rounded integer)", () => {
 		assert.strictEqual(formatTps(1234.5), "1235 t/s");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// formatCacheStats tests
+// ---------------------------------------------------------------------------
+
+function formatCacheStats(
+	cacheRead: number | undefined | null,
+	cacheWrite: number | undefined | null,
+): string {
+	if (
+		cacheRead === undefined ||
+		cacheRead === null ||
+		cacheWrite === undefined ||
+		cacheWrite === null
+	) {
+		return "\u{1F4E6} --/--";
+	}
+	return `\u{1F4E6} ${_fmtTokens(cacheRead)}/${_fmtTokens(cacheWrite)}`;
+}
+
+function _fmtTokens(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+	return String(n);
+}
+
+describe("formatCacheStats", () => {
+	it("formatCacheStats(76288, 0) → 📦 76.3K/0 using formatTokens for each value", () => {
+		assert.strictEqual(formatCacheStats(76288, 0), "\u{1F4E6} 76.3K/0");
+	});
+
+	it("formatCacheStats(1200000, 500) → 📦 1.2M/500 (mixed suffix and plain)", () => {
+		assert.strictEqual(formatCacheStats(1200000, 500), "\u{1F4E6} 1.2M/500");
+	});
+
+	it("formatCacheStats(0, 0) → 📦 0/0 (valid data, not placeholder)", () => {
+		assert.strictEqual(formatCacheStats(0, 0), "\u{1F4E6} 0/0");
+	});
+
+	it("formatCacheStats(undefined, undefined) → 📦 --/-- (no data yet)", () => {
+		assert.strictEqual(formatCacheStats(undefined, undefined), "\u{1F4E6} --/--");
+	});
+
+	it("formatCacheStats(null, undefined) → 📦 --/-- (null treated as unavailable)", () => {
+		assert.strictEqual(formatCacheStats(null, undefined), "\u{1F4E6} --/--");
+	});
+
+	it("formatCacheStats(0, undefined) → 📦 --/-- (partial data treated as unavailable)", () => {
+		assert.strictEqual(formatCacheStats(0, undefined), "\u{1F4E6} --/--");
+	});
+
+	it("formatCacheStats(undefined, 0) → 📦 --/-- (partial data treated as unavailable)", () => {
+		assert.strictEqual(formatCacheStats(undefined, 0), "\u{1F4E6} --/--");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// showCache config tests
+// ---------------------------------------------------------------------------
+
+describe("loadConfig — showCache", () => {
+	it("showCache defaults to true when key absent", () => {
+		const result = loadConfig({
+			contextStatusBar: {
+				enabled: true,
+				thresholds: [{ maxTokens: null, color: "red" }],
+			},
+		});
+		assert.ok(result.config);
+		assert.strictEqual(result.config!.showCache, true);
+	});
+
+	it("showCache: true → showCache true", () => {
+		const result = loadConfig({
+			contextStatusBar: {
+				enabled: true,
+				showCache: true,
+				thresholds: [{ maxTokens: null, color: "red" }],
+			},
+		});
+		assert.ok(result.config);
+		assert.strictEqual(result.config!.showCache, true);
+	});
+
+	it("showCache: false → showCache false", () => {
+		const result = loadConfig({
+			contextStatusBar: {
+				enabled: true,
+				showCache: false,
+				thresholds: [{ maxTokens: null, color: "red" }],
+			},
+		});
+		assert.ok(result.config);
+		assert.strictEqual(result.config!.showCache, false);
+	});
+
+	it("showCache: invalid (non-boolean) → emits warning, defaults to true", () => {
+		const result = loadConfig({
+			contextStatusBar: {
+				enabled: true,
+				showCache: "yes",
+				thresholds: [{ maxTokens: null, color: "red" }],
+			},
+		});
+		assert.ok(result.config);
+		assert.strictEqual(result.config!.showCache, true);
+		assert.ok(result.warnings.some((w) => w.includes("showCache")));
+	});
+
+	it("showCache false with showTimer false and showTps false → all three false", () => {
+		const result = loadConfig({
+			contextStatusBar: {
+				enabled: true,
+				showTimer: false,
+				showTps: false,
+				showCache: false,
+				thresholds: [{ maxTokens: null, color: "red" }],
+			},
+		});
+		assert.ok(result.config);
+		assert.strictEqual(result.config!.showTimer, false);
+		assert.strictEqual(result.config!.showTps, false);
+		assert.strictEqual(result.config!.showCache, false);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #311

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 32s | 71.0K | 44 | — |
| researcher | ✓ SUCCESS | 1m 21s | 40.9K | 8 | — |
| test-designer | ✓ SUCCESS | 1m 34s | 70.3K | 54 | — |
| developer | ✓ SUCCESS | 6m 42s | 136.2K | 105 | — |
| auditor | ✓ SUCCESS | 2m 2s | 77.1K | 32 | — |

**Total:** 5 agents · 13m 10s · 395.5K tokens · 243 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/311