### PR TITLE
feat(#472): Bug: session-logger - missing waitForFile in ensureLatestLink causes dangling symlinks and test failures

### DIFF
--- a/.pi/extensions/session-logger/files.ts
+++ b/.pi/extensions/session-logger/files.ts
@@ -3,6 +3,83 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { Metadata } from "./types.js";
 
+// ---------------------------------------------------------------------------
+// waitForFile — poll for a file to appear on disk
+// ---------------------------------------------------------------------------
+
+export interface WaitForFileOptions {
+	/** Maximum time to wait in ms (default 5000) */
+	timeout?: number;
+	/** Poll interval in ms (default 50) */
+	interval?: number;
+	/** Optional AbortSignal for cancellation */
+	signal?: AbortSignal;
+}
+
+/**
+ * Poll for a file to exist on disk. Resolves immediately if the file already
+ * exists. Rejects if the parent directory doesn't exist, the path is empty,
+ * or the file doesn't appear within the timeout.
+ *
+ * Error messages for timeouts / missing parents / empty path all match the
+ * regex `/waitForFile.*not found/i` so callers can catch them uniformly.
+ */
+export async function waitForFile(filePath: string, options?: WaitForFileOptions): Promise<void> {
+	const timeout = options?.timeout ?? 5000;
+	const interval = options?.interval ?? 50;
+
+	if (!filePath) {
+		throw new Error(`waitForFile: target not found after retries: ${filePath}`);
+	}
+
+	// Validate that the parent directory exists — gives a clear error instead
+	// of a raw ENOENT from fs.symlink later.
+	const dir = path.dirname(filePath);
+	try {
+		await fs.stat(dir);
+	} catch {
+		throw new Error(`waitForFile: target not found after retries: ${filePath}`);
+	}
+
+	const start = Date.now();
+	const signal = options?.signal;
+
+	while (Date.now() - start < timeout) {
+		try {
+			await fs.stat(filePath);
+			return; // file exists
+		} catch {
+			// file doesn't exist yet — continue polling
+		}
+
+		// Wait for the interval, respecting abort signal
+		await new Promise<void>((resolve, reject) => {
+			if (signal?.aborted) {
+				reject(new DOMException("Aborted", "AbortError"));
+				return;
+			}
+			const timer = setTimeout(resolve, interval);
+			if (signal) {
+				signal.addEventListener(
+					"abort",
+					() => {
+						clearTimeout(timer);
+						reject(new DOMException("Aborted", "AbortError"));
+					},
+					{ once: true },
+				);
+			}
+		});
+	}
+
+	// Timeout — file never appeared
+	throw new Error(`waitForFile: target not found after retries: ${filePath}`);
+}
+
+// ---------------------------------------------------------------------------
+// FileOps interface
+// ---------------------------------------------------------------------------
+
 export interface FileOps {
 	ensureSymlink(sessionFile: string, sessionsDir: string): Promise<void>;
 	ensureMdSymlink(sessionDir: string, mdFile: string): Promise<void>;
@@ -13,7 +90,6 @@ export interface FileOps {
 	writeSessionReport(sessionDir: string, sessionPrefix: string, markdown: string): Promise<void>;
 }
 
-/**
 /**
  * Create a symlink at `linkDir/linkName` pointing to `targetFile`.
  *
@@ -29,6 +105,11 @@ async function ensureLatestLink(
 	targetFile: string,
 	linkName: string,
 ): Promise<void> {
+	// Wait for the target file to exist before creating a symlink — prevents
+	// dangling symlinks when the file hasn't been written yet (race between
+	// session_start handler and the subprocess writing the JSONL).
+	await waitForFile(targetFile);
+
 	const latestLink = path.join(linkDir, linkName);
 	const linkTarget = path.relative(linkDir, targetFile);
 	const rand = crypto.randomBytes(4).toString("hex");

--- a/.pi/extensions/session-logger/test/session-logger-waitForFile.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-waitForFile.test.mts
@@ -1,0 +1,121 @@
+/**
+ * Domain / unit tests for waitForFile — polling for a file to appear on disk.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/session-logger/test/session-logger-waitForFile.test.mts
+ */
+
+import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { waitForFile } from "../files.ts";
+
+// ---------------------------------------------------------------------------
+// waitForFile — domain / unit tests
+// ---------------------------------------------------------------------------
+
+describe("waitForFile", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "waitForFile-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("resolves immediately when target already exists", async () => {
+		const filePath = path.join(tmpDir, "existing.txt");
+		fs.writeFileSync(filePath, "hello");
+
+		await waitForFile(filePath);
+		// If we get here, it resolved — no assertion needed beyond that
+	});
+
+	it("waits for file created after a delay (100ms)", async () => {
+		const filePath = path.join(tmpDir, "delayed.txt");
+
+		const writePromise = new Promise<void>((resolve) => {
+			setTimeout(() => {
+				fs.writeFileSync(filePath, "done");
+				resolve();
+			}, 100);
+		});
+
+		await Promise.all([waitForFile(filePath, { timeout: 3000 }), writePromise]);
+		// If we get here, waitForFile resolved after the file appeared
+	});
+
+	it("rejects after timeout when target never appears", async () => {
+		const filePath = path.join(tmpDir, "never-exists.txt");
+
+		await assert.rejects(
+			() => waitForFile(filePath, { timeout: 200, interval: 20 }),
+			/waitForFile.*not found/i,
+		);
+	});
+
+	it("rejects quickly with zero timeout and missing target", async () => {
+		const filePath = path.join(tmpDir, "no-file.txt");
+
+		await assert.rejects(
+			() => waitForFile(filePath, { timeout: 0, interval: 10 }),
+			/waitForFile.*not found/i,
+		);
+	});
+
+	it("rejects when parent directory does not exist", async () => {
+		const filePath = path.join(tmpDir, "nonexistent-dir", "file.txt");
+
+		await assert.rejects(() => waitForFile(filePath, { timeout: 100 }), /waitForFile.*not found/i);
+	});
+
+	it("rejects with empty-string path", async () => {
+		await assert.rejects(() => waitForFile(""), /waitForFile.*not found/i);
+	});
+
+	it("rejects with AbortError when signal is aborted before file appears", async () => {
+		const filePath = path.join(tmpDir, "aborted.txt");
+		const ac = new AbortController();
+
+		// Abort before calling waitForFile
+		ac.abort();
+
+		await assert.rejects(
+			() => waitForFile(filePath, { signal: ac.signal, timeout: 5000 }),
+			(err: unknown) => {
+				// Should be an AbortError (DOMException with name "AbortError")
+				return err instanceof DOMException && err.name === "AbortError";
+			},
+		);
+	});
+
+	it("rejects with AbortError when signal fires during polling", async () => {
+		const filePath = path.join(tmpDir, "abort-while-polling.txt");
+		const ac = new AbortController();
+
+		const waitPromise = waitForFile(filePath, { signal: ac.signal, timeout: 5000 });
+
+		// Abort after 50ms — file never created, so waitForFile is still polling
+		setTimeout(() => ac.abort(), 50);
+
+		await assert.rejects(
+			() => waitPromise,
+			(err: unknown) => {
+				return err instanceof DOMException && err.name === "AbortError";
+			},
+		);
+	});
+
+	it("resolves quickly when file appears before first poll", async () => {
+		const filePath = path.join(tmpDir, "immediate.txt");
+		fs.writeFileSync(filePath, "content");
+
+		// Very short timeout — file already exists, so should resolve
+		// before the timeout fires
+		await waitForFile(filePath, { timeout: 1 });
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #472

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 43s | 26.1K | 13 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 18s | 99.9K | 9 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 43s | 29.8K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 45s | 38.7K | 31 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 30s | 37.6K | 20 | deepseek-v4-flash |

**Total:** 5 agents · 7m 59s · 232.0K tokens · 91 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/472