### PR TITLE
feat(#434): Bug: structural-analyzer - error masking in ast-grep error handling (keyword heuristic misses common errors)

### DIFF
--- a/.pi/extensions/structural-analyzer/README.md
+++ b/.pi/extensions/structural-analyzer/README.md
@@ -47,6 +47,16 @@ structural_search(pattern="class $A extends $B", language="py")
 - `ast-grep` installed globally: `npm i -g @ast-grep/cli`
 - No npm dependencies — all peer deps are pi-provided
 
+### Error handling
+
+`structural_search` uses exit-code-based error detection. ast-grep conventions:
+- **Exit code 0** — Success. Results parsed from JSONL output.
+- **Exit code 1, empty stderr** — No matches found (legitimate, returns `matches: 0`).
+- **Exit code 1, non-empty stderr** — ast-grep error (returns `isError: true` with the stderr message).
+- **Exit code ≥ 2** — Process error (permission denied, segfault, OOM kill, etc.). Always returns `isError: true`.
+
+This replaces the old keyword-heuristic approach that only caught stderr messages containing "unknown", "error", or "not found".
+
 ### When to use structural_search vs ripgrep_search
 
 | Use case | Tool |

--- a/.pi/extensions/structural-analyzer/index.ts
+++ b/.pi/extensions/structural-analyzer/index.ts
@@ -35,6 +35,16 @@ export interface SgResult {
 	results: SgMatch[];
 }
 
+/**
+ * Response shape from interpretSgExecResult.
+ * Matches the AgentToolResult contract used by pi.exec tool execution.
+ */
+export interface ExecResultResponse {
+	content: Array<{ type: "text"; text: string }>;
+	details: Record<string, unknown>;
+	isError?: boolean;
+}
+
 // ═══════════════════════════════════════════════════════════════════════
 // Pure Functions (exported for unit testing)
 // ═══════════════════════════════════════════════════════════════════════
@@ -71,6 +81,96 @@ export function validatePattern(pattern: string): string | null {
 	}
 
 	return null;
+}
+
+/**
+ * Interpret the result of an ast-grep exec call and return the appropriate
+ * response shape based on exit code, stdout, and stderr.
+ *
+ * Replaces the fragile keyword-heuristic error detection with exit-code-based logic.
+ * ast-grep convention:
+ *   - code 0 = success (stdout may contain JSONL matches or be empty)
+ *   - code 1 = no matches found (empty stdout, empty stderr)
+ *   - all other non-zero codes = real errors
+ *
+ * When stderr is non-empty with any exit code, it's treated as an error
+ * (exit code 1 with non-empty stderr means ast-grep encountered an issue).
+ */
+export function interpretSgExecResult(
+	code: number,
+	stdout: string,
+	stderr: string,
+	pattern: string,
+	language: string,
+): ExecResultResponse {
+	const trimmedStdout = (stdout || "").trim();
+	const trimmedStderr = (stderr || "").trim();
+
+	// If there's actual stdout content, parse it regardless of exit code
+	// (ast-grep may produce partial results even on non-zero exit)
+	if (trimmedStdout.length > 0) {
+		const sgResult = parseSgOutput(stdout);
+		const json = JSON.stringify(sgResult, null, 2);
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text:
+						`Structural search results for pattern: ${pattern}\n` +
+						`Language: ${language}\n` +
+						`Matches: ${sgResult.matches}\n\n` +
+						"```json\n" +
+						json +
+						"\n```",
+				},
+			],
+			details: { success: true, ...sgResult } as Record<string, unknown>,
+		};
+	}
+
+	// No stdout content
+	if (code === 0) {
+		// ast-grep succeeded but produced no output
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: `No matches found for pattern "${pattern}" in language "${language}".`,
+				},
+			],
+			details: { success: true, matches: 0, results: [] } as Record<string, unknown>,
+		};
+	}
+
+	// Exit code 1 with empty stderr = legitimate no-match (ast-grep convention)
+	if (code === 1 && trimmedStderr.length === 0) {
+		return {
+			content: [
+				{
+					type: "text" as const,
+					text: `No matches found for pattern "${pattern}" in language "${language}".`,
+				},
+			],
+			details: { success: true, matches: 0, results: [] } as Record<string, unknown>,
+		};
+	}
+
+	// Everything else is a real error
+	const stderrMsg = trimmedStderr || "(no stderr)";
+	return {
+		content: [
+			{
+				type: "text" as const,
+				text: `ast-grep failed (exit code ${code}): ${stderrMsg}`,
+			},
+		],
+		details: {
+			success: false,
+			exitCode: code,
+			stderr: stderr,
+		} as Record<string, unknown>,
+		isError: true,
+	};
 }
 
 /**
@@ -205,67 +305,14 @@ export default function structuralAnalyzer(pi: ExtensionAPI): void {
 				timeout: 30_000,
 			});
 
-			if (result.code !== 0) {
-				// ast-grep exits with code 0 on success, code 1 when no matches found
-				// — in that case stdout is empty, stderr may have a message
-				if (!result.stdout || result.stdout.trim().length === 0) {
-					const stderrMsg = result.stderr?.trim() || "";
-					// If stderr mentions "unknown language" or similar, return error
-					if (
-						stderrMsg &&
-						(stderrMsg.toLowerCase().includes("unknown") ||
-							stderrMsg.toLowerCase().includes("error") ||
-							stderrMsg.toLowerCase().includes("not found"))
-					) {
-						return {
-							content: [
-								{
-									type: "text" as const,
-									text: `ast-grep failed (exit code ${result.code}): ${stderrMsg}`,
-								},
-							],
-							details: { success: false, exitCode: result.code, stderr: result.stderr } as Record<
-								string,
-								unknown
-							>,
-							isError: true,
-						};
-					}
-
-					// No matches found (exit code 1, empty stdout)
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: `No matches found for pattern "${pattern}" in language "${language}".`,
-							},
-						],
-						details: { success: true, matches: 0, results: [] } as Record<string, unknown>,
-					};
-				}
-			}
-
-			// Parse JSONL output
-			const sgResult = parseSgOutput(result.stdout);
-
-			// Format as pretty JSON for LLM consumption
-			const json = JSON.stringify(sgResult, null, 2);
-
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text:
-							`Structural search results for pattern: ${pattern}\n` +
-							`Language: ${language}\n` +
-							`Matches: ${sgResult.matches}\n\n` +
-							"```json\n" +
-							json +
-							"\n```",
-					},
-				],
-				details: { success: true, ...sgResult } as Record<string, unknown>,
-			};
+			// Use the extracted pure function to interpret the exec result
+			return interpretSgExecResult(
+				result.code,
+				result.stdout || "",
+				result.stderr || "",
+				pattern,
+				language,
+			);
 		},
 	});
 }

--- a/.pi/extensions/structural-analyzer/test/structural-search.test.mts
+++ b/.pi/extensions/structural-analyzer/test/structural-search.test.mts
@@ -1,0 +1,228 @@
+/**
+ * Tests: structural-search — error handling in interpretSgExecResult
+ *
+ * The interpretSgExecResult function replaces the fragile keyword-heuristic
+ * error detection with exit-code-based logic. This test covers all
+ * exit-code/stdout/stderr combinations exhaustively.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/structural-analyzer/test/structural-search.test.mts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ---------------------------------------------------------------------------
+// Helper: read source and extract interpretSgExecResult via string matching
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const sourcePath = join(__dirname, "..", "index.ts");
+
+function getSource(): string {
+	return readFileSync(sourcePath, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Imports — we directly import from the source file
+// ---------------------------------------------------------------------------
+
+import { interpretSgExecResult, parseSgOutput, type SgMatch } from "../index.ts";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("interpretSgExecResult", () => {
+	// ── Success cases ─────────────────────────────────────────────────
+
+	it("code 0 with valid JSONL stdout → returns parsed matches with success: true", () => {
+		const stdout = [
+			JSON.stringify({ file: "a.ts", lines: "1-5", text: "console.log(x)" }),
+			JSON.stringify({ file: "b.ts", lines: "10-12", text: "console.log(y)" }),
+		].join("\n");
+
+		const result = interpretSgExecResult(0, stdout, "", "console.log($A)", "ts");
+
+		assert.equal(result.isError, undefined, "should not be an error");
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, true);
+		assert.equal(details.matches, 2);
+		const results = details.results as SgMatch[];
+		assert.equal(results.length, 2);
+		assert.equal(results[0].file, "a.ts");
+		assert.equal(results[1].file, "b.ts");
+		assert.ok(typeof result.content[0].text === "string");
+	});
+
+	it("code 0 with empty stdout → returns success: true, matches: 0", () => {
+		const result = interpretSgExecResult(0, "", "", "console.log($A)", "ts");
+
+		assert.equal(result.isError, undefined);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, true);
+		assert.equal(details.matches, 0);
+		const results = details.results as SgMatch[];
+		assert.equal(results.length, 0);
+	});
+
+	it("code 0 with whitespace-only stdout → returns success: true, matches: 0", () => {
+		const result = interpretSgExecResult(0, "  \n  \n  ", "", "console.log($A)", "ts");
+
+		assert.equal(result.isError, undefined);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, true);
+		assert.equal(details.matches, 0);
+	});
+
+	it("code 0 with stdout having mixed content (valid + invalid JSONL) → parses valid lines", () => {
+		const stdout = [
+			JSON.stringify({ file: "a.ts", lines: "1", text: "foo" }),
+			"not json",
+			JSON.stringify({ file: "b.ts", lines: "5", text: "bar" }),
+		].join("\n");
+
+		const result = interpretSgExecResult(0, stdout, "", "foo", "ts");
+
+		assert.equal(result.isError, undefined);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.matches, 2);
+	});
+
+	// ── No-match case (exit code 1, empty stdout, empty stderr) ──────
+
+	it("code 1, empty stdout, empty stderr → returns success: true, matches: 0 with 'No matches found' text", () => {
+		const result = interpretSgExecResult(1, "", "", "nonexistent($A)", "ts");
+
+		assert.equal(result.isError, undefined);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, true);
+		assert.equal(details.matches, 0);
+		assert.ok(result.content[0].text.includes("No matches found"));
+	});
+
+	it("code 1, empty stdout, whitespace-only stderr → treated as empty, returns success", () => {
+		const result = interpretSgExecResult(1, "", "  \n  ", "nonexistent($A)", "ts");
+
+		assert.equal(result.isError, undefined);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, true);
+		assert.equal(details.matches, 0);
+		assert.ok(result.content[0].text.includes("No matches found"));
+	});
+
+	// ── Error cases (post-fix: any non-zero exit with non-empty stderr or code > 1) ──
+
+	it("code 1, empty stdout, stderr='unknown language: xyz' → returns isError: true with exit code + stderr", () => {
+		const stderr = "unknown language: xyz";
+		const result = interpretSgExecResult(1, "", stderr, "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 1);
+		assert.ok((result.content[0].text as string).includes(stderr));
+	});
+
+	it("code 1, empty stdout, stderr='Some warning message' (no keyword) → returns isError: true", () => {
+		const stderr = "Some warning message";
+		const result = interpretSgExecResult(1, "", stderr, "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 1);
+		// The stderr text should appear in the response
+		assert.ok((result.content[0].text as string).includes(stderr));
+	});
+
+	it("code 126, empty stdout, stderr='Permission denied' → returns isError: true", () => {
+		const stderr = "Permission denied";
+		const result = interpretSgExecResult(126, "", stderr, "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 126);
+		assert.ok((result.content[0].text as string).includes(stderr));
+	});
+
+	it("code 126, empty stdout, empty stderr → returns isError: true with exit code 126", () => {
+		const result = interpretSgExecResult(126, "", "", "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 126);
+		// Should mention "(no stderr)" since stderr is empty
+		assert.ok((result.content[0].text as string).includes("126"));
+	});
+
+	it("code 137, empty stdout, empty stderr → returns isError: true (SIGKILL/OOM)", () => {
+		const result = interpretSgExecResult(137, "", "", "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 137);
+	});
+
+	it("code 139, empty stdout, stderr='Segmentation fault' → returns isError: true", () => {
+		const stderr = "Segmentation fault";
+		const result = interpretSgExecResult(139, "", stderr, "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 139);
+		assert.ok((result.content[0].text as string).includes(stderr));
+	});
+
+	it("code 2 (ast-grep internal error), empty stdout, empty stderr → returns isError: true", () => {
+		const result = interpretSgExecResult(2, "", "", "console.log($A)", "ts");
+
+		assert.equal(result.isError, true);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.success, false);
+		assert.equal(details.exitCode, 2);
+	});
+
+	it("code 1, non-empty stdout (partial results), empty stderr → stdout is parsed, not treated as no-match", () => {
+		// If there's stdout content but exit code 1, we still parse the content
+		const stdout = JSON.stringify({ file: "a.ts", lines: "1", text: "match" });
+		const result = interpretSgExecResult(1, stdout, "", "console.log($A)", "ts");
+
+		// With non-empty stdout, we parse it regardless of exit code
+		assert.equal(result.isError, undefined);
+		const details = result.details as Record<string, unknown>;
+		assert.equal(details.matches, 1);
+	});
+});
+
+describe("parseSgOutput", () => {
+	it("parses valid JSONL lines", () => {
+		const input = [
+			JSON.stringify({ file: "a.ts", lines: "1-5", text: "console.log(x)" }),
+			JSON.stringify({ file: "b.ts", lines: "10", text: "console.log(y)" }),
+		].join("\n");
+
+		const result = parseSgOutput(input);
+		assert.equal(result.matches, 2);
+		assert.equal(result.results[0].file, "a.ts");
+	});
+
+	it("skips malformed JSON lines", () => {
+		const input = ["not json", JSON.stringify({ file: "a.ts", lines: "1", text: "ok" })].join("\n");
+
+		const result = parseSgOutput(input);
+		assert.equal(result.matches, 1);
+	});
+
+	it("returns empty result for empty input", () => {
+		const result = parseSgOutput("");
+		assert.equal(result.matches, 0);
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #434

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 22s | 13.1K | 12 | deepseek-v4-flash |
| researcher | ✓ SUCCESS (after retry) | 2m 27s | 84.2K | 24 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 9s | 23.0K | 23 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 6s | 54.1K | 47 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 56s | 37.8K | 22 | deepseek-v4-flash |

**Total:** 5 agents · 8m 59s · 212.2K tokens · 128 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/434