### PR TITLE
feat(#477): Dead Code: crawl4ai - duplicate ExecResult/ExecFn interfaces across 3 files

### DIFF
--- a/.pi/extensions/crawl4ai/backends.ts
+++ b/.pi/extensions/crawl4ai/backends.ts
@@ -11,7 +11,7 @@
 import { runCrawl4aiScript } from "./executor.ts";
 import { CRAWL4AI_SCRIPT } from "./python-script.ts";
 import { ensurePythonVenv, ensureChromiumDeps } from "./venv-setup.ts";
-import type { OnUpdateCallback } from "./types.ts";
+import type { ExecResult, ExecFn, OnUpdateCallback } from "./types.ts";
 import type { VenvCache } from "./venv-setup.ts";
 import { apifyCrawl } from "./apify-crawl.ts";
 import { directFetchCrawl } from "./direct-fetch.ts";
@@ -38,22 +38,6 @@ export interface CrawlBackend {
 		signal?: AbortSignal,
 		onUpdate?: OnUpdateCallback,
 	): Promise<string | null>;
-}
-
-// ── ExecFn type (matches executor.ts and venv-setup.ts) ──
-
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-interface ExecFn {
-	(
-		cmd: string,
-		args: string[],
-		opts?: { timeout?: number; signal?: AbortSignal },
-	): Promise<ExecResult>;
 }
 
 // ── Local crawl4ai backend ──

--- a/.pi/extensions/crawl4ai/executor.ts
+++ b/.pi/extensions/crawl4ai/executor.ts
@@ -10,20 +10,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-interface ExecFn {
-	(
-		cmd: string,
-		args: string[],
-		opts?: { timeout?: number; signal?: AbortSignal },
-	): Promise<ExecResult>;
-}
+import type { ExecResult, ExecFn } from "./types.ts";
 
 /**
  * Escape a string for use as a single-quoted bash argument.

--- a/.pi/extensions/crawl4ai/test/backends.test.ts
+++ b/.pi/extensions/crawl4ai/test/backends.test.ts
@@ -6,6 +6,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it, mock } from "node:test";
+import type { ExecResult, ExecFn } from "../types.ts";
 import {
 	CrawlBackendRegistry,
 	DirectFetchBackend,
@@ -15,17 +16,7 @@ import {
 
 // ── Helpers ──
 
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-type ExecHandler = (
-	cmd: string,
-	args: string[],
-	opts?: { timeout?: number; signal?: AbortSignal },
-) => Promise<ExecResult>;
+type ExecHandler = ExecFn;
 
 function makeMockExec(): ReturnType<typeof mock.fn<ExecHandler>> {
 	return mock.fn<ExecHandler>();

--- a/.pi/extensions/crawl4ai/test/crawl4ai.test.mts
+++ b/.pi/extensions/crawl4ai/test/crawl4ai.test.mts
@@ -11,6 +11,7 @@
 
 import assert from "node:assert";
 import { describe, it, mock } from "node:test";
+import type { ExecResult, ExecFn } from "../types.ts";
 
 // ===========================================================================
 // direct-fetch.ts — htmlToMarkdown (pure function, no infra)
@@ -268,18 +269,6 @@ describe("directFetchCrawl", () => {
 // ===========================================================================
 // venv-setup.ts — ensurePythonVenv with mock exec
 // ===========================================================================
-
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-type ExecFn = (
-	cmd: string,
-	args: string[],
-	opts?: { timeout?: number; signal?: AbortSignal },
-) => Promise<ExecResult>;
 
 function lazyPaths(cwd: string) {
 	return {

--- a/.pi/extensions/crawl4ai/test/executor.test.ts
+++ b/.pi/extensions/crawl4ai/test/executor.test.ts
@@ -10,20 +10,11 @@ import { describe, it, mock } from "node:test";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { ExecResult, ExecFn } from "../types.ts";
 import { CRAWL4AI_SCRIPT } from "../python-script.ts";
 import { shSingleQuote, runCrawl4aiScript } from "../executor.ts";
 
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-type ExecHandler = (
-	cmd: string,
-	args: string[],
-	opts?: { timeout?: number; signal?: AbortSignal },
-) => Promise<ExecResult>;
+type ExecHandler = ExecFn;
 
 function makeMockExec(): ReturnType<typeof mock.fn<ExecHandler>> {
 	return mock.fn<ExecHandler>();

--- a/.pi/extensions/crawl4ai/test/types.test.ts
+++ b/.pi/extensions/crawl4ai/test/types.test.ts
@@ -1,7 +1,10 @@
 /**
- * Tests for types.ts — dead code verification
+ * Tests for types.ts — shared ExecResult/ExecFn extraction
  *
- * Validates that unused exported interfaces are removed.
+ * Validates that ExecResult and ExecFn are defined once in types.ts
+ * and imported by all consumers (no local interface copies).
+ *
+ * Layer: (D) Domain — source scanning, no I/O beyond filesystem reads.
  */
 
 import assert from "node:assert/strict";
