### PR TITLE
feat(#448): Duplicate Code: session-logger - flushTurn() exact clone in renderer.ts and stats.ts

### DIFF
--- a/.pi/extensions/session-logger/per-turn.ts
+++ b/.pi/extensions/session-logger/per-turn.ts
@@ -1,0 +1,66 @@
+/**
+ * per-turn.ts — Shared per-turn token tracking for session-logger
+ *
+ * Extracted from duplicate definitions in renderer.ts and stats.ts.
+ * Both modules manipulate the same per-turn state shape; this module
+ * provides the single source of truth for flushTurn() and TurnStats.
+ */
+
+// ── Types ──
+
+export interface TurnStats {
+	turnIndex: number;
+	tokens: number;
+	cost: number;
+	toolCount: number;
+	errorCount: number;
+}
+
+export interface PerTurnState {
+	currentTurnIndex: number;
+	currentTurnTokens: number;
+	currentTurnCost: number;
+	currentTurnToolCount: number;
+	currentTurnErrorCount: number;
+	perTurnTokens: TurnStats[];
+}
+
+// ── Factory ──
+
+export function createPerTurnState(): PerTurnState {
+	return {
+		currentTurnIndex: -1,
+		currentTurnTokens: 0,
+		currentTurnCost: 0,
+		currentTurnToolCount: 0,
+		currentTurnErrorCount: 0,
+		perTurnTokens: [],
+	};
+}
+
+// ── flushTurn ──
+
+/**
+ * Flush accumulated per-turn stats into the perTurnTokens array and reset
+ * accumulators to zero.
+ *
+ * If currentTurnIndex < 0, no entry is pushed (initial state before any
+ * turn has started). Accumulators are still reset to zero in all cases.
+ *
+ * @param state - Mutable per-turn state object to flush and reset.
+ */
+export function flushTurn(state: PerTurnState): void {
+	if (state.currentTurnIndex >= 0) {
+		state.perTurnTokens.push({
+			turnIndex: state.currentTurnIndex,
+			tokens: state.currentTurnTokens,
+			cost: state.currentTurnCost,
+			toolCount: state.currentTurnToolCount,
+			errorCount: state.currentTurnErrorCount,
+		});
+	}
+	state.currentTurnTokens = 0;
+	state.currentTurnCost = 0;
+	state.currentTurnToolCount = 0;
+	state.currentTurnErrorCount = 0;
+}

--- a/.pi/extensions/session-logger/renderer.ts
+++ b/.pi/extensions/session-logger/renderer.ts
@@ -6,6 +6,8 @@
  */
 
 import { readFileSync } from "node:fs";
+import { createPerTurnState, flushTurn } from "./per-turn.ts";
+import type { PerTurnState } from "./per-turn.ts";
 
 const TRUNCATE_RESULT_LINES = 8;
 const THINKING_PREVIEW_CHARS = 120;
@@ -199,29 +201,8 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 	const toolCounts: Record<string, { calls: number; errors: number; totalDurationMs: number }> = {};
 	const fileMods: Array<{ action: string; path: string; timestamp: string; size?: number }> = [];
 
-	// Per-turn tracking
-	let currentTurnIndex = -1;
-	let currentTurnTokens = 0;
-	let currentTurnCost = 0;
-	let currentTurnToolCount = 0;
-	let currentTurnErrorCount = 0;
-	const perTurnTokens: ParsedSessionStats["perTurnTokens"] = [];
-
-	function flushTurn() {
-		if (currentTurnIndex >= 0) {
-			perTurnTokens.push({
-				turnIndex: currentTurnIndex,
-				tokens: currentTurnTokens,
-				cost: currentTurnCost,
-				toolCount: currentTurnToolCount,
-				errorCount: currentTurnErrorCount,
-			});
-		}
-		currentTurnTokens = 0;
-		currentTurnCost = 0;
-		currentTurnToolCount = 0;
-		currentTurnErrorCount = 0;
-	}
+	// Per-turn tracking — uses shared PerTurnState from per-turn.ts
+	const turnState: PerTurnState = createPerTurnState();
 
 	for (const entry of entries) {
 		if (entry.type === "model_change") {
@@ -251,8 +232,8 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 					totalTokens += usage.totalTokens ?? 0;
 					const cost = usage.cost?.total ?? 0;
 					totalCost += cost;
-					currentTurnTokens += usage.totalTokens ?? 0;
-					currentTurnCost += cost;
+					turnState.currentTurnTokens += usage.totalTokens ?? 0;
+					turnState.currentTurnCost += cost;
 				}
 
 				// File modifications from tool calls
@@ -284,20 +265,20 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 				if (!toolCounts[tn]) toolCounts[tn] = { calls: 0, errors: 0, totalDurationMs: 0 };
 				toolCounts[tn].calls++;
 				if (msg.isError) toolCounts[tn].errors++;
-				currentTurnToolCount++;
-				if (msg.isError) currentTurnErrorCount++;
+				turnState.currentTurnToolCount++;
+				if (msg.isError) turnState.currentTurnErrorCount++;
 			}
 
 			// Turn boundaries
 			if (role === "user") {
-				flushTurn();
-				currentTurnIndex++;
-			} else if (role === "assistant" && currentTurnIndex < 0) {
-				currentTurnIndex = 0;
+				flushTurn(turnState);
+				turnState.currentTurnIndex++;
+			} else if (role === "assistant" && turnState.currentTurnIndex < 0) {
+				turnState.currentTurnIndex = 0;
 			}
 		}
 	}
