### PR TITLE
feat(#401): Empty footer rows when supervisor/caveman clear status with empty string

### DIFF
--- a/.pi/extensions/caveman/index.ts
+++ b/.pi/extensions/caveman/index.ts
@@ -20,7 +20,7 @@ export default function caveman(pi: ExtensionAPI): void {
 		const showStatus = configStore.getConfig().showStatus;
 
 		if (level === "off" || !showStatus) {
-			ctx.ui.setStatus("caveman", "");
+			ctx.ui.setStatus("caveman", undefined);
 			return;
 		}
 

--- a/.pi/extensions/caveman/test/status-clear.test.ts
+++ b/.pi/extensions/caveman/test/status-clear.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests: caveman status clearing should use undefined, not empty string
+ *
+ * The syncStatus function previously called ctx.ui.setStatus("caveman", "")
+ * when level is "off" or showStatus is false.
+ * This keeps an entry in the extension statuses map with "" as value,
+ * causing the footer to render extra empty rows.
+ *
+ * Fix: change "" → undefined so the entry is properly deleted from the map.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/caveman/test/status-clear.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Helper: read caveman source to verify no empty-string status clears
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cavemanSourcePath = join(__dirname, "..", "index.ts");
+
+function readCavemanSource(): string {
+	return readFileSync(cavemanSourcePath, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("caveman status clearing", () => {
+	it("source does NOT contain setStatus('caveman', '') — uses undefined instead", () => {
+		const source = readCavemanSource();
+		const lines = source.split("\n");
+
+		const problematicLines: Array<{ line: number; text: string }> = [];
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i]!;
+			if (
+				line.includes('setStatus("caveman"') &&
+				line.includes('""') &&
+				!line.includes("undefined")
+			) {
+				problematicLines.push({ line: i + 1, text: line.trim() });
+			}
+		}
+
+		assert.equal(
+			problematicLines.length,
+			0,
+			`Found ${problematicLines.length} problematic line(s) with setStatus("caveman", ""):\n` +
+				problematicLines.map((l) => `  Line ${l.line}: ${l.text}`).join("\n") +
+				"\nChange to setStatus('caveman', undefined) instead.",
+		);
+	});
+
+	it("no empty-string status calls in source", () => {
+		// Verify the fix is applied — all status clears use undefined
+		const source = readCavemanSource();
+
+		// Count all occurrences of setStatus("caveman", "") — should be 0
+		const matches = source.match(/setStatus\("caveman",\s*""\)/g);
+		assert.equal(
+			matches,
+			null,
+			`Found ${matches?.length || 0} occurrence(s) of setStatus("caveman", "") in index.ts.\n` +
+				"All status clears should use undefined instead of empty string.",
+		);
+	});
+});

--- a/.pi/extensions/supervisor/agent-runner.ts
+++ b/.pi/extensions/supervisor/agent-runner.ts
@@ -318,7 +318,7 @@ export async function runAgentSubprocess(
 
 			ctx.ui.setWidget(widgetId, undefined);
 			ctx.ui.setWorkingMessage(undefined);
-			ctx.ui.setStatus("supervisor", "");
+			ctx.ui.setStatus("supervisor", undefined);
 
 			resolve({
 				output: rawOutput,
@@ -355,7 +355,7 @@ export async function runAgentSubprocess(
 			clearInterval(heartbeatTimer);
 			ctx.ui.setWidget(widgetId, undefined);
 			ctx.ui.setWorkingMessage(undefined);
-			ctx.ui.setStatus("supervisor", "");
+			ctx.ui.setStatus("supervisor", undefined);
 			resolve({
 				output: `Failed to start pi: ${err.message}`,
 				success: false,

--- a/.pi/extensions/supervisor/agent-session-runner.ts
+++ b/.pi/extensions/supervisor/agent-session-runner.ts
@@ -317,7 +317,7 @@ export async function runAgentInProcess(
 				watchdogHandle?.stop();
 				ctx.ui.setWidget(widgetId, undefined);
 				ctx.ui.setWorkingMessage(undefined);
-				ctx.ui.setStatus("supervisor", "");
+				ctx.ui.setStatus("supervisor", undefined);
 
 				const messages = session?.state?.messages || [];
 				return buildAgentRunResult(state, agentName, false, durationMs, messages);
@@ -419,7 +419,7 @@ export async function runAgentInProcess(
 
 		ctx.ui.setWidget(widgetId, undefined);
 		ctx.ui.setWorkingMessage(undefined);
-		ctx.ui.setStatus("supervisor", "");
+		ctx.ui.setStatus("supervisor", undefined);
 
 		const durationMs = Date.now() - startedAt;
 		const messages = session?.state?.messages || [];
@@ -439,7 +439,7 @@ export async function runAgentInProcess(
 
 		ctx.ui.setWidget(widgetId, undefined);
 		ctx.ui.setWorkingMessage(undefined);
-		ctx.ui.setStatus("supervisor", "");
+		ctx.ui.setStatus("supervisor", undefined);
 
 		const durationMs = Date.now() - startedAt;
 		const errorMsg = err instanceof Error ? err.message : String(err);

--- a/.pi/extensions/supervisor/pipeline/handler.ts
+++ b/.pi/extensions/supervisor/pipeline/handler.ts
@@ -106,7 +106,7 @@ export async function handleSupervisorCommand(
 		const loopItem = findIssueItem(items, issueNum);
 		if (!loopItem) {
 			ctx.ui.notify(`Issue #${issueNum} not on project board #${config.projectNumber}.`, "error");
-			ctx.ui.setStatus("supervisor", "");
+			ctx.ui.setStatus("supervisor", undefined);
 			return;
 		}
 
@@ -420,7 +420,7 @@ export async function handleSupervisorCommand(
 				stopReason,
 			);
 		} else {
-			ctx.ui.setStatus("supervisor", "");
+			ctx.ui.setStatus("supervisor", undefined);
 		}
 	} catch (err: unknown) {
 		// Also cleanup on error

--- a/.pi/extensions/supervisor/pipeline/notifications.ts
+++ b/.pi/extensions/supervisor/pipeline/notifications.ts
@@ -152,6 +152,6 @@ export function sendPipelineError(
 			process.stdout.write("\x07");
 		}
 	} else {
-		ctx.ui.setStatus("supervisor", "");
+		ctx.ui.setStatus("supervisor", undefined);
 	}
 }

--- a/.pi/extensions/supervisor/status-clear.test.mts
+++ b/.pi/extensions/supervisor/status-clear.test.mts
@@ -1,0 +1,82 @@
+/**
+ * Tests: supervisor status clearing should use undefined, not empty string
+ *
+ * Multiple supervisor files previously called ctx.ui.setStatus("supervisor", "")
+ * when cleaning up after agent runs. This keeps entries in the extension statuses
+ * map with "" as value, causing the footer to render extra empty rows.
+ *
+ * Fix: change "" → undefined so the entry is properly deleted from the map.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/supervisor/status-clear.test.mts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Helper: scan source files for problematic empty-string status clears
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const FILES_TO_CHECK = [
+	"agent-session-runner.ts",
+	"agent-runner.ts",
+	"pipeline/handler.ts",
+	"pipeline/notifications.ts",
+];
+
+interface ProblematicLine {
+	file: string;
+	line: number;
+	text: string;
+}
+
+function checkFile(filePath: string): ProblematicLine[] {
+	const source = readFileSync(filePath, "utf-8");
+	const lines = source.split("\n");
+	const problems: ProblematicLine[] = [];
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i]!;
+		if (
+			line.includes('setStatus("supervisor"') &&
+			line.includes('""') &&
+			!line.includes("undefined")
+		) {
+			problems.push({
+				file: filePath,
+				line: i + 1,
+				text: line.trim(),
+			});
+		}
+	}
+
+	return problems;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+for (const file of FILES_TO_CHECK) {
+	const filePath = join(__dirname, file);
+
+	describe(`supervisor status clearing — ${file}`, () => {
+		it("does NOT contain setStatus('supervisor', '') — uses undefined instead", () => {
+			const problems = checkFile(filePath);
+
+			assert.equal(
+				problems.length,
+				0,
+				`Found ${problems.length} problematic line(s) in ${file}:\n` +
+					problems.map((p) => `  Line ${p.line}: ${p.text}`).join("\n") +
+					"\nChange to setStatus('supervisor', undefined) instead.",
+			);
+		});
+	});
+}


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #401

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 1s | 38.9K | 29 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 1m 30s | 240.8K | 8 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 38s | 55.4K | 48 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 45s | 91.4K | 63 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 32s | 31.4K | 31 | deepseek-v4-flash |

**Total:** 5 agents · 9m 26s · 457.9K tokens · 179 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/401