@@ -11,15 +14,234 @@ import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const typesPath = resolve(__dirname, "types.ts");
+const extDir = resolve(__dirname, "..");
 
-describe("types.ts exports — dead code audit", () => {
-	it("should NOT export CrawlResult (dead code removed)", () => {
-		const source = readFileSync(typesPath, "utf-8");
-		// CrawlResult was dead code — exported but never imported or referenced
+/** Match import from ./types or ./types.ts */
+function hasImportFromTypes(source: string, symbols: string[]): boolean {
+	// Pattern 1: import type { ..., ExecResult, ..., ExecFn, ... } from "./types(.ts)"
+	const typePattern = new RegExp(
+		`import\\s+type\\s*\\{[^}]*\\b${symbols[0]}\\b[^}]*\\b${symbols[1]}\\b[^}]*\\}\\s*from\\s+["']\\.\\/types(?:\\.ts)?["']`,
+	);
+	if (typePattern.test(source)) return true;
+
+	// Pattern 2: import { ..., type ExecResult, ..., type ExecFn, ... } from "./types(.ts)"
+	const mixedPattern = new RegExp(
+		`import\\s+\\{[^}]*\\btype\\s+${symbols[0]}\\b[^}]*\\btype\\s+${symbols[1]}\\b[^}]*\\}\\s*from\\s+["']\\.\\/types(?:\\.ts)?["']`,
+	);
+	if (mixedPattern.test(source)) return true;
+
+	// Pattern 3: import type { ExecResult, ExecFn } from "../types(.ts)" (for test files)
+	const testPattern = new RegExp(
+		`import\\s+type\\s*\\{[^}]*\\b${symbols[0]}\\b[^}]*\\b${symbols[1]}\\b[^}]*\\}\\s*from\\s+["']\\.\\.\\/types(?:\\.ts)?["']`,
+	);
+	return testPattern.test(source);
+}
+
+/** Assert no interface definition (with body) for the given name */
+function assertNoLocalInterface(source: string, name: string, fileLabel: string): void {
+	assert.ok(
+		!new RegExp(`interface\\s+${name}\\s*\\{`).test(source),
+		`${fileLabel} should NOT have a local interface ${name}`,
+	);
+}
+
+/** Assert no full type definition (type X = ... with function signature) for the given name.
+ *  Thin type aliases (type Foo = Bar) are allowed — only full definitions are flagged. */
+function assertNoLocalFullType(source: string, name: string, fileLabel: string): void {
+	// Full type definition: type Foo = (args) => RetType;  (function signature type)
+	const signaturePattern = new RegExp(`type\\s+${name}\\s*=\\s*\\(`);
+	assert.ok(
+		!signaturePattern.test(source),
+		`${fileLabel} should NOT have a local full type definition for ${name}`,
+	);
+}
+
+// ── Phase 1: types.ts exports shared interfaces ──
+
+describe("types.ts exports — shared ExecResult/ExecFn", () => {
+	const typesSource = readFileSync(resolve(extDir, "types.ts"), "utf-8");
+
+	it("(D) types.ts exports ExecResult with code, stdout, stderr fields", () => {
 		assert.ok(
-			!source.includes("CrawlResult"),
-			"CrawlResult interface should have been removed (unused export)",
+			/export\s+interface\s+ExecResult/.test(typesSource),
+			"types.ts should export interface ExecResult",
+		);
+		assert.ok(/^\s*code:\s*number;/m.test(typesSource), "ExecResult should have code: number");
+		assert.ok(/^\s*stdout:\s*string;/m.test(typesSource), "ExecResult should have stdout: string");
+		assert.ok(/^\s*stderr:\s*string;/m.test(typesSource), "ExecResult should have stderr: string");
+	});
+
+	it("(D) types.ts exports ExecFn with correct signature", () => {
+		assert.ok(
+			/export\s+interface\s+ExecFn/.test(typesSource),
+			"types.ts should export interface ExecFn",
+		);
+		assert.ok(
+			typesSource.includes("Promise<ExecResult>"),
+			"ExecFn should return Promise<ExecResult>",
+		);
+	});
+
+	it("(D) CrawlParams and OnUpdateCallback remain exported", () => {
+		assert.ok(
+			/export\s+interface\s+CrawlParams/.test(typesSource),
+			"CrawlParams should remain exported",
+		);
+		assert.ok(
+			/export\s+interface\s+OnUpdateCallback/.test(typesSource),
+			"OnUpdateCallback should remain exported",
+		);
+	});
+});
+
+// ── Helper: read a source file ──
+
+function readSource(filename: string): string {
+	return readFileSync(resolve(extDir, filename), "utf-8");
+}
+
+// ── Phase 2: production files remove local copies, import shared ──
+
+describe("executor.ts — no local ExecResult/ExecFn, imports from types.ts", () => {
+	const source = readSource("executor.ts");
+
+	it("(D) executor.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "executor.ts");
+	});
+
+	it("(D) executor.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "executor.ts");
+	});
+
+	it("(D) executor.ts imports ExecResult and ExecFn from ./types.ts", () => {
+		assert.ok(
+			hasImportFromTypes(source, ["ExecResult", "ExecFn"]),
+			'executor.ts should import ExecResult and ExecFn from "./types"',
+		);
+	});
+});
+
+describe("backends.ts — no local ExecResult/ExecFn, imports from types.ts", () => {
+	const source = readSource("backends.ts");
+
+	it("(D) backends.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "backends.ts");
+	});
+
+	it("(D) backends.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "backends.ts");
+	});
+
+	it("(D) backends.ts imports ExecResult and ExecFn from ./types.ts", () => {
+		assert.ok(
+			hasImportFromTypes(source, ["ExecResult", "ExecFn"]),
+			'backends.ts should import ExecResult and ExecFn from "./types"',
+		);
+	});
+});
+
+describe("venv-setup.ts — no local ExecResult/ExecFn, imports from types.ts", () => {
+	const source = readSource("venv-setup.ts");
+
+	it("(D) venv-setup.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "venv-setup.ts");
+	});
+
+	it("(D) venv-setup.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "venv-setup.ts");
+	});
+
+	it("(D) venv-setup.ts imports ExecResult and ExecFn from ./types.ts", () => {
+		assert.ok(
+			hasImportFromTypes(source, ["ExecResult", "ExecFn"]),
+			'venv-setup.ts should import ExecResult and ExecFn from "./types"',
+		);
+	});
+});
+
+// ── Phase 3: test files remove local copies, import shared ──
+
+describe("test/executor.test.ts — no local ExecResult/ExecHandler, imports from types.ts", () => {
+	const source = readSource("test/executor.test.ts");
+
+	it("(D) test/executor.test.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/executor.test.ts");
+	});
+
+	it("(D) test/executor.test.ts no local full ExecHandler type definition", () => {
+		assertNoLocalFullType(source, "ExecHandler", "test/executor.test.ts");
+	});
+
+	it("(D) test/executor.test.ts imports ExecResult and ExecFn from ../types.ts", () => {
+		// For test files, use ../types pattern
+		const pattern =
+			/import\s+type\s*\{[^}]*\bExecResult\b[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\.\/types(?:\.ts)?["']/;
+		assert.ok(
+			pattern.test(source),
+			'test/executor.test.ts should import ExecResult and ExecFn from "../types"',
+		);
+	});
+});
+
+describe("test/backends.test.ts — no local ExecResult/ExecHandler, imports from types.ts", () => {
+	const source = readSource("test/backends.test.ts");
+
+	it("(D) test/backends.test.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/backends.test.ts");
+	});
+
+	it("(D) test/backends.test.ts no local full ExecHandler type definition", () => {
+		assertNoLocalFullType(source, "ExecHandler", "test/backends.test.ts");
+	});
+
+	it("(D) test/backends.test.ts imports ExecResult and ExecFn from ../types.ts", () => {
+		const pattern =
+			/import\s+type\s*\{[^}]*\bExecResult\b[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\.\/types(?:\.ts)?["']/;
+		assert.ok(
+			pattern.test(source),
+			'test/backends.test.ts should import ExecResult and ExecFn from "../types"',
+		);
+	});
+});
+
+describe("test/venv-setup.test.ts — no local ExecResult/ExecHandler, imports from types.ts", () => {
+	const source = readSource("test/venv-setup.test.ts");
+
+	it("(D) test/venv-setup.test.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/venv-setup.test.ts");
+	});
+
+	it("(D) test/venv-setup.test.ts no local full ExecHandler type definition", () => {
+		assertNoLocalFullType(source, "ExecHandler", "test/venv-setup.test.ts");
+	});
+
+	it("(D) test/venv-setup.test.ts imports ExecResult and ExecFn from ../types.ts", () => {
+		const pattern =
+			/import\s+type\s*\{[^}]*\bExecResult\b[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\.\/types(?:\.ts)?["']/;
+		assert.ok(
+			pattern.test(source),
+			'test/venv-setup.test.ts should import ExecResult and ExecFn from "../types"',
+		);
+	});
+});
+
+describe("test/crawl4ai.test.mts — no local ExecResult/ExecFn, imports from types.ts", () => {
+	const source = readSource("test/crawl4ai.test.mts");
+
+	it("(D) test/crawl4ai.test.mts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/crawl4ai.test.mts");
+	});
+
+	it("(D) test/crawl4ai.test.mts no local full ExecFn type definition", () => {
+		assertNoLocalFullType(source, "ExecFn", "test/crawl4ai.test.mts");
+	});
+
+	it("(D) test/crawl4ai.test.mts imports ExecResult and ExecFn from ../types.ts", () => {
+		const pattern =
+			/import\s+type\s*\{[^}]*\bExecResult\b[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\.\/types(?:\.ts)?["']/;
+		assert.ok(
+			pattern.test(source),
+			'test/crawl4ai.test.mts should import ExecResult and ExecFn from "../types"',
 		);
 	});
 });

