### PR TITLE
feat(#436): Duplicate Code: agent-harness/lib — READ_BASH_CMDS & FILE_MODIFY_SIGNALS duplicated across bash-command.ts and harness-rules.ts

### DIFF
--- a/.pi/lib/bash-command.test.ts
+++ b/.pi/lib/bash-command.test.ts
@@ -70,6 +70,28 @@ describe("BashCommand.isFileRead", () => {
 		assert.equal(new BashCommand("more file.ts").isFileRead(), true);
 	});
 
+	// ── Phase 1 characterization: each READ_BASH_CMDS value triggers isFileRead ──
+
+	it("cat triggers isFileRead (characterization)", () => {
+		assert.equal(new BashCommand("cat file.ts").isFileRead(), true);
+	});
+
+	it("head triggers isFileRead (characterization)", () => {
+		assert.equal(new BashCommand("head -5 f.ts").isFileRead(), true);
+	});
+
+	it("tail triggers isFileRead (characterization)", () => {
+		assert.equal(new BashCommand("tail -10 f.ts").isFileRead(), true);
+	});
+
+	it("less triggers isFileRead (characterization)", () => {
+		assert.equal(new BashCommand("less f.ts").isFileRead(), true);
+	});
+
+	it("more triggers isFileRead (characterization)", () => {
+		assert.equal(new BashCommand("more f.ts").isFileRead(), true);
+	});
+
 	it("false for cat with write redirect (cat >)", () => {
 		assert.equal(new BashCommand("cat > /tmp/foo").isFileRead(), false);
 	});
@@ -132,6 +154,48 @@ describe("BashCommand.isFileModify", () => {
 
 	it("detects dd command", () => {
 		assert.equal(new BashCommand("dd if=/dev/zero of=file bs=1M count=1").isFileModify(), true);
+	});
+
+	// ── Phase 1 characterization: each FILE_MODIFY_SIGNALS value triggers isFileModify ──
+
+	it("sed triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("sed -i 's/foo/bar/g' f.ts").isFileModify(), true);
+	});
+
+	it("echo triggers isFileModify (characterization)", () => {
+		// echo alone triggers isFileModify because "echo" is in FILE_MODIFY_SIGNALS
+		assert.equal(new BashCommand("echo hi").isFileModify(), true);
+		assert.equal(new BashCommand("echo hi > f.ts").isFileModify(), true);
+	});
+
+	it("cat triggers isFileModify (characterization)", () => {
+		// cat is in FILE_MODIFY_SIGNALS (used with redirect), so even plain cat returns true
+		assert.equal(new BashCommand("cat > f.ts").isFileModify(), true);
+		assert.equal(new BashCommand("cat file.ts").isFileModify(), true);
+	});
+
+	it("tee triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("tee f.ts").isFileModify(), true);
+	});
+
+	it("mv triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("mv a b").isFileModify(), true);
+	});
+
+	it("cp triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("cp a b").isFileModify(), true);
+	});
+
+	it("rm triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("rm f.ts").isFileModify(), true);
+	});
+
+	it("chmod triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("chmod +x f.sh").isFileModify(), true);
+	});
+
+	it("dd triggers isFileModify (characterization)", () => {
+		assert.equal(new BashCommand("dd if=/dev/zero of=f bs=1M count=1").isFileModify(), true);
 	});
 
 	it("does not flag read-only commands", () => {
@@ -222,6 +286,38 @@ describe("BashCommand.detectMismatch", () => {
 		const result = new BashCommand("").detectMismatch();
 		assert.equal(result, null);
 	});
+
+	// ── Phase 1 characterization: each READ_BASH_CMDS value triggers detectMismatch with "read" ──
+
+	it("cat triggers detectMismatch with 'read' suggestion (characterization)", () => {
+		const result = new BashCommand("cat file.ts").detectMismatch();
+		assert.notEqual(result, null);
+		assert.ok(result!.suggestion.includes("read"));
+	});
+
+	it("head triggers detectMismatch with 'read' suggestion (characterization)", () => {
+		const result = new BashCommand("head -5 f.ts").detectMismatch();
+		assert.notEqual(result, null);
+		assert.ok(result!.suggestion.includes("read"));
+	});
+
+	it("tail triggers detectMismatch with 'read' suggestion (characterization)", () => {
+		const result = new BashCommand("tail -10 f.ts").detectMismatch();
+		assert.notEqual(result, null);
+		assert.ok(result!.suggestion.includes("read"));
+	});
+
+	it("less triggers detectMismatch with 'read' suggestion (characterization)", () => {
+		const result = new BashCommand("less f.ts").detectMismatch();
+		assert.notEqual(result, null);
+		assert.ok(result!.suggestion.includes("read"));
+	});
+
+	it("more triggers detectMismatch with 'read' suggestion (characterization)", () => {
+		const result = new BashCommand("more f.ts").detectMismatch();
+		assert.notEqual(result, null);
+		assert.ok(result!.suggestion.includes("read"));
+	});
 });
 
 // ── Behavior: suggestRedirection ──
