### PR TITLE
feat(#346): ICA: Move CSV migration to session_start

### DIFF
--- a/.pi/extensions/ask-user/README.md
+++ b/.pi/extensions/ask-user/README.md
@@ -10,7 +10,7 @@
   - `multi-select` — Pick zero or more from a list
 - **`ask_user_read` tool** — LLM retrieves past Q&A entries (by id, list, or text search)
 - **`/qna` command** — Browse logged Q&A history in the TUI
-- **Persistent log** — All interactions saved to `.pi/context/qna.jsonl` (auto-migrates from legacy `.csv`)
+- **Persistent log** — All interactions saved to `.pi/context/qna.jsonl` (legacy `.csv` auto-migrated at session start)
 
 ## How it works
 

--- a/.pi/extensions/ask-user/index.ts
+++ b/.pi/extensions/ask-user/index.ts
@@ -9,7 +9,7 @@
  *   - ask_user_read tool for LLM extraction of past Q&A entries
  *
  * All completed interactions are logged to .pi/context/qna.jsonl.
- * Legacy .pi/context/qna.csv is migrated on first append if present.
+ * Legacy .pi/context/qna.csv is migrated at session start if present.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
@@ -24,40 +24,6 @@ import {
 import { QuestionHandler } from "./question-handler.ts";
 import * as fs from "node:fs";
 import * as path from "node:path";
-
-// ---------------------------------------------------------------------------
-// Migration guard
-// ---------------------------------------------------------------------------
-
-let csvMigrated = false;
-
-/**
- * Run CSV→JSONL migration once on first write if CSV file exists.
- *
- * Sets csvMigrated BEFORE calling migrateQnaFromCsv to prevent re-entry.
- * If the migration throws, csvMigrated is already true, so the next call
- * will skip migration entirely — no duplicate entries are appended.
- */
-async function ensureMigrated(projectDir: string): Promise<void> {
-	if (csvMigrated) return;
-	// Set flag first to prevent re-entry on failure
-	csvMigrated = true;
-	const csvPath = path.join(projectDir, ".pi", "context", "qna.csv");
-	if (fs.existsSync(csvPath)) {
-		try {
-			const result = await migrateQnaFromCsv(projectDir);
-			if (result.migrated > 0 || result.skipped > 0) {
-				console.warn(
-					`Migration: ${result.migrated} entries migrated to qna.jsonl, ${result.skipped} skipped`,
-				);
-			}
-		} catch (err) {
-			// Migration failed but csvMigrated is already true.
-			// Log a warning so the user knows migration had issues.
-			console.warn(`Migration warning: ${(err as Error).message}`);
-		}
-	}
-}
 
 // ---------------------------------------------------------------------------
 // Utility: format entries as markdown table
@@ -90,6 +56,27 @@ function formatTable(
 // ---------------------------------------------------------------------------
 
 export default function askUser(pi: ExtensionAPI): void {
+	// ── CSV→JSONL migration at session start ─────────────────────────
+	// Migration runs once per session when the session starts, not on
+	// every first ask_user call. This avoids delaying the first question
+	// when CSV has many rows.
+	pi.on("session_start", async (_event, ctx) => {
+		const projectDir = ctx.sessionManager.getCwd();
+		const csvPath = path.join(projectDir, ".pi", "context", "qna.csv");
+		if (fs.existsSync(csvPath)) {
+			try {
+				const result = await migrateQnaFromCsv(projectDir);
+				if (result.migrated > 0 || result.skipped > 0) {
+					console.warn(
+						`Migration: ${result.migrated} entries migrated to qna.jsonl, ${result.skipped} skipped`,
+					);
+				}
+			} catch (err) {
+				console.warn(`Migration warning: ${(err as Error).message}`);
+			}
+		}
+	});
+
 	// ── ask_user tool (unchanged except storage backend) ──────────────
 	pi.registerTool({
 		name: "ask_user",
@@ -115,15 +102,6 @@ export default function askUser(pi: ExtensionAPI): void {
 			details: Record<string, unknown>;
 		}> {
 			const projectDir = ctx.sessionManager.getCwd();
-
-			// Run CSV→JSONL migration on first write
-			// Wrapped in try/catch so a migration failure doesn't crash the tool
-			try {
-				await ensureMigrated(projectDir);
-			} catch (err) {
-				console.warn(`Migration warning: ${(err as Error).message}`);
-			}
-
 			const handler = new QuestionHandler(projectDir, ctx);
 			return handler.handle(params);
 		},

--- a/.pi/extensions/ask-user/jsonl-logger.ts
+++ b/.pi/extensions/ask-user/jsonl-logger.ts
@@ -499,7 +499,8 @@ export async function migrateQnaFromCsv(
 		return { migrated, skipped };
 	} catch (err) {
 		// Temp file (former CSV) remains on disk for potential manual recovery.
-		// The caller's csvMigrated flag prevents re-entry and duplicate writes.
+		// Migration runs once per session (called from session_start handler), so
+		// even on failure no duplicate writes occur within the same session.
 		throw err;
 	}
 }

--- a/test/ask-user.test.mts
+++ b/test/ask-user.test.mts
@@ -282,18 +282,16 @@ async function migrateQnaFromCsv(
 		return { migrated, skipped };
 	} catch (err) {
 		// Temp file (former CSV) remains on disk for potential recovery.
-		// csvMigrated flag (set before call in ensureMigrated) prevents re-entry.
 		throw err;
 	}
 }
 
-// ── ensureMigrated (Phase 1 guard) ─────────────────────────────────────────
+// ── session_start handler ────────────────────────────────────────────
+//
+// Simulates the pi.on("session_start", ...) logic that runs migration
+// at session start instead of inside the ask_user execute handler.
 
-let testCsvMigrated = false;
-
-async function ensureMigrated(projectDir: string): Promise<void> {
-	if (testCsvMigrated) return;
-	testCsvMigrated = true;
+async function handleSessionStart(projectDir: string): Promise<void> {
 	const csvPath = path.join(projectDir, ".pi", "context", "qna.csv");
 	if (fs.existsSync(csvPath)) {
 		try {
@@ -969,79 +967,50 @@ describe("migrateQnaFromCsv", () => {
 });
 
 // ============================================================================
-// Integration tests: ensureMigrated (Phase 1 — state guard)
+// Integration tests: session_start handler
 // ============================================================================
 
-describe("ensureMigrated (Phase 1 — state guard)", () => {
+describe("session_start handler", () => {
 	let tmpDir: string;
 
 	beforeEach(() => {
-		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-user-ensure-test-"));
-		testCsvMigrated = false;
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-user-session-start-test-"));
 	});
 
 	afterEach(() => {
 		fs.rmSync(tmpDir, { recursive: true, force: true });
-		testCsvMigrated = false;
 	});
 
-	it("sets csvMigrated flag before migration call — flag is true even if migration throws", async () => {
+	it("calls migrateQnaFromCsv when CSV exists", async () => {
 		const csvDir = path.join(tmpDir, ".pi", "context");
 		fs.mkdirSync(csvDir, { recursive: true });
-		fs.writeFileSync(path.join(csvDir, "qna.csv"), "2026-05-15T19:00:00.000Z;Q1;A1", "utf-8");
+		fs.writeFileSync(
+			path.join(csvDir, "qna.csv"),
+			"2026-05-15T19:00:00.000Z;What is your name?;Alice",
+			"utf-8",
+		);
 
-		// Make appendFile fail
-		const origAppend = fs.promises.appendFile;
-		fs.promises.appendFile = async () => {
-			throw new Error("Simulated failure");
-		};
+		await handleSessionStart(tmpDir);
 
-		try {
-			await ensureMigrated(tmpDir);
-		} catch {
-			// Expected — error is caught inside ensureMigrated
-		}
+		// CSV should be gone (migrated)
+		assert.ok(!fs.existsSync(path.join(csvDir, "qna.csv")), "CSV should be migrated and removed");
 
-		fs.promises.appendFile = origAppend;
+		// JSONL should exist with the entry
+		const jsonlPath = path.join(csvDir, "qna.jsonl");
+		assert.ok(fs.existsSync(jsonlPath), "JSONL should exist after migration");
 
-		// Flag should be true even though migration failed
-		assert.ok(testCsvMigrated, "csvMigrated should be true after ensureMigrated call");
+		const content = fs.readFileSync(jsonlPath, "utf-8");
+		assert.ok(content.includes("What is your name?"), "Entry should be in JSONL");
+		assert.ok(content.includes("Alice"), "Answer should be in JSONL");
 	});
 
-	it("returns immediately if csvMigrated is already true", async () => {
-		testCsvMigrated = true;
+	it("is a no-op when CSV does not exist", async () => {
+		// No CSV file — handler should do nothing
+		await handleSessionStart(tmpDir);
 
-		// Even with no CSV dir at all, ensureMigrated should return immediately
-		await ensureMigrated(tmpDir);
-
-		// No crash, no exception — flag remains true
-		assert.ok(testCsvMigrated);
-	});
-
-	it("sets csvMigrated even when CSV does not exist", async () => {
-		assert.ok(!testCsvMigrated, "Flag should start false");
-
-		await ensureMigrated(tmpDir);
-
-		assert.ok(testCsvMigrated, "Flag should be true after ensureMigrated with no CSV");
-	});
-
-	it("second call with read-only CSV returns immediately (csvMigrated already true)", async () => {
-		const csvDir = path.join(tmpDir, ".pi", "context");
-		fs.mkdirSync(csvDir, { recursive: true });
-		fs.writeFileSync(path.join(csvDir, "qna.csv"), "2026-05-15T19:00:00.000Z;Q1;A1", "utf-8");
-
-		// First call succeeds
-		await ensureMigrated(tmpDir);
-
-		// Reset CSV and try second call
-		testCsvMigrated = true; // Simulate already migrated
-
-		// This would throw if it tried to migrate again since CSV is gone
-		// (renamed during first call). But since flag is true, it returns immediately.
-		await ensureMigrated(tmpDir);
-
-		assert.ok(testCsvMigrated, "Flag remains true");
+		// No JSONL should be created
+		const jsonlPath = path.join(tmpDir, ".pi", "context", "qna.jsonl");
+		assert.ok(!fs.existsSync(jsonlPath), "JSONL should not be created when no CSV exists");
 	});
 
 	it("catches errors from migrateQnaFromCsv and logs warning instead of throwing", async () => {
@@ -1059,101 +1028,60 @@ describe("ensureMigrated (Phase 1 — state guard)", () => {
 		const origWarn = console.warn;
 		console.warn = (msg: string) => warnings.push(msg);
 
-		try {
-			await ensureMigrated(tmpDir);
-		} finally {
-			fs.promises.appendFile = origAppend;
-			console.warn = origWarn;
-		}
+		// Should not throw — errors are caught internally
+		await handleSessionStart(tmpDir);
+
+		fs.promises.appendFile = origAppend;
+		console.warn = origWarn;
 
 		assert.ok(
 			warnings.some((w) => w.includes("Migration warning")),
 			"Should log a warning instead of throwing",
 		);
 	});
-});
 
-// ============================================================================
-// Integration tests: Phase 3 — ensureMigrated called from execute context
-// (Tests that the try/catch in execute() prevents crashes even when migration fails)
-// ============================================================================
+	it("does not crash when .pi/context directory does not exist and no CSV", async () => {
+		// No .pi/context dir at all — handler should be a no-op, not crash
+		await handleSessionStart(tmpDir);
 
-describe("Phase 3 — Error resilience (execute wrapper)", () => {
-	let tmpDir: string;
-
-	beforeEach(() => {
-		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-user-phase3-test-"));
-		testCsvMigrated = false;
+		// No JSONL should exist
+		const jsonlPath = path.join(tmpDir, ".pi", "context", "qna.jsonl");
+		assert.ok(!fs.existsSync(jsonlPath), "JSONL should not be created");
 	});
 
-	afterEach(() => {
-		fs.rmSync(tmpDir, { recursive: true, force: true });
-		testCsvMigrated = false;
+	it("does not crash when .pi/context directory does not exist but CSV should be checked", async () => {
+		// Test that existsSync on a non-existent path returns false gracefully
+		const csvPath = path.join(tmpDir, ".pi", "context", "qna.csv");
+		assert.ok(!fs.existsSync(csvPath), "CSV should not exist");
+
+		await handleSessionStart(tmpDir);
+
+		// Should have completed without error
+		const jsonlPath = path.join(tmpDir, ".pi", "context", "qna.jsonl");
+		assert.ok(!fs.existsSync(jsonlPath), "JSONL should not be created");
 	});
 
-	it("simulates execute() wrapping ensureMigrated in try/catch — does not throw on migration failure", async () => {
+	it("logs migration summary when entries are migrated", async () => {
 		const csvDir = path.join(tmpDir, ".pi", "context");
 		fs.mkdirSync(csvDir, { recursive: true });
-		fs.writeFileSync(path.join(csvDir, "qna.csv"), "2026-05-15T19:00:00.000Z;Q1;A1", "utf-8");
-
-		// Make appendFile fail
-		const origAppend = fs.promises.appendFile;
-		fs.promises.appendFile = async () => {
-			throw new Error("Simulated write failure");
-		};
-
-		// Simulate execute() wrapping ensureMigrated in try/catch
-		let caughtError: Error | null = null;
-		try {
-			await ensureMigrated(tmpDir); // ensureMigrated itself now catches errors
-		} catch (err) {
-			caughtError = err as Error;
-		}
-
-		fs.promises.appendFile = origAppend;
-
-		// ensureMigrated catches errors internally, so the try/catch wrapper should not trigger
-		assert.strictEqual(caughtError, null, "ensureMigrated should catch errors internally");
-		assert.ok(testCsvMigrated, "Flag should be true after call");
-	});
-
-	it("multiple execute calls with failing migration do not create duplicates (csvMigrated prevents re-entry)", async () => {
-		const csvDir = path.join(tmpDir, ".pi", "context");
-		fs.mkdirSync(csvDir, { recursive: true });
-		fs.writeFileSync(path.join(csvDir, "qna.csv"), "2026-05-15T19:00:00.000Z;Q1;A1", "utf-8");
-
-		const origAppend = fs.promises.appendFile;
-		let callCount = 0;
-		fs.promises.appendFile = async () => {
-			callCount++;
-			throw new Error("Simulated write failure");
-		};
-
-		try {
-			// First call — migration fails, but csvMigrated is set
-			await ensureMigrated(tmpDir);
-		} catch {
-			// Expected internally caught
-		}
-
-		const appendCountAfterFirstCall = callCount;
-
-		// Second call — csvMigrated is true, so ensureMigrated returns immediately
-		try {
-			await ensureMigrated(tmpDir);
-		} catch {
-			// Should not throw
-		}
-
-		fs.promises.appendFile = origAppend;
-
-		// appendFile should only have been called once (first attempt only)
-		assert.strictEqual(
-			callCount,
-			appendCountAfterFirstCall,
-			"Second call should not retry migration",
+		fs.writeFileSync(
+			path.join(csvDir, "qna.csv"),
+			"2026-05-15T19:00:00.000Z;Q1;A1\n2026-05-15T20:00:00.000Z;Q2;A2",
+			"utf-8",
 		);
-		assert.ok(testCsvMigrated, "Flag should be true");
+
+		const warnings: string[] = [];
+		const origWarn = console.warn;
+		console.warn = (msg: string) => warnings.push(msg);
+
+		await handleSessionStart(tmpDir);
+
+		console.warn = origWarn;
+
+		assert.ok(
+			warnings.some((w) => w.includes("Migration:") && w.includes("2 entries migrated")),
+			"Should log migration summary",
+		);
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #346

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 30s | 54.8K | 9 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 0s | 35.4K | 24 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 23s | 81.9K | 57 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 42s | 39.4K | 15 | deepseek-v4-flash |

**Total:** 4 agents · 6m 35s · 211.5K tokens · 105 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/346