--- a/.pi/extensions/crawl4ai/test/venv-setup.test.ts
+++ b/.pi/extensions/crawl4ai/test/venv-setup.test.ts
@@ -10,19 +10,10 @@ import { describe, it, mock } from "node:test";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import type { ExecResult, ExecFn } from "../types.ts";
 import { ensureChromiumDeps, VENV_RETRY_TTL_MS, VENV_RETRY_MAX } from "../venv-setup.ts";
 
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-type ExecHandler = (
-	cmd: string,
-	args: string[],
-	opts?: { timeout?: number; signal?: AbortSignal },
-) => Promise<ExecResult>;
+type ExecHandler = ExecFn;
 
 function makeMockExec(handler: ExecHandler) {
 	return mock.fn(handler) as ReturnType<typeof mock.fn<ExecHandler>> & {

--- a/.pi/extensions/crawl4ai/types.ts
+++ b/.pi/extensions/crawl4ai/types.ts
@@ -2,6 +2,20 @@
  * Shared types for crawl4ai extension
  */
 
+export interface ExecResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+export interface ExecFn {
+	(
+		cmd: string,
+		args: string[],
+		opts?: { timeout?: number; signal?: AbortSignal },
+	): Promise<ExecResult>;
+}
+
 export interface OnUpdateCallback {
 	(u: { content: Array<{ type: "text"; text: string }>; details: unknown }): void;
 }

--- a/.pi/extensions/crawl4ai/venv-setup.ts
+++ b/.pi/extensions/crawl4ai/venv-setup.ts
@@ -9,7 +9,7 @@
  * up to max retries. This prevents permanent lockout without restart.
  */
 
-import type { OnUpdateCallback } from "./types";
+import type { ExecResult, ExecFn, OnUpdateCallback } from "./types.ts";
 
 // ── Configurable constants ──
 
@@ -29,20 +29,6 @@ export interface VenvCacheEntry {
 }
 
 export type VenvCache = Map<string, VenvCacheEntry>;
-
-interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-interface ExecFn {
-	(
-		cmd: string,
-		args: string[],
-		opts?: { timeout?: number; signal?: AbortSignal },
-	): Promise<ExecResult>;
-}
 
 function lazyPaths(cwd: string) {
 	return {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #477

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 28s | 20.3K | 13 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 8s | 62.6K | 20 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 7s | 44.0K | 25 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 47s | 84.3K | 50 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 10s | 32.0K | 28 | deepseek-v4-flash |

**Total:** 5 agents · 8m 41s · 243.2K tokens · 136 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/477