@@ -245,6 +341,28 @@ describe("BashCommand.suggestRedirection", () => {
 
 	it("backtick grep → ripgrep_search", () => {
 		assert.equal(new BashCommand("`grep foo`").suggestRedirection(), "ripgrep_search");
+	});
+
+	// ── Phase 1 characterization: each READ_BASH_CMDS value triggers suggestRedirection "read" ──
+
+	it("cat triggers suggestRedirection 'read' (characterization)", () => {
+		assert.equal(new BashCommand("cat file.ts").suggestRedirection(), "read");
+	});
+
+	it("head triggers suggestRedirection 'read' (characterization)", () => {
+		assert.equal(new BashCommand("head -5 f.ts").suggestRedirection(), "read");
+	});
+
+	it("tail triggers suggestRedirection 'read' (characterization)", () => {
+		assert.equal(new BashCommand("tail -10 f.ts").suggestRedirection(), "read");
+	});
+
+	it("less triggers suggestRedirection 'read' (characterization)", () => {
+		assert.equal(new BashCommand("less f.ts").suggestRedirection(), "read");
+	});
+
+	it("more triggers suggestRedirection 'read' (characterization)", () => {
+		assert.equal(new BashCommand("more f.ts").suggestRedirection(), "read");
 	});
 });
 

--- a/.pi/lib/bash-command.ts
+++ b/.pi/lib/bash-command.ts
@@ -13,8 +13,12 @@
  *   detectMismatchAndSuggest() → BashCommand(cmd).detectMismatch()
  *   suggestRedirection()   → BashCommand(cmd).suggestRedirection()
  *
- * All constants remain in harness-rules.ts for shared access.
+ * Constants imported from constants.ts (shared with harness-rules.ts).
  */
+
+// ── Imports ──
+
+import { READ_BASH_CMDS, FILE_MODIFY_SIGNALS } from "./constants.ts";
 
 // ── Re-export the segment type ──
 
@@ -25,24 +29,6 @@ export interface BashSegment {
 	/** Output redirect detected on segment (e.g., > or >>). */
 	redirect?: "write" | "append" | "read";
 }
-
-/** Bash file-reading commands that should use `read` tool instead. */
-const READ_BASH_CMDS: readonly string[] = ["cat", "head", "tail", "less", "more"];
-
-/**
- * Bash commands that modify files — triggers read cache invalidation.
- */
-const FILE_MODIFY_SIGNALS: readonly string[] = [
-	"sed",
-	"echo",
-	"cat",
-	"tee",
-	"mv",
-	"cp",
-	"rm",
-	"chmod",
-	"dd",
-];
 
 // ── Tokenizer (extracted from harness-rules.ts) ──
 

--- a/.pi/lib/constants.test.ts
+++ b/.pi/lib/constants.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for shared constants extracted to constants.ts.
+ * Verifies exact values, ordering, and readonly nature.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { READ_BASH_CMDS, FILE_MODIFY_SIGNALS } from "./constants.ts";
+
+// ── Entity: READ_BASH_CMDS ──
+
+describe("READ_BASH_CMDS (from constants.ts)", () => {
+	it("has exactly the expected values in order", () => {
+		assert.deepEqual([...READ_BASH_CMDS], ["cat", "head", "tail", "less", "more"]);
+	});
+
+	it("is declared as readonly array", () => {
+		// TypeScript readonly: push should not be possible at compile time
+		assert.ok(Array.isArray(READ_BASH_CMDS));
+		// Verify immutability at runtime — Object.freeze or equivalent
+		assert.throws(
+			() => {
+				(READ_BASH_CMDS as string[]).push("bat");
+			},
+			/readonly|frozen|immutable|not extensible|Cannot add property/,
+			"READ_BASH_CMDS should be frozen or readonly at runtime",
+		);
+	});
+
+	it("contains cat, head, tail, less, more", () => {
+		for (const cmd of ["cat", "head", "tail", "less", "more"]) {
+			assert.ok(READ_BASH_CMDS.includes(cmd), `${cmd} should be in READ_BASH_CMDS`);
+		}
+	});
+
+	it("does not contain bat or other non-read commands", () => {
+		assert.equal(READ_BASH_CMDS.includes("bat"), false);
+		assert.equal(READ_BASH_CMDS.includes("echo"), false);
+		assert.equal(READ_BASH_CMDS.includes("sed"), false);
+	});
+});
+
+// ── Entity: FILE_MODIFY_SIGNALS ──
+
+describe("FILE_MODIFY_SIGNALS (from constants.ts)", () => {
+	it("has exactly the expected values in order", () => {
+		assert.deepEqual(
+			[...FILE_MODIFY_SIGNALS],
+			["sed", "echo", "cat", "tee", "mv", "cp", "rm", "chmod", "dd"],
+		);
+	});
+
+	it("is declared as readonly array", () => {
+		assert.ok(Array.isArray(FILE_MODIFY_SIGNALS));
+		assert.throws(
+			() => {
+				(FILE_MODIFY_SIGNALS as string[]).push("truncate");
+			},
+			/readonly|frozen|immutable|not extensible|Cannot add property/,
+			"FILE_MODIFY_SIGNALS should be frozen or readonly at runtime",
+		);
+	});
+
+	it("contains all file-modifying commands", () => {
+		for (const cmd of ["sed", "echo", "cat", "tee", "mv", "cp", "rm", "chmod", "dd"]) {
+			assert.ok(FILE_MODIFY_SIGNALS.includes(cmd), `${cmd} should be in FILE_MODIFY_SIGNALS`);
+		}
+	});
+
+	it("does not contain read-only commands", () => {
+		assert.equal(FILE_MODIFY_SIGNALS.includes("ls"), false);
+		assert.equal(FILE_MODIFY_SIGNALS.includes("grep"), false);
+		assert.equal(FILE_MODIFY_SIGNALS.includes("rg"), false);
+	});
+});

