### PR TITLE
Fix supervisor comments for thinking-only agent output

### DIFF
--- a/.pi/extensions/supervisor/agent-stream.test.mts
+++ b/.pi/extensions/supervisor/agent-stream.test.mts
@@ -137,7 +137,7 @@ describe("processJsonLine — budget check at message_end (Phase 1)", () => {
 // ─── Phase 3: Dedup flag fix via JSON line text_end/thinking_end ────
 
 describe("processJsonLine — dedup flag fix (Phase 3)", () => {
-	it("text_end sets textPushedThisTurn=true even when liveText is empty", () => {
+	it("text_end leaves textPushedThisTurn=false when liveText is empty and no delta was pushed", () => {
 		const state = createState();
 		state.liveText = "";
 		processJsonLine(
@@ -147,11 +147,11 @@ describe("processJsonLine — dedup flag fix (Phase 3)", () => {
 			}),
 			state,
 		);
-		assert.equal(state.textPushedThisTurn, true, "flag should be set even when buffer empty");
+		assert.equal(state.textPushedThisTurn, false, "empty text_end must not block fallback capture");
 		assert.equal(state.liveText, "", "liveText should be cleared");
 	});
 
-	it("thinking_end sets thinkingPushedThisTurn=true even when liveThinking is empty", () => {
+	it("thinking_end leaves thinkingPushedThisTurn=false when liveThinking is empty and no delta was pushed", () => {
 		const state = createState();
 		state.liveThinking = "";
 		processJsonLine(
@@ -161,7 +161,11 @@ describe("processJsonLine — dedup flag fix (Phase 3)", () => {
 			}),
 			state,
 		);
-		assert.equal(state.thinkingPushedThisTurn, true, "flag should be set even when buffer empty");
+		assert.equal(
+			state.thinkingPushedThisTurn,
+			false,
+			"empty thinking_end must not block fallback capture",
+		);
 		assert.equal(state.liveThinking, "", "liveThinking should be cleared");
 	});
 

--- a/.pi/extensions/supervisor/event-adapter.test.mts
+++ b/.pi/extensions/supervisor/event-adapter.test.mts
@@ -480,13 +480,14 @@ describe("processNormalizedEvent", () => {
 	it("handles thinking_delta", () => {
 		const state = createState();
 		const result = processNormalizedEvent({ kind: "thinking_delta", delta: "step\n" }, state);
+		assert.equal(state.thinkingPushedThisTurn, true);
 		assert.equal(result.flush, true);
 	});
 
-	it("handles thinking_end", () => {
+	it("handles thinking_end without prior delta", () => {
 		const state = createState();
 		const result = processNormalizedEvent({ kind: "thinking_end" }, state);
-		assert.equal(state.thinkingPushedThisTurn, true);
+		assert.equal(state.thinkingPushedThisTurn, false);
 		assert.equal(result.flush, true);
 	});
 
@@ -500,13 +501,14 @@ describe("processNormalizedEvent", () => {
 	it("handles text_delta", () => {
 		const state = createState();
 		const result = processNormalizedEvent({ kind: "text_delta", delta: "hello\n" }, state);
+		assert.equal(state.textPushedThisTurn, true);
 		assert.equal(result.flush, true);
 	});
 
-	it("handles text_end", () => {
+	it("handles text_end without prior delta", () => {
 		const state = createState();
 		const result = processNormalizedEvent({ kind: "text_end" }, state);
-		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(state.textPushedThisTurn, false);
 		assert.equal(result.flush, true);
 	});
 

--- a/.pi/extensions/supervisor/event-handlers.ts
+++ b/.pi/extensions/supervisor/event-handlers.ts
@@ -82,7 +82,10 @@ export function handleThinkingDelta(
 		while ((nlIdx = state.liveThinking.indexOf("\n")) !== -1) {
 			const line = state.liveThinking.slice(0, nlIdx);
 			state.liveThinking = state.liveThinking.slice(nlIdx + 1);
-			if (line.trim()) pushLog(state, `💭 ${line}`);
+			if (line.trim()) {
+				pushLog(state, `💭 ${line}`);
+				state.thinkingPushedThisTurn = true;
+			}
 		}
 		return { flush: true, workingChange: prevPhase !== "thinking" };
 	}
@@ -137,7 +140,10 @@ export function handleTextDelta(
 		while ((nlIdx = state.liveText.indexOf("\n")) !== -1) {
 			const line = state.liveText.slice(0, nlIdx);
 			state.liveText = state.liveText.slice(nlIdx + 1);
-			if (line.trim()) pushLog(state, line);
+			if (line.trim()) {
+				pushLog(state, line);
+				state.textPushedThisTurn = true;
+			}
 		}
 		return { flush: true, workingChange: prevPhase !== "text" };
 	}

--- a/.pi/extensions/supervisor/issue-440.test.mts
+++ b/.pi/extensions/supervisor/issue-440.test.mts
@@ -1,0 +1,157 @@
+// ─── Regression: GitHub issue #440 ────────────────────────────────
+// thinking:high models may emit zero text/thinking deltas. Full JSON arrives
+// in message_update.done / message_end thinking blocks and still must produce
+// a GitHub issue comment.
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { processSessionEvent } from "./session-events.ts";
+import { buildAgentRunResult } from "./session-result.ts";
+import { extractAgentCommentBody } from "./github/comment.ts";
+import { handlePostAgentSuccess } from "./pipeline/stages.ts";
+import type { AgentRunState, FilteredIssueData, SupervisorConfig } from "./types.ts";
+
+interface ExecCall {
+	cmd: string;
+	args: string[];
+	opts: Record<string, unknown>;
+}
+
+function createState(overrides?: Partial<AgentRunState>): AgentRunState {
+	return {
+		currentTool: undefined,
+		currentToolArgs: undefined,
+		toolCount: 0,
+		tokenCount: 0,
+		fullLog: [],
+		liveThinking: "",
+		liveText: "",
+		textOutputLines: [],
+		thinkingOutputLines: [],
+		lastToolName: undefined,
+		phase: "idle",
+		startedAt: Date.now(),
+		contextTokens: undefined,
+		contextWindow: undefined,
+		contextInfoReceived: false,
+		thinkingPushedThisTurn: false,
+		textPushedThisTurn: false,
+		budgetExceeded: false,
+		budgetExceededReason: undefined,
+		maxToolCalls: 0,
+		agentTokenBudget: 0,
+		...overrides,
+	};
+}
+
+function createMockPi(calls: ExecCall[]): ExtensionAPI {
+	return {
+		exec: ((cmd: string, args: string[], opts?: Record<string, unknown>) => {
+			calls.push({ cmd, args: args || [], opts: opts || {} });
+			return Promise.resolve({ code: 0, stdout: "", stderr: "" });
+		}) as ExtensionAPI["exec"],
+		registerCommand: (() => {}) as ExtensionAPI["registerCommand"],
+		sendMessage: (() => {}) as ExtensionAPI["sendMessage"],
+	} as ExtensionAPI;
+}
+
+function createMockCtx(): ExtensionCommandContext {
+	return {
+		cwd: "/repo",
+		ui: {
+			notify: () => {},
+			setStatus: () => {},
+			theme: { fg: (_style: string, text: string) => text },
+		},
+	} as unknown as ExtensionCommandContext;
+}
+
+const config: SupervisorConfig = {
+	repo: "owner/repo",
+	projectNumber: 1,
+	statusField: "Status",
+	statusMapping: { Architecture: "architect" },
+	codeowners: ["owner"],
+	defaultBranch: "main",
+	remote: "origin",
+};
+
+const filteredData: FilteredIssueData = { body: "", comments: [] };
+
+describe("issue #440 — thinking-only architect output posts comment", () => {
+	it("captures done/message_end thinking JSON and passes it to postIssueComment", async () => {
+		const state = createState();
+		const commentBody = "## Architecture\nThinking-only architecture comment";
+		const finalJson = JSON.stringify(
+			{
+				action: "COMPLETE",
+				agentName: "architect",
+				commentBody,
+				summary: "Architecture ready",
+			},
+			null,
+			2,
+		);
+		const message = {
+			role: "assistant",
+			content: [{ type: "thinking", thinking: finalJson }],
+			usage: { totalTokens: 1234 },
+		};
+
+		// SDK path for thinking:high: no text_delta/thinking_delta events, full
+		// response arrives in message_update.done and then message_end.
+		processSessionEvent(
+			{
+				type: "message_update",
+				assistantMessageEvent: { type: "done" },
+				message,
+			},
+			state,
+		);
+		processSessionEvent({ type: "message_end", message }, state);
+
+		assert.equal(state.textOutputLines.length, 0, "thinking-only output has no text blocks");
+		assert.equal(state.thinkingOutputLines.length, 1, "thinking JSON captured once");
+		assert.ok(
+			state.fullLog.some((line) => line.startsWith("💭")),
+			"fullLog has thinking lines",
+		);
+
+		const result = buildAgentRunResult(state, "architect", true, 1000, [message]);
+		assert.equal(result.textOnly, "", "textOnly stays empty for thinking-only output");
+		assert.ok(result.textOutput.includes("💭"), "textOutput includes prefixed thinking log");
+		assert.ok(result.output.includes("[ASSISTANT THINKING]"), "raw output includes thinking block");
+		assert.equal(extractAgentCommentBody(result.textOutput), commentBody);
+		assert.equal(extractAgentCommentBody(result.output), commentBody);
+		assert.equal(extractAgentCommentBody(result.thinkingOutput || ""), commentBody);
+
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(calls);
+		const success = await handlePostAgentSuccess(
+			pi,
+			createMockCtx(),
+			result,
+			"architect",
+			440,
+			config,
+			filteredData,
+			undefined,
+			undefined,
+			"Bug: supervisor - architect comment not posted",
+		);
+
+		assert.equal(success, true);
+		const commentCall = calls.find((call) => call.cmd === "gh");
+		assert.ok(commentCall, "postIssueComment should call gh");
+		assert.deepEqual(commentCall.args, [
+			"issue",
+			"comment",
+			"440",
+			"--repo",
+			"owner/repo",
+			"--body",
+			commentBody,
+		]);
+	});
+});

--- a/.pi/extensions/supervisor/session-events.test.mts
+++ b/.pi/extensions/supervisor/session-events.test.mts
@@ -36,31 +36,35 @@ function createState(overrides?: Partial<AgentRunState>): AgentRunState {
 	};
 }
 
-// ─── Phase 1: text_end/thinking_end dedup flag fix (flag outside if) ──────
+// ─── Phase 1: text_end/thinking_end dedup flag fix ────────────────
 
 describe("text_end and thinking_end — dedup flag fix (Phase 3)", () => {
-	it("text_end sets textPushedThisTurn=true even when liveText is empty", () => {
+	it("text_end leaves textPushedThisTurn=false when liveText is empty and no delta was pushed", () => {
 		const state = createState();
-		state.liveText = ""; // empty — all content streamed as complete lines
+		state.liveText = "";
 		const ev = {
 			type: "message_update",
 			assistantMessageEvent: { type: "text_end" },
 		};
 		processSessionEvent(ev, state);
-		assert.equal(state.textPushedThisTurn, true, "flag should be set even when buffer empty");
+		assert.equal(state.textPushedThisTurn, false, "empty text_end must not block fallback capture");
 		assert.equal(state.liveText, "", "liveText should be cleared");
 		assert.equal(state.textOutputLines.length, 0, "no text output (buffer was empty)");
 	});
 
-	it("thinking_end sets thinkingPushedThisTurn=true even when liveThinking is empty", () => {
+	it("thinking_end leaves thinkingPushedThisTurn=false when liveThinking is empty and no delta was pushed", () => {
 		const state = createState();
-		state.liveThinking = ""; // empty
+		state.liveThinking = "";
 		const ev = {
 			type: "message_update",
 			assistantMessageEvent: { type: "thinking_end" },
 		};
 		processSessionEvent(ev, state);
-		assert.equal(state.thinkingPushedThisTurn, true, "flag should be set even when buffer empty");
+		assert.equal(
+			state.thinkingPushedThisTurn,
+			false,
+			"empty thinking_end must not block fallback capture",
+		);
 		assert.equal(state.liveThinking, "", "liveThinking should be cleared");
 	});
 
@@ -88,9 +92,9 @@ describe("text_end and thinking_end — dedup flag fix (Phase 3)", () => {
 		assert.ok(state.thinkingOutputLines[0]?.includes("some thinking"));
 	});
 
-	it("empty buffer text_end + message_end does not produce duplicate push", () => {
+	it("empty buffer text_end + message_end captures fallback content", () => {
 		const state = createState();
-		// text_end with empty buffer
+		// text_end with empty buffer and no prior text_delta
 		processSessionEvent(
 			{
 				type: "message_update",
@@ -98,29 +102,28 @@ describe("text_end and thinking_end — dedup flag fix (Phase 3)", () => {
 			},
 			state,
 		);
-		assert.equal(state.textPushedThisTurn, true);
+		assert.equal(state.textPushedThisTurn, false);
 
-		// message_end follows
+		// message_end follows with full content from provider
 		processSessionEvent(
 			{
 				type: "message_end",
 				message: {
 					role: "assistant",
-					content: [{ type: "text", text: "streamed content" }],
+					content: [{ type: "text", text: "fallback content" }],
 				},
 			},
 			state,
 		);
-		// textOutputLines should be empty (text_end had empty buffer, message_end
-		// should NOT push because textPushedThisTurn flag blocks it)
-		assert.equal(state.textOutputLines.length, 0, "no duplicate from empty text_end + message_end");
+		assert.equal(state.textOutputLines.length, 1, "fallback content captured");
+		assert.equal(state.textOutputLines[0], "fallback content");
 	});
 });
 
 // ─── Phase 2: Full streaming chain — no duplicate output (trigger scenario) ──
 // Reproduce exact trigger: text_delta with complete newline-delimited chunks
-// empties buffer, text_end fires with empty liveText, flag is set unconditionally,
-// message_end does NOT re-push.
+// empties buffer, delta handler marks content as pushed, and message_end
+// does NOT re-push.
 
 describe("full streaming chain — no duplicate output (Phase 2)", () => {
 	it('text_delta("Hello\\nWorld\\n") → text_end → message_end does not re-push to fullLog', () => {
@@ -150,7 +153,7 @@ describe("full streaming chain — no duplicate output (Phase 2)", () => {
 			"fullLog has 'World' once from delta handler",
 		);
 
-		// Step 2: text_end with empty buffer — flag set unconditionally
+		// Step 2: text_end with empty buffer — flag remains true from delta handler
 		processSessionEvent(
 			{
 				type: "message_update",
@@ -215,7 +218,7 @@ describe("full streaming chain — no duplicate output (Phase 2)", () => {
 			"fullLog has 'Step 2' once from delta handler",
 		);
 
-		// Step 2: thinking_end with empty buffer — flag set unconditionally
+		// Step 2: thinking_end with empty buffer — flag remains true from delta handler
 		processSessionEvent(
 			{
 				type: "message_update",


### PR DESCRIPTION
## Summary
- Capture dedup state when streamed delta handlers actually push complete lines
- Keep empty text/thinking end events from blocking done/message_end fallback capture
- Add issue #440 regression test covering thinking-only JSON through comment posting

Fixes #440

## Validation
- node --experimental-strip-types --test .pi/extensions/supervisor/agent-output.test.mts .pi/extensions/supervisor/agent-stream.test.mts .pi/extensions/supervisor/event-adapter.test.mts .pi/extensions/supervisor/event-handlers.test.mts .pi/extensions/supervisor/session-events.test.mts .pi/extensions/supervisor/session-result.test.mts .pi/extensions/supervisor/pipeline/stages.test.mts .pi/extensions/supervisor/issue-440.test.mts
- npm run tsc:extensions
- node --experimental-strip-types --test $(ls .pi/extensions/supervisor/*.test.mts .pi/extensions/supervisor/github/*.test.mts .pi/extensions/supervisor/pipeline/*.test.mts | grep -v "agent-runner-subprocess.test.mts")

Note: full supervisor suite including agent-runner-subprocess.test.mts still hits pre-existing Node v22 incompatibility: `TypeError: mock.module is not a function`.
