### PR TITLE
feat(#475): Bug: caveman - resolveSessionLevel uses first match instead of last, wrong level restored on resume

### DIFF
--- a/.pi/extensions/caveman/session.ts
+++ b/.pi/extensions/caveman/session.ts
@@ -48,7 +48,9 @@ export function resolveSessionLevel(
 	sessionEntries: SessionEntry[],
 ): ResolvedSessionLevel {
 	// Check for session-level override first (resuming a session)
-	for (const entry of sessionEntries) {
+	// Iterate backward to find the MOST RECENT caveman-level entry (fixes bug #475)
+	for (let i = sessionEntries.length - 1; i >= 0; i--) {
+		const entry = sessionEntries[i];
 		if (entry.type === "custom" && entry.customType === "caveman-level") {
 			const data = entry.data;
 			if (

--- a/.pi/extensions/caveman/test/session.test.ts
+++ b/.pi/extensions/caveman/test/session.test.ts
@@ -78,6 +78,58 @@ describe("resolveSessionLevel (pure function)", () => {
 		assert.equal(result.level, "full");
 		assert.equal(result.shouldAppendEntry, true);
 	});
+
+	// ---------------------------------------------------------------------------
+	// Bug #475: resolveSessionLevel must return LAST matching entry, not first
+	// ---------------------------------------------------------------------------
+
+	it("multiple level changes: lite→full→ultra → returns ultra (last)", () => {
+		const result = resolveSessionLevel(config({ defaultLevel: "lite" }), [
+			entry("lite"),
+			entry("full"),
+			entry("ultra"),
+		]);
+		assert.equal(result.level, "ultra");
+		assert.equal(result.shouldAppendEntry, false);
+	});
+
+	it("multiple level changes: lite→full → returns full (last)", () => {
+		const result = resolveSessionLevel(config({ defaultLevel: "lite" }), [
+			entry("lite"),
+			entry("full"),
+		]);
+		assert.equal(result.level, "full");
+		assert.equal(result.shouldAppendEntry, false);
+	});
+
+	it("multiple level changes: full→ultra→off → returns off (last)", () => {
+		const result = resolveSessionLevel(config({ defaultLevel: "full" }), [
+			entry("full"),
+			entry("ultra"),
+			entry("off"),
+		]);
+		assert.equal(result.level, "off");
+		assert.equal(result.shouldAppendEntry, false);
+	});
+
+	it("interleaved: non-caveman entries between level changes → returns last caveman-level", () => {
+		const result = resolveSessionLevel(config({ defaultLevel: "lite" }), [
+			{ type: "custom", customType: "other-type", data: { foo: "bar" } },
+			entry("lite"),
+			{ type: "custom", customType: "other-type", data: { baz: "qux" } },
+			entry("full"),
+			{ type: "custom", customType: "text-message", data: { text: "some message" } },
+			entry("ultra"),
+		]);
+		assert.equal(result.level, "ultra");
+		assert.equal(result.shouldAppendEntry, false);
+	});
+
+	it("single entry: resume with one caveman-level entry → returns that level", () => {
+		const result = resolveSessionLevel(config({ defaultLevel: "lite" }), [entry("full")]);
+		assert.equal(result.level, "full");
+		assert.equal(result.shouldAppendEntry, false);
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #475

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 2m 1s | 54.1K | 39 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 56s | 26.5K | 20 | deepseek-v4-flash |

**Total:** 2 agents · 2m 57s · 80.6K tokens · 59 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/475