--- a/.pi/lib/constants.ts
+++ b/.pi/lib/constants.ts
@@ -1,0 +1,32 @@
+/**
+ * constants.ts — Shared constants for tool-call detection and agent-harness rules.
+ *
+ * Extracted from bash-command.ts and harness-rules.ts to eliminate
+ * duplicate definitions. Both modules import from here.
+ *
+ * Zero pi dependencies — domain layer only.
+ */
+
+/** Bash file-reading commands that should use `read` tool instead. */
+export const READ_BASH_CMDS: readonly string[] = Object.freeze([
+	"cat",
+	"head",
+	"tail",
+	"less",
+	"more",
+]);
+
+/**
+ * Bash commands that modify files — triggers read cache invalidation.
+ */
+export const FILE_MODIFY_SIGNALS: readonly string[] = Object.freeze([
+	"sed",
+	"echo",
+	"cat",
+	"tee",
+	"mv",
+	"cp",
+	"rm",
+	"chmod",
+	"dd",
+]);

--- a/.pi/lib/harness-rules.ts
+++ b/.pi/lib/harness-rules.ts
@@ -13,14 +13,16 @@
  * Zero pi dependencies — domain layer only.
  */
 
-// ── Imports from bash-command.ts ──
+// ── Imports ──
 
+import { READ_BASH_CMDS, FILE_MODIFY_SIGNALS } from "./constants.ts";
 import { parseBashCmd as parseBashCmdImpl } from "./bash-command.ts";
 
-// ── Re-export BashCommand class for direct use ──
+// ── Re-export BashCommand class and constants for direct use ──
 
 export { BashCommand } from "./bash-command.ts";
 export type { BashSegment } from "./bash-command.ts";
+export { READ_BASH_CMDS, FILE_MODIFY_SIGNALS };
 
 // ── Constants ──
 
@@ -35,9 +37,6 @@ export const BASH_SEARCH_SIGNALS: readonly string[] = [
 	"`rg`",
 	"`grep`",
 ];
-
-/** Bash file-reading commands that should use `read` tool instead. */
-export const READ_BASH_CMDS: readonly string[] = ["cat", "head", "tail", "less", "more"];
 
 /** Dedicated search tools available to the agent. */
 export const SEARCH_TOOLS = new Set(["ripgrep_search", "structural_search"]);
@@ -66,21 +65,6 @@ export const MULTI_VERB_TOOLS = new Set([
 	"kubectl",
 	"gh",
 ]);
-
-/**
- * Bash commands that modify files — triggers read cache invalidation.
- */
-export const FILE_MODIFY_SIGNALS: readonly string[] = [
-	"sed",
-	"echo",
-	"cat",
-	"tee",
-	"mv",
-	"cp",
-	"rm",
-	"chmod",
-	"dd",
-];
 
 /** Max errors tracked per tool before triggering retry block. */
 export const MAX_ERRORS_PER_TOOL = 3;


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #436

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 59s | 23.1K | 12 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 4m 15s | 48.1K | 23 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 56s | 24.8K | 19 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 7s | 54.2K | 39 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 7s | 32.1K | 21 | deepseek-v4-flash |

**Total:** 5 agents · 10m 25s · 182.4K tokens · 114 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/436