### PR TITLE
feat(#404): Bug: supervisor - commitAndPush silently swallows no-op commits, pipeline wastes auditor run

### DIFF
--- a/.pi/extensions/supervisor/github/git.test.mts
+++ b/.pi/extensions/supervisor/github/git.test.mts
@@ -82,14 +82,15 @@ describe("commitAndPush()", () => {
 		assert.deepEqual(calls[2].args, ["push", "origin", "feature"]);
 	});
 
-	it("pushes even when git commit returns 'nothing to commit'", async () => {
-		const { pi, calls } = createMockPi([
+	it("throws when git commit returns 'nothing to commit' (no changes)", async () => {
+		const { pi } = createMockPi([
 			{ code: 0, stdout: "", stderr: "" },
 			{ code: 1, stdout: "", stderr: "nothing to commit" },
-			{ code: 0, stdout: "", stderr: "" },
 		]);
-		await commitAndPush(pi, "/tmp/worktree", "origin", "feature", "msg");
-		assert.equal(calls.length, 3);
+		await assert.rejects(
+			() => commitAndPush(pi, "/tmp/worktree", "origin", "feature", "msg"),
+			/No changes to commit/,
+		);
 	});
 
 	it("throws when git add fails", async () => {
@@ -109,5 +110,17 @@ describe("commitAndPush()", () => {
 			() => commitAndPush(pi, "/tmp/worktree", "origin", "feature", "msg"),
 			/git commit failed/,
 		);
+	});
+
+	it("does not push when nothing to commit (short-circuits before push)", async () => {
+		const { pi, calls } = createMockPi([
+			{ code: 0, stdout: "", stderr: "" },
+			{ code: 1, stdout: "", stderr: "nothing to commit" },
+		]);
+		await assert.rejects(
+			() => commitAndPush(pi, "/tmp/worktree", "origin", "feature", "msg"),
+			/No changes to commit/,
+		);
+		assert.equal(calls.length, 2); // add + commit, no push
 	});
 });

--- a/.pi/extensions/supervisor/github/git.ts
+++ b/.pi/extensions/supervisor/github/git.ts
@@ -39,9 +39,10 @@ export async function commitAndPush(
 	const commitResult = await pi.exec("git", ["commit", "-m", message], { cwd });
 	if (commitResult.code !== 0) {
 		const output = (commitResult.stderr || "") + (commitResult.stdout || "");
-		if (!output.includes("nothing to commit")) {
-			throw new Error(`git commit failed: ${output.trim()}`);
+		if (output.includes("nothing to commit")) {
+			throw new Error("No changes to commit — developer produced no output");
 		}
+		throw new Error(`git commit failed: ${output.trim()}`);
 	}
 	await pushBranch(pi, cwd, remote, branch);
 }

--- a/.pi/extensions/supervisor/pipeline/stages.test.mts
+++ b/.pi/extensions/supervisor/pipeline/stages.test.mts
@@ -832,13 +832,12 @@ describe("handlePostAgentSuccess()", () => {
 		assert.equal(success, false, "git push failure must return false — pipeline should stop");
 	});
 
-	it("developer git commit returns 'nothing to commit' — still pushes, push succeeds — returns true", async () => {
+	it("developer commit returns 'nothing to commit' — throws, returns false (halts pipeline)", async () => {
 		const calls: ExecCall[] = [];
 		const pi = createMockPi(
 			[
 				{ code: 0, stdout: "", stderr: "" }, // git add succeeds
-				{ code: 1, stdout: "", stderr: "nothing to commit, working tree clean" }, // git commit: nothing to commit
-				{ code: 0, stdout: "", stderr: "" }, // git push succeeds
+				{ code: 1, stdout: "", stderr: "nothing to commit, working tree clean" }, // git commit: nothing to commit (throws now)
 			],
 			calls,
 		);
@@ -867,45 +866,11 @@ describe("handlePostAgentSuccess()", () => {
 			"Test issue",
 		);
 
-		assert.equal(success, true, "'nothing to commit' + push succeeds — pipeline should continue");
-	});
-
-	it("developer git commit returns 'nothing to commit' — still pushes, push fails — returns false", async () => {
-		const calls: ExecCall[] = [];
-		const pi = createMockPi(
-			[
-				{ code: 0, stdout: "", stderr: "" }, // git add succeeds
-				{ code: 1, stdout: "", stderr: "nothing to commit, working tree clean" }, // git commit: nothing to commit
-				{ code: 1, stdout: "", stderr: "fatal: permission denied" }, // git push fails
-			],
-			calls,
-		);
-		const ctx = createMockCtx();
-		const result: AgentRunResult = {
-			...baseResult,
-			agentName: "developer",
-			textOutput: "IMPLEMENTATION_COMPLETE",
-			textOnly: "IMPLEMENTATION_COMPLETE",
-		};
-		const filteredData: FilteredIssueData = {
-			body: "",
-			comments: [],
-		};
-
-		const success = await handlePostAgentSuccess(
-			pi,
-			ctx,
-			result,
-			"developer",
-			42,
-			mockConfig,
-			filteredData,
-			"/repo/worktree",
-			"feature-branch",
-			"Test issue",
-		);
-
-		assert.equal(success, false, "'nothing to commit' + push fails — pipeline should stop");
+		assert.equal(success, false, "'nothing to commit' now throws — pipeline should stop");
+		assert.equal(calls.length, 2, "should only call add + commit, NO push");
+		// Verify the error message is about no changes
+		const addCall = calls[1];
+		assert.ok(addCall.args.includes("commit"), "second call should be commit");
 	});
 
 	it("developer with worktreePath undefined — returns true (no-op)", async () => {

--- a/test/supervisor-github-helpers.test.mts
+++ b/test/supervisor-github-helpers.test.mts
@@ -126,14 +126,16 @@ describe("commitAndPush", () => {
 		assert.strictEqual(calls.length, 1); // only add, not commit/push
 	});
 
-	it("handles 'nothing to commit' gracefully (continues to push)", async () => {
+	it("throws when 'nothing to commit' (no changes — prevents pipeline progression)", async () => {
 		const { pi, calls } = makeMockPi([
 			{ code: 0, stdout: "" },
 			{ code: 1, stderr: "nothing to commit" },
-			{ code: 0, stdout: "Everything up-to-date" },
 		]);
-		await commitAndPush(pi as any, "/cwd", "origin", "branch", "msg");
-		assert.strictEqual(calls.length, 3); // add + commit(ignored) + push
+		await assert.rejects(
+			() => commitAndPush(pi as any, "/cwd", "origin", "branch", "msg"),
+			/No changes to commit/,
+		);
+		assert.strictEqual(calls.length, 2); // add + commit, no push
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #404

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 0s | 36.1K | 19 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 1m 51s | 111.3K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 51s | 32.7K | 17 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 36s | 61.2K | 30 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 9s | 38.1K | 38 | deepseek-v4-flash |

**Total:** 5 agents · 10m 28s · 279.4K tokens · 116 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/404