### PR TITLE
feat(#432): Bug: supervisor - computeAuditScoreFromFindings counts untracked dimensions (inflated failures)

### DIFF
--- a/.pi/extensions/supervisor/agent-output.ts
+++ b/.pi/extensions/supervisor/agent-output.ts
@@ -3,13 +3,7 @@
 // Agents output structured JSON; this function parses and validates it.
 // No regex fallback, no text marker scanning, no lastIndexOf lookups.
 
-import type {
-	AgentOutput,
-	FailedParse,
-	ParseResult,
-	FindingSeverity,
-	AuditDimension,
-} from "./types.ts";
+import type { AgentOutput, FailedParse, ParseResult, FindingSeverity } from "./types.ts";
 
 // ─── ANSI Stripping ──────────────────────────────────────────────
 
@@ -37,18 +31,6 @@ const THINKING_PREFIX_RE = /^💭\s*/gm;
 function stripThinkingPrefix(text: string): string {
 	return text.replace(THINKING_PREFIX_RE, "");
 }
-
-// ─── Known Auditing Dimensions ────────────────────────────────────
-
-const KNOWN_DIMENSIONS = new Set<AuditDimension>([
-	"architecture-compliance",
-	"ticket-fulfillment",
-	"tests-passed",
-	"test-quality",
-	"correctness-safety",
-	"code-quality",
-	"completeness",
-]);
 
 const VALID_SEVERITIES = new Set<FindingSeverity>(["critical", "warning", "suggestion"]);
 

--- a/.pi/extensions/supervisor/workflow.test.mts
+++ b/.pi/extensions/supervisor/workflow.test.mts
@@ -183,7 +183,7 @@ describe("computeAuditScoreFromFindings", () => {
 		assert.equal(result.total, 6);
 	});
 
-	it("handles unknown dimensions gracefully", () => {
+	it("handles unknown dimensions gracefully — unknown dimensions do NOT affect score", () => {
 		const findings: Finding[] = [
 			{
 				severity: "critical",
@@ -193,7 +193,46 @@ describe("computeAuditScoreFromFindings", () => {
 				remedy: "Fix",
 			},
 		];
-		// Unknown dimensions still count as failed
+		// Unknown dimensions should NOT affect score (not in KNOWN_AUDIT_DIMENSIONS)
+		const result = computeAuditScoreFromFindings(findings);
+		assert.equal(result.passing, 6);
+		assert.equal(result.total, 6);
+	});
+
+	it("filters out tests-passed dimension — not in KNOWN_AUDIT_DIMENSIONS", () => {
+		const findings: Finding[] = [
+			{
+				severity: "critical",
+				dimension: "tests-passed",
+				symptom: "Tests failing",
+				consequence: "Unreliable",
+				remedy: "Fix tests",
+			},
+		];
+		// "tests-passed" is NOT in KNOWN_AUDIT_DIMENSIONS, so filtered out
+		const result = computeAuditScoreFromFindings(findings);
+		assert.equal(result.passing, 6);
+		assert.equal(result.total, 6);
+	});
+
+	it("known dimension still fails after filtering unknown dimensions", () => {
+		const findings: Finding[] = [
+			{
+				severity: "critical",
+				dimension: "custom-dimension",
+				symptom: "Issue",
+				consequence: "Bad",
+				remedy: "Fix",
+			},
+			{
+				severity: "critical",
+				dimension: "code-quality",
+				symptom: "Issue",
+				consequence: "Bad",
+				remedy: "Fix",
+			},
+		];
+		// custom-dimension is filtered out, but code-quality still counts
 		const result = computeAuditScoreFromFindings(findings);
 		assert.equal(result.passing, 5);
 		assert.equal(result.total, 6);
@@ -203,13 +242,12 @@ describe("computeAuditScoreFromFindings", () => {
 		const dimensions = [
 			"architecture-compliance",
 			"ticket-fulfillment",
-			"tests-passed",
 			"test-quality",
 			"correctness-safety",
 			"code-quality",
 			"completeness",
 		];
-		const findings: Finding[] = dimensions.slice(0, 6).map((d) => ({
+		const findings: Finding[] = dimensions.map((d) => ({
 			severity: "critical" as const,
 			dimension: d,
 			symptom: "Issue",

--- a/.pi/extensions/supervisor/workflow.ts
+++ b/.pi/extensions/supervisor/workflow.ts
@@ -223,8 +223,14 @@ export function computeAuditScoreFromFindings(findings: Finding[]): AuditScore {
 	const failedDimensions = new Set<string>();
 
 	for (const finding of findings) {
-		// Only critical and warning findings fail a dimension
-		if (finding.severity === "critical" || finding.severity === "warning") {
+		// Only critical and warning findings fail a dimension, and only
+		// if the dimension is in KNOWN_AUDIT_DIMENSIONS — unknown/custom
+		// dimensions (e.g., "tests-passed", user-defined ones) do not
+		// affect the score.
+		if (
+			(finding.severity === "critical" || finding.severity === "warning") &&
+			KNOWN_AUDIT_DIMENSIONS.includes(finding.dimension as (typeof KNOWN_AUDIT_DIMENSIONS)[number])
+		) {
 			failedDimensions.add(finding.dimension);
 		}
 	}


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #432

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 11s | 28.9K | 21 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 1m 40s | 85.4K | 20 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 47s | 26.4K | 17 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 46s | 32.3K | 32 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 43s | 59.9K | 59 | deepseek-v4-flash |

**Total:** 5 agents · 9m 6s · 233.0K tokens · 149 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/432