### PR TITLE
feat(#347): ICA: Unify error handling in ask_user_read tool

### DIFF
--- a/.pi/extensions/ask-user/index.ts
+++ b/.pi/extensions/ask-user/index.ts
@@ -264,6 +264,22 @@ export default function askUser(pi: ExtensionAPI): void {
 		},
 	});
 
+	// ── ask_user_read error helper ─────────────────────────────────
+	function readError(message: string): {
+		content: Array<{ type: "text"; text: string }>;
+		details: Record<string, unknown>;
+	} {
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: JSON.stringify({ entries: [], count: 0, error: message }),
+				},
+			],
+			details: { entries: [], count: 0, error: message },
+		};
+	}
+
 	// ── ask_user_read LLM tool ──────────────────────────────────────
 	pi.registerTool({
 		name: "ask_user_read",
@@ -320,51 +336,15 @@ export default function askUser(pi: ExtensionAPI): void {
 
 				if (action === "get") {
 					if (id === undefined || id === null) {
-						return {
-							content: [
-								{
-									type: "text" as const,
-									text: JSON.stringify({
-										entries: [],
-										count: 0,
-										message: "id parameter is required for get action",
-									}),
-								},
-							],
-							details: { entries: [], count: 0 },
-						};
+						return readError("id parameter is required for get action");
 					}
 
 					const entry = await getQnaEntry(projectDir, id);
 					if (entry === undefined) {
-						return {
-							content: [
-								{
-									type: "text" as const,
-									text: JSON.stringify({
-										entries: [],
-										count: 0,
-										message: "No Q&A history yet",
-									}),
-								},
-							],
-							details: { entries: [], count: 0 },
-						};
+						return readError("No Q&A history yet");
 					}
 					if (entry === null) {
-						return {
-							content: [
-								{
-									type: "text" as const,
-									text: JSON.stringify({
-										entries: [],
-										count: 0,
-										message: `Entry #${id} not found`,
-									}),
-								},
-							],
-							details: { entries: [], count: 0 },
-						};
+						return readError(`Entry #${id} not found`);
 					}
 
 					return {
@@ -383,19 +363,7 @@ export default function askUser(pi: ExtensionAPI): void {
 
 				if (action === "query") {
 					if (!text) {
-						return {
-							content: [
-								{
-									type: "text" as const,
-									text: JSON.stringify({
-										entries: [],
-										count: 0,
-										message: "text parameter is required for query action",
-									}),
-								},
-							],
-							details: { entries: [], count: 0 },
-						};
+						return readError("text parameter is required for query action");
 					}
 
 					const entries = await queryQnaEntries(projectDir, text);
@@ -415,33 +383,9 @@ export default function askUser(pi: ExtensionAPI): void {
 				}
 
 				// Unknown action
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: JSON.stringify({
-								entries: [],
-								count: 0,
-								message: `Unknown action: ${action}`,
-							}),
-						},
-					],
-					details: { entries: [], count: 0 },
-				};
+				return readError(`Unknown action: ${action}`);
 			} catch (err) {
-				return {
-					content: [
-						{
-							type: "text" as const,
-							text: JSON.stringify({
-								entries: [],
-								count: 0,
-								message: `Error reading Q&A history: ${(err as Error).message}`,
-							}),
-						},
-					],
-					details: { entries: [], count: 0 },
-				};
+				return readError(`Error reading Q&A history: ${(err as Error).message}`);
 			}
 		},
 	});

--- a/test/ask-user.test.mts
+++ b/test/ask-user.test.mts
@@ -1318,3 +1318,74 @@ describe("Empty JSONL file edge cases", () => {
 		assert.strictEqual(entry, undefined);
 	});
 });
+
+// ============================================================================
+// Unit tests: readError helper (ask_user_read error unification)
+// ============================================================================
+
+interface ContentResult {
+	content: Array<{ type: "text"; text: string }>;
+	details: Record<string, unknown>;
+}
+
+function readError(message: string): ContentResult {
+	return {
+		content: [{ type: "text", text: JSON.stringify({ entries: [], count: 0, error: message }) }],
+		details: { entries: [], count: 0, error: message },
+	};
+}
+
+describe("readError (ask_user_read error unification)", () => {
+	it("returns correct ContentResult shape", () => {
+		const result = readError("test error");
+		assert.ok(Array.isArray(result.content));
+		assert.strictEqual(result.content.length, 1);
+		assert.strictEqual(result.content[0]!.type, "text");
+	});
+
+	it("includes error message in content text JSON", () => {
+		const result = readError("test error");
+		const parsed = JSON.parse(result.content[0]!.text);
+		assert.deepStrictEqual(parsed.entries, []);
+		assert.strictEqual(parsed.count, 0);
+		assert.strictEqual(parsed.error, "test error");
+		assert.strictEqual(parsed.message, undefined, "Should use 'error' not 'message' key");
+	});
+
+	it("includes error message in details", () => {
+		const result = readError("test error");
+		assert.deepStrictEqual(result.details.entries, []);
+		assert.strictEqual(result.details.count, 0);
+		assert.strictEqual(result.details.error, "test error");
+	});
+
+	it("handles all expected error messages", () => {
+		const messages = [
+			"id parameter is required for get action",
+			"text parameter is required for query action",
+			"Unknown action: invalid",
+			"Error reading Q&A history: something broke",
+			"No Q&A history yet",
+			"Entry #42 not found",
+		];
+		for (const msg of messages) {
+			const result = readError(msg);
+			const parsed = JSON.parse(result.content[0]!.text);
+			assert.strictEqual(parsed.error, msg, `Message: "${msg}"`);
+		}
+	});
+
+	it("details.error matches content.error", () => {
+		const msg = "Something went wrong";
+		const result = readError(msg);
+		const parsed = JSON.parse(result.content[0]!.text);
+		assert.strictEqual(parsed.error, result.details.error);
+	});
+
+	it("content is a single text block", () => {
+		const result = readError("error");
+		assert.strictEqual(result.content.length, 1);
+		assert.strictEqual(result.content[0]!.type, "text");
+		assert.ok(typeof result.content[0]!.text === "string");
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #347

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 20s | 94.7K | 20 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 14s | 39.5K | 32 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 56s | 59.7K | 45 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 39s | 33.0K | 28 | deepseek-v4-flash |

**Total:** 4 agents · 9m 9s · 226.8K tokens · 125 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/347