### PR TITLE
feat(#402): Bug: supervisor - done event type unreachable in both event adapters (JSON lines + SDK sessions)

### DIFF
--- a/.pi/extensions/supervisor/event-adapter.test.mts
+++ b/.pi/extensions/supervisor/event-adapter.test.mts
@@ -192,6 +192,61 @@ describe("jsonLineToNormalizedEvent", () => {
 		);
 	});
 
+	it("converts done at top level", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "done",
+				message: {
+					content: [{ type: "text", text: "final answer" }],
+					usage: { input: 10, output: 5 },
+				},
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.[0]?.type, "text");
+			assert.equal(result!.message.content?.[0]?.text, "final answer");
+			assert.equal(result!.message.usage?.input, 10);
+			assert.equal(result!.message.usage?.output, 5);
+		}
+	});
+
+	it("converts done at top level without usage", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "done",
+				message: {
+					content: [{ type: "text", text: "done" }],
+				},
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.[0]?.text, "done");
+		}
+	});
+
+	it("converts done at top level with thinking and text content", () => {
+		const result = jsonLineToNormalizedEvent(
+			JSON.stringify({
+				type: "done",
+				message: {
+					content: [
+						{ type: "thinking", thinking: "deep thought" },
+						{ type: "text", text: "result" },
+					],
+				},
+			}),
+		);
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.length, 2);
+		}
+	});
+
 	it("returns null for unknown event types", () => {
 		const result = jsonLineToNormalizedEvent(JSON.stringify({ type: "unknown_xyz" }));
 		assert.equal(result, null);
@@ -309,6 +364,53 @@ describe("sessionEventToNormalizedEvent", () => {
 		assert.equal(result!.kind, "done");
 		if (result!.kind === "done") {
 			assert.equal(result!.message.content?.[0]?.type, "text");
+		}
+	});
+
+	it("converts done at top level", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "done",
+			message: {
+				content: [{ type: "text", text: "final" }],
+				usage: { input: 10, output: 5 },
+			},
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.[0]?.text, "final");
+			assert.equal(result!.message.usage?.input, 10);
+		}
+	});
+
+	it("converts done at top level without usage", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "done",
+			message: {
+				content: [{ type: "text", text: "done" }],
+			},
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.[0]?.text, "done");
+		}
+	});
+
+	it("converts done at top level with thinking and text", () => {
+		const result = sessionEventToNormalizedEvent({
+			type: "done",
+			message: {
+				content: [
+					{ type: "thinking", thinking: "thought" },
+					{ type: "text", text: "result" },
+				],
+			},
+		});
+		assert.ok(result);
+		assert.equal(result!.kind, "done");
+		if (result!.kind === "done") {
+			assert.equal(result!.message.content?.length, 2);
 		}
 	});
 

--- a/.pi/extensions/supervisor/event-adapter.ts
+++ b/.pi/extensions/supervisor/event-adapter.ts
@@ -83,6 +83,9 @@ export function jsonLineToNormalizedEvent(line: string): NormalizedEvent | null 
 			case "agent_end":
 				return { kind: "agent_end" };
 
+			case "done":
+				return { kind: "done", message: ev.message };
+
 			default:
 				return null;
 		}
@@ -167,6 +170,9 @@ export function sessionEventToNormalizedEvent(ev: Record<string, unknown>): Norm
 			return { kind: "agent_end" };
 		case "session":
 			return { kind: "session" };
+
+		case "done":
+			return { kind: "done", message: ev.message as any };
 
 		default:
 			return null;


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #402

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 49s | 40.6K | 16 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 0s | 72.1K | 17 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 19s | 39.4K | 38 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 48s | 60.0K | 53 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 8s | 26.2K | 24 | deepseek-v4-flash |

**Total:** 5 agents · 8m 4s · 238.3K tokens · 148 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/402