### PR TITLE
feat(#405): Bug: supervisor - sessionEventToNormalizedEvent drops done events from SDK sessions

### DIFF
--- a/.pi/extensions/supervisor/event-adapter.test.mts
+++ b/.pi/extensions/supervisor/event-adapter.test.mts
@@ -357,13 +357,16 @@ describe("sessionEventToNormalizedEvent", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: { content: [{ type: "text", text: "done" }], usage: { input: 10, output: 5 } },
 			},
+			message: { content: [{ type: "text", text: "done" }], usage: { input: 10, output: 5 } },
 		});
 		assert.ok(result);
 		assert.equal(result!.kind, "done");
 		if (result!.kind === "done") {
 			assert.equal(result!.message.content?.[0]?.type, "text");
+			assert.equal(result!.message.content?.[0]?.text, "done");
+			assert.equal(result!.message.usage?.input, 10);
+			assert.equal(result!.message.usage?.output, 5);
 		}
 	});
 

--- a/.pi/extensions/supervisor/event-adapter.ts
+++ b/.pi/extensions/supervisor/event-adapter.ts
@@ -143,13 +143,9 @@ export function sessionEventToNormalizedEvent(ev: Record<string, unknown>): Norm
 					return { kind: "text_end", usage: msg?.usage as any };
 				}
 				case "done": {
-					const doneMsg = ae.message as Record<string, unknown> | undefined;
 					return {
 						kind: "done",
-						message: {
-							content: doneMsg?.content as any[],
-							usage: doneMsg?.usage as any,
-						},
+						message: ev.message as any,
 					};
 				}
 				default:

--- a/.pi/extensions/supervisor/session-events.test.mts
+++ b/.pi/extensions/supervisor/session-events.test.mts
@@ -435,9 +435,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "text", text: "hello" }],
-				},
+			},
+			message: {
+				content: [{ type: "text", text: "hello" }],
 			},
 		};
 		const result = processSessionEvent(ev, state);
@@ -454,9 +454,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "thinking", thinking: "deep thought" }],
-				},
+			},
+			message: {
+				content: [{ type: "thinking", thinking: "deep thought" }],
 			},
 		};
 		const result = processSessionEvent(ev, state);
@@ -475,12 +475,12 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [
-						{ type: "text", text: "hello" },
-						{ type: "thinking", thinking: "deep thought" },
-					],
-				},
+			},
+			message: {
+				content: [
+					{ type: "text", text: "hello" },
+					{ type: "thinking", thinking: "deep thought" },
+				],
 			},
 		};
 		const result = processSessionEvent(ev, state);
@@ -498,9 +498,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [],
-				},
+			},
+			message: {
+				content: [],
 			},
 		};
 		processSessionEvent(ev, state);
@@ -516,8 +516,8 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: undefined,
 			},
+			message: undefined,
 		};
 		processSessionEvent(ev, state);
 		assert.equal(state.textPushedThisTurn, false);
@@ -530,9 +530,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					usage: { input: 10, output: 5 },
-				},
+			},
+			message: {
+				usage: { input: 10, output: 5 },
 			},
 		};
 		processSessionEvent(ev, state);
@@ -547,9 +547,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "text", text: "line1\nline2\nline3" }],
-				},
+			},
+			message: {
+				content: [{ type: "text", text: "line1\nline2\nline3" }],
 			},
 		};
 		processSessionEvent(ev, state);
@@ -567,9 +567,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "text", text: "   " }],
-				},
+			},
+			message: {
+				content: [{ type: "text", text: "   " }],
 			},
 		};
 		processSessionEvent(ev, state);
@@ -584,9 +584,9 @@ describe("done handler — dedup flag fix", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "thinking", thinking: "deep thought" }],
-				},
+			},
+			message: {
+				content: [{ type: "thinking", thinking: "deep thought" }],
 			},
 		};
 		processSessionEvent(ev, state);
@@ -607,9 +607,9 @@ describe("dedup chain — done then message_end", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "text", text: "hello world" }],
-				},
+			},
+			message: {
+				content: [{ type: "text", text: "hello world" }],
 			},
 		};
 		processSessionEvent(doneEv, state);
@@ -645,9 +645,9 @@ describe("dedup chain — done then message_end", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [{ type: "thinking", thinking: "deep thought" }],
-				},
+			},
+			message: {
+				content: [{ type: "thinking", thinking: "deep thought" }],
 			},
 		};
 		processSessionEvent(doneEv, state);
@@ -676,12 +676,12 @@ describe("dedup chain — done then message_end", () => {
 			type: "message_update",
 			assistantMessageEvent: {
 				type: "done",
-				message: {
-					content: [
-						{ type: "text", text: "hello" },
-						{ type: "thinking", thinking: "deep thought" },
-					],
-				},
+			},
+			message: {
+				content: [
+					{ type: "text", text: "hello" },
+					{ type: "thinking", thinking: "deep thought" },
+				],
 			},
 		};
 		processSessionEvent(doneEv, state);


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #405

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 45s | 48.1K | 23 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 56s | 105.0K | 58 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 42s | 49.7K | 26 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 14m 3s | 105.5K | 72 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 18s | 34.8K | 37 | deepseek-v4-flash |

**Total:** 5 agents · 22m 45s · 343.1K tokens · 216 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/405