-	flushTurn();
+	flushTurn(turnState);
 
 	return {
 		sessionId: header.id ?? "?",
@@ -319,7 +300,7 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 		compactions,
 		toolStats: toolCounts,
 		fileModifications: fileMods,
-		perTurnTokens,
+		perTurnTokens: turnState.perTurnTokens,
 	};
 }
 

--- a/.pi/extensions/session-logger/stats.ts
+++ b/.pi/extensions/session-logger/stats.ts
@@ -1,4 +1,8 @@
 import type { Usage } from "@earendil-works/pi-ai";
+import { createPerTurnState, flushTurn } from "./per-turn.ts";
+import type { TurnStats, PerTurnState } from "./per-turn.ts";
+
+export type { TurnStats } from "./per-turn.ts";
 
 export interface ToolExecution {
 	toolCallId: string;
@@ -7,14 +11,6 @@ export interface ToolExecution {
 	endTime: number | null;
 	isError: boolean;
 	resultSize: number;
-}
-
-export interface TurnStats {
-	turnIndex: number;
-	tokens: number;
-	cost: number;
-	toolCount: number;
-	errorCount: number;
 }
 
 export interface StatsSnapshot {
@@ -84,7 +80,6 @@ export function createSessionStats(): SessionStats {
 	let thinkingChanges: Array<{ time: string; level: string }> = [];
 	let compactionCount = 0;
 	let toolExecutions: ToolExecution[] = [];
-	let perTurnTokens: TurnStats[] = [];
 	let fileModifications: Array<{
 		action: "read" | "write" | "edit";
 		path: string;
@@ -92,31 +87,11 @@ export function createSessionStats(): SessionStats {
 		size?: number;
 	}> = [];
 
-	// Current turn tracking
-	let currentTurnIndex = -1;
-	let currentTurnTokens = 0;
-	let currentTurnCost = 0;
-	let currentTurnToolCount = 0;
-	let currentTurnErrorCount = 0;
+	// Current turn tracking — uses shared PerTurnState from per-turn.ts
+	const turnState: PerTurnState = createPerTurnState();
 
 	// Track tool call IDs to execution objects
 	const pendingTools: Map<string, ToolExecution> = new Map();
-
-	function flushTurn() {
-		if (currentTurnIndex >= 0) {
-			perTurnTokens.push({
-				turnIndex: currentTurnIndex,
-				tokens: currentTurnTokens,
-				cost: currentTurnCost,
-				toolCount: currentTurnToolCount,
-				errorCount: currentTurnErrorCount,
-			});
-		}
-		currentTurnTokens = 0;
-		currentTurnCost = 0;
-		currentTurnToolCount = 0;
-		currentTurnErrorCount = 0;
-	}
 
 	return {
 		addUsage(usage: Usage) {
@@ -134,8 +109,8 @@ export function createSessionStats(): SessionStats {
 			totalCost += cost;
 
 			// Also track per-turn
-			currentTurnTokens += input + output + cacheRead + cacheWrite;
-			currentTurnCost += cost;
+			turnState.currentTurnTokens += input + output + cacheRead + cacheWrite;
+			turnState.currentTurnCost += cost;
 		},
 
 		seedStats(sm: { getEntries(): any[] }) {
@@ -165,22 +140,24 @@ export function createSessionStats(): SessionStats {
 			thinkingChanges = [];
 			compactionCount = 0;
 			toolExecutions = [];
-			perTurnTokens = [];
 			fileModifications = [];
-			currentTurnIndex = -1;
-			currentTurnTokens = 0;
-			currentTurnCost = 0;
-			currentTurnToolCount = 0;
-			currentTurnErrorCount = 0;
+			// Reset per-turn state via factory
+			const fresh = createPerTurnState();
+			turnState.currentTurnIndex = fresh.currentTurnIndex;
+			turnState.currentTurnTokens = fresh.currentTurnTokens;
+			turnState.currentTurnCost = fresh.currentTurnCost;
+			turnState.currentTurnToolCount = fresh.currentTurnToolCount;
+			turnState.currentTurnErrorCount = fresh.currentTurnErrorCount;
+			turnState.perTurnTokens.length = 0;
 			pendingTools.clear();
 		},
 
 		getSnapshot(): StatsSnapshot {
 			// Flush current turn if there's one open
-			if (currentTurnIndex >= 0 && currentTurnTokens > 0) {
-				const last = perTurnTokens[perTurnTokens.length - 1];
-				if (!last || last.turnIndex !== currentTurnIndex) {
-					flushTurn();
+			if (turnState.currentTurnIndex >= 0 && turnState.currentTurnTokens > 0) {
+				const last = turnState.perTurnTokens[turnState.perTurnTokens.length - 1];
+				if (!last || last.turnIndex !== turnState.currentTurnIndex) {
+					flushTurn(turnState);
 				}
 			}
 			return {
@@ -193,7 +170,7 @@ export function createSessionStats(): SessionStats {
 				thinkingChanges: [...thinkingChanges],
 				compactionCount,
 				toolExecutions: [...toolExecutions],
-				perTurnTokens: [...perTurnTokens],
+				perTurnTokens: [...turnState.perTurnTokens],
 				fileModifications: [...fileModifications],
 			};
 		},
@@ -234,18 +211,18 @@ export function createSessionStats(): SessionStats {
 				exec.resultSize = resultSize;
 				pendingTools.delete(toolCallId);
 			}
-			currentTurnToolCount++;
-			if (isError) currentTurnErrorCount++;
+			turnState.currentTurnToolCount++;
+			if (isError) turnState.currentTurnErrorCount++;
 		},
 
 		recordTurnStart(turnIndex: number) {
-			flushTurn();
-			currentTurnIndex = turnIndex;
+			flushTurn(turnState);
+			turnState.currentTurnIndex = turnIndex;
 		},
 
 		recordTurnEnd() {
-			flushTurn();
-			currentTurnIndex = -1;
+			flushTurn(turnState);
+			turnState.currentTurnIndex = -1;
 		},
 
 		recordFileModification(action: "read" | "write" | "edit", path: string, size?: number) {

--- a/test/per-turn.test.mts
+++ b/test/per-turn.test.mts
@@ -1,0 +1,167 @@
+/**
+ * Tests for per-turn.ts — extracted flushTurn() shared function
+ *
+ * Uses Node built-in test runner. Run with:
+ *   node --experimental-strip-types --test test/per-turn.test.mts
+ *
+ * These tests validate the extracted flushTurn function works correctly
+ * on a PerTurnState object, independent of its consumers.
+ */
+
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { createPerTurnState, flushTurn } from "../.pi/extensions/session-logger/per-turn.ts";
+
+// ---------------------------------------------------------------------------
+// flushTurn() — extracted shared function unit tests
+// ---------------------------------------------------------------------------
+
+describe("flushTurn() — extracted shared function", () => {
+	it("pushes entry and resets accumulators when turnIndex >= 0 with non-zero values", () => {
+		const state = createPerTurnState();
+		state.currentTurnIndex = 0;
+		state.currentTurnTokens = 100;
+		state.currentTurnCost = 0.005;
+		state.currentTurnToolCount = 3;
+		state.currentTurnErrorCount = 1;
+
+		flushTurn(state);
+
+		assert.strictEqual(state.perTurnTokens.length, 1);
+		assert.deepStrictEqual(state.perTurnTokens[0], {
+			turnIndex: 0,
+			tokens: 100,
+			cost: 0.005,
+			toolCount: 3,
+			errorCount: 1,
+		});
+		assert.strictEqual(state.currentTurnTokens, 0);
+		assert.strictEqual(state.currentTurnCost, 0);
+		assert.strictEqual(state.currentTurnToolCount, 0);
+		assert.strictEqual(state.currentTurnErrorCount, 0);
+		// currentTurnIndex is NOT reset by flushTurn
+		assert.strictEqual(state.currentTurnIndex, 0);
+	});
+
+	it("does not push entry when turnIndex is -1 but still resets accumulators", () => {
+		const state = createPerTurnState();
+		state.currentTurnIndex = -1;
+		state.currentTurnTokens = 100;
+		state.currentTurnCost = 0.005;
+		state.currentTurnToolCount = 2;
+		state.currentTurnErrorCount = 1;
+
+		flushTurn(state);
+
+		assert.strictEqual(state.perTurnTokens.length, 0);
+		assert.strictEqual(state.currentTurnTokens, 0);
+		assert.strictEqual(state.currentTurnCost, 0);
+		assert.strictEqual(state.currentTurnToolCount, 0);
+		assert.strictEqual(state.currentTurnErrorCount, 0);
+	});
+
+	it("pushes entry with zeros when turnIndex >= 0 but all accumulators are zero", () => {
+		const state = createPerTurnState();
+		state.currentTurnIndex = 0;
+
+		flushTurn(state);
+
+		assert.strictEqual(state.perTurnTokens.length, 1);
+		assert.deepStrictEqual(state.perTurnTokens[0], {
+			turnIndex: 0,
+			tokens: 0,
+			cost: 0,
+			toolCount: 0,
+			errorCount: 0,
+		});
+		assert.strictEqual(state.currentTurnTokens, 0);
+		assert.strictEqual(state.currentTurnCost, 0);
+		assert.strictEqual(state.currentTurnToolCount, 0);
+		assert.strictEqual(state.currentTurnErrorCount, 0);
+	});
+
+	it("two consecutive calls: first pushes entry then resets, second pushes all-zero entry", () => {
+		const state = createPerTurnState();
+		state.currentTurnIndex = 0;
+		state.currentTurnTokens = 200;
+		state.currentTurnCost = 0.01;
+		state.currentTurnToolCount = 5;
+		state.currentTurnErrorCount = 2;
+
+		flushTurn(state);
+		assert.strictEqual(state.perTurnTokens.length, 1);
+		assert.strictEqual(state.currentTurnTokens, 0);
+
+		flushTurn(state);
+		assert.strictEqual(state.perTurnTokens.length, 2);
+		assert.deepStrictEqual(state.perTurnTokens[1], {
+			turnIndex: 0,
+			tokens: 0,
+			cost: 0,
+			toolCount: 0,
+			errorCount: 0,
+		});
+	});
+
+	it("different turn indices across calls produce correct entries", () => {
+		const state = createPerTurnState();
+
+		state.currentTurnIndex = 0;
+		state.currentTurnTokens = 150;
+		flushTurn(state);
+
+		state.currentTurnIndex = 1;
+		state.currentTurnTokens = 250;
+		flushTurn(state);
+
+		state.currentTurnIndex = 2;
+		state.currentTurnTokens = 350;
+		flushTurn(state);
+
+		assert.strictEqual(state.perTurnTokens.length, 3);
+		assert.strictEqual(state.perTurnTokens[0].turnIndex, 0);
+		assert.strictEqual(state.perTurnTokens[0].tokens, 150);
+		assert.strictEqual(state.perTurnTokens[1].turnIndex, 1);
+		assert.strictEqual(state.perTurnTokens[1].tokens, 250);
+		assert.strictEqual(state.perTurnTokens[2].turnIndex, 2);
+		assert.strictEqual(state.perTurnTokens[2].tokens, 350);
+	});
+
+	it("perTurnTokens preserves previously pushed entries across calls (no data loss)", () => {
+		const state = createPerTurnState();
+
+		state.currentTurnIndex = 0;
+		state.currentTurnTokens = 100;
+		flushTurn(state);
+
+		state.currentTurnIndex = 1;
+		state.currentTurnTokens = 200;
+		flushTurn(state);
+
+		assert.strictEqual(state.perTurnTokens.length, 2);
+		assert.deepStrictEqual(state.perTurnTokens[0], {
+			turnIndex: 0,
+			tokens: 100,
+			cost: 0,
+			toolCount: 0,
+			errorCount: 0,
+		});
+		assert.deepStrictEqual(state.perTurnTokens[1], {
+			turnIndex: 1,
+			tokens: 200,
+			cost: 0,
+			toolCount: 0,
+			errorCount: 0,
+		});
+	});
+
+	it("flushTurn does not affect turnIndex (caller manages it)", () => {
+		const state = createPerTurnState();
+		state.currentTurnIndex = 42;
+		state.currentTurnTokens = 99;
+
+		flushTurn(state);
+
+		assert.strictEqual(state.currentTurnIndex, 42, "flushTurn should not reset turnIndex");
+	});
+});

--- a/test/session-logger-renderer.test.mts
+++ b/test/session-logger-renderer.test.mts
@@ -10,7 +10,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, it, beforeEach, afterEach } from "node:test";
-import { renderSessionToMarkdown } from "../.pi/extensions/session-logger/renderer.ts";
+import {
+	renderSessionToMarkdown,
+	parseSessionStats,
+} from "../.pi/extensions/session-logger/renderer.ts";
 
 // ---------------------------------------------------------------------------
 // renderSessionToMarkdown — supervisor custom entry rendering
@@ -410,5 +413,235 @@ describe("renderSessionToMarkdown — existing custom message handling (no regre
 		fs.writeFileSync(filepath, "   \n  \n  ", "utf-8");
 		const md = renderSessionToMarkdown(filepath);
 		assert.strictEqual(md, "*Empty session*");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// parseSessionStats — perTurnTokens characterization (migration safety)
+// ---------------------------------------------------------------------------
+
+describe("parseSessionStats — perTurnTokens characterization", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-logger-perturn-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeJsonl(entries: Record<string, unknown>[]): string {
+		const filepath = path.join(tmpDir, "test-session.jsonl");
+		const header = {
+			type: "session",
+			id: "test-session-perturn",
+			timestamp: "2025-06-01T10:00:00Z",
+			cwd: "/tmp",
+			version: 1,
+		};
+		const lines = [header, ...entries].map((e) => JSON.stringify(e)).join("\n") + "\n";
+		fs.writeFileSync(filepath, lines, "utf-8");
+		return filepath;
+	}
+
+	it("returns perTurnTokens with 2 entries for 2 user turns with assistant usage", () => {
+		const filepath = writeJsonl([
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:01:00Z",
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Hello" }],
+				},
+			},
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:02:00Z",
+				message: {
+					role: "assistant",
+					usage: {
+						input: 100,
+						output: 50,
+						cacheRead: 10,
+						cacheWrite: 5,
+						totalTokens: 165,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.002 },
+					},
+					content: [{ type: "text", text: "Hi there!" }],
+				},
+			},
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:03:00Z",
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Write code" }],
+				},
+			},
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:04:00Z",
+				message: {
+					role: "assistant",
+					usage: {
+						input: 200,
+						output: 100,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 300,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.004 },
+					},
+					content: [{ type: "text", text: "Sure!" }],
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.perTurnTokens.length, 2, "should have 2 per-turn entries");
+
+		// Turn 0: first user turn + assistant usage
+		assert.strictEqual(parsed.perTurnTokens[0].turnIndex, 0);
+		assert.strictEqual(parsed.perTurnTokens[0].tokens, 165);
+		assert.strictEqual(parsed.perTurnTokens[0].cost, 0.002);
+
+		// Turn 1: second user turn + assistant usage
+		assert.strictEqual(parsed.perTurnTokens[1].turnIndex, 1);
+		assert.strictEqual(parsed.perTurnTokens[1].tokens, 300);
+		assert.strictEqual(parsed.perTurnTokens[1].cost, 0.004);
+	});
+
+	it("empty file (session header only, no messages) returns parsed stats with empty perTurnTokens", () => {
+		const filepath = path.join(tmpDir, "empty-session.jsonl");
+		const header = {
+			type: "session",
+			id: "test-empty",
+			timestamp: "2025-06-01T10:00:00Z",
+			cwd: "/tmp",
+			version: 1,
+		};
+		fs.writeFileSync(filepath, JSON.stringify(header) + "\n", "utf-8");
+
+		const parsed = parseSessionStats(filepath);
+		// Header-only is valid (1 entry), returns stats with zeroed fields
+		assert.ok(parsed, "should parse");
+		assert.ok(Array.isArray(parsed.perTurnTokens));
+		assert.strictEqual(parsed.perTurnTokens.length, 0);
+		assert.strictEqual(parsed.entryCount, 1);
+	});
+
+	it("0 user turns but an assistant message — perTurnTokens has 1 entry at turnIndex 0", () => {
+		const filepath = writeJsonl([
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:01:00Z",
+				message: {
+					role: "assistant",
+					usage: {
+						input: 50,
+						output: 25,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 75,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.001 },
+					},
+					content: [{ type: "text", text: "Hello" }],
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.perTurnTokens.length, 1, "should have 1 per-turn entry");
+		assert.strictEqual(parsed.perTurnTokens[0].turnIndex, 0);
+		assert.strictEqual(parsed.perTurnTokens[0].tokens, 75);
+		assert.strictEqual(parsed.perTurnTokens[0].cost, 0.001);
+	});
+
+	it("tool results and errors — perTurnTokens entries include toolCount and errorCount", () => {
+		const filepath = writeJsonl([
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:01:00Z",
+				message: {
+					role: "user",
+					content: [{ type: "text", text: "Run tests" }],
+				},
+			},
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:02:00Z",
+				message: {
+					role: "assistant",
+					usage: {
+						input: 50,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 50,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.0 },
+					},
+					content: [{ type: "toolCall", name: "bash", arguments: { command: "npm test" } }],
+				},
+			},
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:03:00Z",
+				message: {
+					role: "toolResult",
+					toolName: "bash",
+					isError: false,
+					content: [{ type: "text", text: "All tests passed" }],
+				},
+			},
+			{
+				type: "message",
+				timestamp: "2025-06-01T10:04:00Z",
+				message: {
+					role: "toolResult",
+					toolName: "bash",
+					isError: true,
+					content: [{ type: "text", text: "Failed" }],
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.perTurnTokens.length, 1, "should have 1 per-turn entry");
+		assert.strictEqual(parsed.perTurnTokens[0].toolCount, 2, "should count 2 tool results");
+		assert.strictEqual(parsed.perTurnTokens[0].errorCount, 1, "should count 1 error");
+	});
+
+	it("no messages — perTurnTokens is empty array", () => {
+		const filepath = path.join(tmpDir, "no-messages.jsonl");
+		const header = {
+			type: "session",
+			id: "test-no-msgs",
+			timestamp: "2025-06-01T10:00:00Z",
+			cwd: "/tmp",
+			version: 1,
+		};
+		const someEntry = {
+			type: "model_change",
+			timestamp: "2025-06-01T10:01:00Z",
+			provider: "openai",
+			modelId: "gpt-4",
+		};
+		const lines = [JSON.stringify(header), JSON.stringify(someEntry)].join("\n") + "\n";
+		fs.writeFileSync(filepath, lines, "utf-8");
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.ok(Array.isArray(parsed.perTurnTokens));
+		assert.strictEqual(parsed.perTurnTokens.length, 0);
+	});
+
+	it("truly empty file returns null", () => {
+		const filepath = path.join(tmpDir, "truly-empty.jsonl");
+		fs.writeFileSync(filepath, "", "utf-8");
+		const parsed = parseSessionStats(filepath);
+		assert.strictEqual(parsed, null);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #448

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 42s | 37.9K | 28 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 39s | 45.1K | 17 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 1s | 30.0K | 24 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 17s | 93.3K | 62 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 6s | 45.0K | 21 | deepseek-v4-flash |

**Total:** 5 agents · 10m 45s · 251.3K tokens · 152 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/448