### PR TITLE
feat(#447): Bug: context-info - tryEmit never emits due to wrong property path

### DIFF
--- a/.pi/extensions/context-info/telemetry.ts
+++ b/.pi/extensions/context-info/telemetry.ts
@@ -14,10 +14,14 @@ export function isJsonMode(): boolean {
 
 export function tryEmit(
 	ctx: { getContextUsage: () => { tokens?: number | null; contextWindow?: number } | undefined },
-	state: { emitted: boolean; lastContextWindow?: number },
+	state: {
+		emitted: boolean;
+		footerConfig: { lastContextWindow: { value: number | undefined } };
+	},
 ): void {
 	if (state.emitted) return;
-	if (!state.lastContextWindow || state.lastContextWindow <= 0) return;
+	const cw = state.footerConfig.lastContextWindow.value;
+	if (!cw || cw <= 0) return;
 	const usage = ctx.getContextUsage();
 	if (!usage || typeof usage.tokens !== "number" || usage.tokens <= 0) return;
 	state.emitted = true;
@@ -26,7 +30,7 @@ export function tryEmit(
 		JSON.stringify({
 			type: "context_info",
 			contextTokens: usage.tokens,
-			contextWindow: state.lastContextWindow,
+			contextWindow: cw,
 		}),
 	);
 }


### PR DESCRIPTION
## Summary

Fixes #447. `tryEmit()` in telemetry.ts reads `state.lastContextWindow` but `FooterState` stores it as `state.footerConfig.lastContextWindow.value`. Guard always returns early — telemetry is dead code.

## Root Cause

PR #433 refactored footer mutable state into a `FooterConfig` object (nested under `footerConfig`), but `tryEmit` was not updated to read the new path. The type signature still expected a flat `lastContextWindow?: number`.

## Fix

- Updated `tryEmit` type signature to match `FooterState` shape: `{ emitted: boolean; footerConfig: { lastContextWindow: { value: number | undefined } } }`
- Reads `state.footerConfig.lastContextWindow.value` instead of `state.lastContextWindow`
- Uses local `cw` const for both guard check and log output

## Verification

All 37 tests pass. Fix restores telemetry emission on `model_select` and `message_end` events.

## Testing

`node --experimental-strip-types --test test/context-info.test.mts` — all 37 pass.