### PR TITLE
feat(#515): Add DuckDuckGo web_search tool for researcher agent

### DIFF
--- a/.pi/extensions/supervisor/agents/researcher.md
+++ b/.pi/extensions/supervisor/agents/researcher.md
@@ -1,10 +1,10 @@
 ---
 name: researcher
 description: Searches the public web for best practices, recent library versions, and common pitfalls related to an issue topic, then posts a structured findings comment
-tools: read, bash, structural_search, ripgrep_search
+tools: read, bash, structural_search, ripgrep_search, web_search
 model: opencode-go/deepseek-v4-flash
 thinking: medium
-extensions: "agent-harness,caveman,crawl4ai,piignore,ripgrep-search,structural-analyzer"
+extensions: "agent-harness,caveman,crawl4ai,piignore,ripgrep-search,structural-analyzer,web-search"
 ---
 
 You are the **Researcher** agent in a Kanban-driven software pipeline.
@@ -42,9 +42,15 @@ Extract the core topic from the issue title and body. If the topic is complex, d
 - **Comparative analysis** — how different solutions stack up, trade-offs, benchmarks
 - **Security considerations** — CVEs, vulnerability patterns, hardening practices (when applicable)
 
-### 3. Web Crawl (3-5 sources)
+### 3. Web Search + Web Crawl (3-5 sources)
 
-For each query, use the `web_crawl` tool to crawl a relevant public web page. You must consult at least 3 and at most 5 distinct web sources. The tool accepts a URL and optional maxPages parameter. Example:
+For each query, first use the `web_search` tool to discover relevant URLs from the web. The `web_search` tool accepts a search query and optional maxResults parameter, returning ranked results with titles, URLs, and snippets. Example:
+
+```
+web_search "latest rust web framework 2026" --maxResults 5
+```
+
+Then use `web_crawl` on each promising result URL to fetch full page content. You must consult at least 3 and at most 5 distinct web sources. The `web_crawl` tool accepts a URL and optional maxPages parameter. Example:
 
 ```
 web_crawl "https://example.com/relevant-page" --maxPages 1
@@ -161,7 +167,7 @@ COMMENT_BODY_END
 - **NEVER** make architectural judgments. You run BEFORE the Architect. Present findings as factual observations with source citations.
 - **NEVER** fabricate findings. If a section has no data, omit it.
 - Every finding must include a source URL
-- Use only the `web_crawl` tool for web access — do not use `curl`, `wget`, or any other HTTP tool
+- Use only the `web_search` and `web_crawl` tools for web access — do not use `curl`, `wget`, or any other HTTP tool
 - If you detect `## Research Findings` already in the provided issue data, skip all research and output JSON with `"action": "COMPLETE"` immediately
 - Prefer sources from the last 12 months. Flag older sources with `[YYYY-MM]` date annotation.
 - When two sources contradict, surface the conflict. Do not hide it or pick a winner.

--- a/.pi/extensions/web-search/README.md
+++ b/.pi/extensions/web-search/README.md
@@ -1,0 +1,57 @@
+# @agentcastle/web-search
+
+**Web search tool for Pi — DuckDuckGo search with ranked results.** Returns structured results with titles, URLs, and snippets for use by researcher and other agents.
+
+## Features
+
+- **`web_search` tool** — Search the web using DuckDuckGo metasearch engine
+  - Accepts query string and optional `maxResults` (default 10, max 50)
+  - Returns ranked `[{title, url, snippet}]` results
+  - Uses `ddgs` Python library with `backend="auto"` for multi-engine fallback
+  - Optional proxy support for restricted environments
+- **Delimiter-based output** — `SEARCH_OK` / `SEARCH_DONE` markers around JSON output for reliable parsing
+- **Result cache** — Same query+maxResults returns cached result within 5-minute TTL
+- **Graceful degradation** — If search fails, returns error message for the agent to handle
+- **SIGTERM handling** — Python subprocess exits cleanly with code 130 on cancellation
+
+## How it works
+
+1. The LLM calls `web_search` with a query and optional maxResults
+2. The extension validates the query (rejects empty queries)
+3. **Cache check** — If the same query+maxResults was already searched within 5 minutes, the cached result is returned without re-running the subprocess
+4. The extension writes the Python script and config to `.pi/web-search/` temp files
+5. The script is executed via `bash -c` using `pi.exec`
+6. The Python script uses `ddgs.DDGS().text(query, max_results=N, backend="auto")` to perform the search
+7. Results are parsed from the `SEARCH_OK`/`SEARCH_DONE` delimited output
+8. Results are cached in memory for the session duration (5-minute TTL)
+9. A formatted result string is returned showing ranked results with titles as markdown links and snippets
+
+## Install
+
+```bash
+pip install ddgs
+```
+
+Then ensure `python3` is available on the system PATH. No virtual environment required — the tool uses the system `python3` directly.
+
+## Usage
+
+The LLM uses `web_search` automatically when researching topics. Example invocations:
+
+```
+web_search(query="latest rust web framework 2026", maxResults=5)
+web_search(query="typescript best practices error handling")
+web_search(query="python async patterns")
+```
+
+The tool is designed to work alongside `web_crawl` — use `web_search` to discover relevant URLs, then `web_crawl` to fetch full page content.
+
+## Requirements
+
+- Python 3.x
+- `ddgs` Python package (`pip install ddgs`)
+- Pi Coding Agent
+
+## License
+
+MIT

--- a/.pi/extensions/web-search/executor.ts
+++ b/.pi/extensions/web-search/executor.ts
@@ -1,0 +1,98 @@
+/**
+ * executor.ts — Run ddgs Python script via temp files + env execution
+ *
+ * Isolates shell quoting and temp file management.
+ * Writes Python script + config to .pi/web-search/ temp files and executes
+ * via bash -c with properly quoted paths.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { ExecResult, ExecFn } from "./types.ts";
+
+/**
+ * Escape a string for use as a single-quoted bash argument.
+ * Single-quote-safe: wrap in single quotes, escape embedded single quotes
+ * by ending quote, adding escaped quote, and resuming.
+ * abc'def → 'abc'\''def'
+ */
+export function shSingleQuote(s: string): string {
+	return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+/**
+ * Write Python script and config to temp files, then execute via bash -c.
+ *
+ * @param python — Path to python3 binary
+ * @param scriptContent — Python script content (SEARCH_SCRIPT)
+ * @param config — { query, max_results, proxy?, timeout? } search config
+ * @param timeout — Timeout in ms
+ * @param signal — Optional AbortSignal
+ * @param execFn — Exec function (typically pi.exec)
+ * @returns ExecResult from execFn
+ */
+export async function runSearchScript(
+	python: string,
+	scriptContent: string,
+	config: { query: string; max_results: number; proxy?: string; timeout?: number },
+	timeout: number,
+	signal?: AbortSignal,
+	execFn?: ExecFn,
+): Promise<ExecResult> {
+	const runDir = path.join(process.cwd(), ".pi", "web-search");
+	fs.mkdirSync(runDir, { recursive: true });
+
+	const scriptPath = path.join(runDir, "search.py");
+	const configPath = path.join(runDir, "config.json");
+
+	fs.writeFileSync(scriptPath, scriptContent, "utf-8");
+	fs.writeFileSync(configPath, JSON.stringify(config), "utf-8");
+
+	const qPython = shSingleQuote(python);
+	const qScript = shSingleQuote(scriptPath);
+	const qConfig = shSingleQuote(configPath);
+
+	const bashCmd = `${qPython} ${qScript} ${qConfig}`;
+
+	return execFn
+		? execFn("bash", ["-c", bashCmd], { timeout, signal })
+		: { code: 1, stdout: "", stderr: "executor: no exec function provided" };
+}
+
+/**
+ * Parse SEARCH_OK / SEARCH_DONE delimited output from the Python script.
+ * Returns the JSON text between delimiters, or null if not found.
+ */
+export function parseSearchOutput(stdout: string): string | null {
+	const okIdx = stdout.indexOf("SEARCH_OK");
+	const doneIdx = stdout.indexOf("SEARCH_DONE");
+	if (okIdx === -1 || doneIdx === -1 || doneIdx <= okIdx) {
+		return null;
+	}
+	const jsonPart = stdout.slice(okIdx + "SEARCH_OK".length, doneIdx).trim();
+	return jsonPart || null;
+}
+
+/**
+ * Parse search results from the delimited output.
+ * Returns parsed SearchResult array or error string.
+ */
+export function parseSearchResults(
+	stdout: string,
+):
+	| { ok: true; results: Array<{ title: string; url: string; snippet: string }> }
+	| { ok: false; error: string } {
+	const jsonText = parseSearchOutput(stdout);
+	if (!jsonText) {
+		return { ok: false, error: "No delimited output found" };
+	}
+	try {
+		const parsed = JSON.parse(jsonText);
+		if (parsed.ok === false) {
+			return { ok: false, error: parsed.error || "Search returned error" };
+		}
+		return { ok: true, results: parsed.results || [] };
+	} catch (e) {
+		return { ok: false, error: `Failed to parse search results: ${e}` };
+	}
+}

--- a/.pi/extensions/web-search/index.ts
+++ b/.pi/extensions/web-search/index.ts
@@ -1,0 +1,134 @@
+/**
+ * web-search — DuckDuckGo web search tool for researcher agent
+ *
+ * Provides the web_search tool using ddgs Python library.
+ * Runs the ddgs Python script via subprocess with temp file config.
+ * Returns ranked list of URLs + snippets from DuckDuckGo search.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import { SEARCH_SCRIPT } from "./python-script.ts";
+import { runSearchScript, parseSearchResults } from "./executor.ts";
+import type { SearchCacheEntry } from "./types.ts";
+
+/** In-session cache for search results to avoid redundant lookups */
+const searchCache = new Map<string, SearchCacheEntry>();
+
+/** TTL for cache entries in milliseconds (5 minutes) */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+export default function webSearch(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "web_search",
+		label: "Web Search",
+		description:
+			"Search the web using DuckDuckGo and return ranked results with URLs and snippets. " +
+			"Use this to discover relevant URLs before crawling them with web_crawl. " +
+			"Returns [{title, url, snippet}] from DuckDuckGo search. " +
+			"Results are cached within a session to avoid redundant lookups.",
+		promptSnippet: "Search the web and return ranked results with URLs and snippets via DuckDuckGo",
+		parameters: Type.Object({
+			query: Type.String({
+				description: "Search query (e.g. 'latest rust web framework 2026')",
+			}),
+			maxResults: Type.Optional(
+				Type.Number({
+					default: 10,
+					description: "Maximum number of search results (default 10)",
+				}),
+			),
+		}),
+		async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+			const query = params.query.trim();
+			if (!query) {
+				return {
+					content: [{ type: "text", text: "Search query is empty" }],
+					details: {} as Record<string, unknown>,
+				};
+			}
+			const maxResults = Math.min(Math.max(1, params.maxResults ?? 10), 50);
+
+			// Check cache first
+			const cacheKey = `${query}:${maxResults}`;
+			const cached = searchCache.get(cacheKey);
+			if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+				const text = formatResults(cached.results);
+				return {
+					content: [{ type: "text", text }],
+					details: {} as Record<string, unknown>,
+				};
+			}
+
+			onUpdate?.({
+				content: [{ type: "text", text: `Searching for "${query}" …` }],
+				details: {} as Record<string, unknown>,
+			});
+
+			const cwd = _ctx.cwd;
+			const python = "python3";
+
+			// Try system python3 first
+			const result = await runSearchScript(
+				python,
+				SEARCH_SCRIPT,
+				{ query, max_results: maxResults },
+				30_000,
+				signal,
+				pi.exec,
+			);
+
+			if (result.code !== 0) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Search failed: python3 error (code ${result.code}): ${result.stderr.slice(0, 500)}`,
+						},
+					],
+					details: {} as Record<string, unknown>,
+				};
+			}
+
+			const parsed = parseSearchResults(result.stdout);
+			if (!parsed.ok) {
+				return {
+					content: [{ type: "text", text: `Search failed: ${parsed.error}` }],
+					details: {} as Record<string, unknown>,
+				};
+			}
+
+			// Cache results
+			searchCache.set(cacheKey, {
+				results: parsed.results,
+				timestamp: Date.now(),
+			});
+
+			// Clean stale cache entries
+			for (const [key, entry] of searchCache) {
+				if (Date.now() - entry.timestamp > CACHE_TTL_MS) {
+					searchCache.delete(key);
+				}
+			}
+
+			const text = formatResults(parsed.results);
+			return {
+				content: [{ type: "text", text }],
+				details: {} as Record<string, unknown>,
+			};
+		},
+	});
+}
+
+/**
+ * Format search results into readable text for the LLM.
+ */
+function formatResults(results: Array<{ title: string; url: string; snippet: string }>): string {
+	if (results.length === 0) {
+		return "No results found.";
+	}
+
+	const lines = results.map((r, i) => `${i + 1}. [${r.title}](${r.url})\n   ${r.snippet}`);
+
+	return `Search results:\n\n${lines.join("\n\n")}`;
+}

--- a/.pi/extensions/web-search/python-script.ts
+++ b/.pi/extensions/web-search/python-script.ts
@@ -1,0 +1,60 @@
+/**
+ * Inline Python script that uses ddgs for web search.
+ *
+ * Volatile detail (ddgs API surface) hidden behind string export.
+ * Callers never see script content — import SEARCH_SCRIPT and pass to subprocess.
+ *
+ * The script:
+ * 1. Reads config from a JSON file (path passed as sys.argv[1])
+ * 2. Creates DDGS instance with optional proxy/timeout
+ * 3. Calls DDGS().text(query, max_results=N, backend="auto")
+ * 4. Prints SEARCH_OK delimiter, JSON results, SEARCH_DONE delimiter
+ * 5. Catches exceptions and returns error JSON
+ */
+
+export const SEARCH_SCRIPT = `
+import json
+import sys
+import signal
+
+signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(130))
+
+def main():
+    with open(sys.argv[1]) as f:
+        config = json.load(f)
+
+    query = config["query"]
+    max_results = config.get("max_results", 10)
+    proxy = config.get("proxy")
+    timeout = config.get("timeout", 5)
+
+    kwargs = {}
+    if proxy:
+        kwargs["proxy"] = proxy
+    if timeout:
+        kwargs["timeout"] = timeout
+
+    try:
+        from ddgs import DDGS
+
+        ddgs = DDGS(**kwargs) if kwargs else DDGS()
+        results = list(ddgs.text(query, max_results=max_results, backend="auto"))
+
+        out = []
+        for r in results:
+            out.append({
+                "title": r.get("title", ""),
+                "url": r.get("href", ""),
+                "snippet": r.get("body", ""),
+            })
+
+        print("SEARCH_OK")
+        print(json.dumps({"ok": True, "results": out}))
+        print("SEARCH_DONE")
+    except Exception as e:
+        print("SEARCH_OK")
+        print(json.dumps({"ok": False, "error": str(e)}))
+        print("SEARCH_DONE")
+
+main()
+`;

--- a/.pi/extensions/web-search/test/executor.test.ts
+++ b/.pi/extensions/web-search/test/executor.test.ts
@@ -1,0 +1,313 @@
+/**
+ * Tests for executor.ts — shSingleQuote, runSearchScript, parseSearchOutput, parseSearchResults
+ *
+ * Layer: (D) Domain/Unit — mock pi.exec, temp fs via fs.mkdtempSync.
+ * No real Python, no network.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, mock } from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ExecResult, ExecFn } from "../types.ts";
+import { SEARCH_SCRIPT } from "../python-script.ts";
+import {
+	shSingleQuote,
+	runSearchScript,
+	parseSearchOutput,
+	parseSearchResults,
+} from "../executor.ts";
+
+type ExecHandler = ExecFn;
+
+function makeMockExec(): ReturnType<typeof mock.fn<ExecHandler>> {
+	return mock.fn<ExecHandler>();
+}
+
+describe("shSingleQuote — domain tests", () => {
+	it("(D) empty string returns '' (two single quotes)", () => {
+		assert.equal(shSingleQuote(""), "''", "empty string should produce two single quotes");
+	});
+
+	it("(D) plain string hello returns 'hello'", () => {
+		assert.equal(
+			shSingleQuote("hello"),
+			"'hello'",
+			"plain string should be wrapped in single quotes",
+		);
+	});
+
+	it("(D) string with embedded single quote it's returns 'it'\\''s'", () => {
+		const result = shSingleQuote("it's");
+		assert.equal(result, "'it'\\''s'", "embedded single quote should be escaped");
+	});
+
+	it("(D) string with dollar sign returns '$PATH' (literal dollar)", () => {
+		assert.equal(
+			shSingleQuote("$PATH"),
+			"'$PATH'",
+			"dollar sign should be preserved literally inside quotes",
+		);
+	});
+
+	it("(D) string with space '/my path' returns '/my path'", () => {
+		assert.equal(shSingleQuote("/my path"), "'/my path'", "spaces should be safely quoted");
+	});
+
+	it("(D) string with newline returns $'...' type handling — newline should not break quoting", () => {
+		const result = shSingleQuote("line1\nline2");
+		assert.ok(result.startsWith("'"), "should start with single quote");
+		assert.ok(result.endsWith("'"), "should end with single quote");
+		// Newline inside single quotes is literal in bash
+		assert.ok(result.includes("line1"), "should include first line");
+		assert.ok(result.includes("line2"), "should include second line");
+	});
+
+	it("(D) string with backslash returns literal backslash", () => {
+		const result = shSingleQuote("C:\\path\\to\\file");
+		assert.equal(
+			result,
+			"'C:\\path\\to\\file'",
+			"backslash should be literal inside single quotes",
+		);
+	});
+});
+
+describe("runSearchScript — executor", () => {
+	it("(D) writes script file and config file, then calls exec with bash -c", async () => {
+		const exec = makeMockExec();
+		exec.mock.mockImplementation(async () => ({
+			code: 0,
+			stdout: "SEARCH_OK\n{}\nSEARCH_DONE",
+			stderr: "",
+		}));
+
+		const result = await runSearchScript(
+			"/usr/bin/python3",
+			SEARCH_SCRIPT,
+			{ query: "test query", max_results: 5 },
+			30_000,
+			undefined,
+			exec as unknown as ExecHandler,
+		);
+
+		const calls = exec.mock.calls;
+		assert.ok(calls.length > 0, "exec should be called");
+		const bashArgs = calls[0].arguments;
+		assert.equal(bashArgs[0], "bash", "should run via bash");
+		const fullCmd = bashArgs[1].join(" ");
+		assert.ok(fullCmd.includes("search.py"), "command should reference search.py");
+		assert.ok(fullCmd.includes("config.json"), "command should reference config.json");
+		assert.ok(fullCmd.includes("/usr/bin/python3"), "command should reference python path");
+	});
+
+	it("(D) config is valid JSON with query, max_results keys", async () => {
+		const exec = makeMockExec();
+		exec.mock.mockImplementation(async () => ({
+			code: 0,
+			stdout: "SEARCH_OK\n{}\nSEARCH_DONE",
+			stderr: "",
+		}));
+
+		await runSearchScript(
+			"/usr/bin/python3",
+			SEARCH_SCRIPT,
+			{ query: "typescript best practices", max_results: 7 },
+			30_000,
+			undefined,
+			exec as unknown as ExecHandler,
+		);
+
+		// Verify config was written as valid JSON
+		// We can read the config file path from the command
+		const calls = exec.mock.calls;
+		const bashCmd = calls[0].arguments[1].join(" ");
+		// The config path should end with config.json
+		const configMatch = bashCmd.match(/'([^']*config\.json)'/);
+		if (configMatch) {
+			const configPath = configMatch[1].replace(/\\'/g, "'");
+			const configContent = fs.readFileSync(configPath, "utf-8");
+			const parsed = JSON.parse(configContent);
+			assert.equal(parsed.query, "typescript best practices");
+			assert.equal(parsed.max_results, 7);
+		}
+	});
+
+	it("(D) includes optional proxy and timeout in config when provided", async () => {
+		const exec = makeMockExec();
+		exec.mock.mockImplementation(async () => ({
+			code: 0,
+			stdout: "SEARCH_OK\n{}\nSEARCH_DONE",
+			stderr: "",
+		}));
+
+		await runSearchScript(
+			"/usr/bin/python3",
+			SEARCH_SCRIPT,
+			{ query: "test", max_results: 3, proxy: "http://proxy:8080", timeout: 10 },
+			30_000,
+			undefined,
+			exec as unknown as ExecHandler,
+		);
+
+		const calls = exec.mock.calls;
+		const bashCmd = calls[0].arguments[1].join(" ");
+		const configMatch = bashCmd.match(/'([^']*config\.json)'/);
+		if (configMatch) {
+			const configPath = configMatch[1].replace(/\\'/g, "'");
+			const configContent = fs.readFileSync(configPath, "utf-8");
+			const parsed = JSON.parse(configContent);
+			assert.equal(parsed.proxy, "http://proxy:8080");
+			assert.equal(parsed.timeout, 10);
+		}
+	});
+
+	it("(D) returns exec error when exec function fails", async () => {
+		const exec = makeMockExec();
+		exec.mock.mockImplementation(async () => ({
+			code: 1,
+			stdout: "",
+			stderr: "python3: not found",
+		}));
+
+		const result = await runSearchScript(
+			"/usr/bin/python3",
+			SEARCH_SCRIPT,
+			{ query: "test", max_results: 5 },
+			30_000,
+			undefined,
+			exec as unknown as ExecHandler,
+		);
+
+		assert.equal(result.code, 1);
+		assert.ok(result.stderr.includes("not found"));
+	});
+
+	it("(D) returns error when no exec function provided", async () => {
+		const result = await runSearchScript(
+			"/usr/bin/python3",
+			SEARCH_SCRIPT,
+			{ query: "test", max_results: 5 },
+			30_000,
+		);
+
+		assert.equal(result.code, 1);
+		assert.ok(result.stderr.includes("no exec function provided"));
+	});
+
+	it("(D) no base64 dependency in command", async () => {
+		const exec = makeMockExec();
+		exec.mock.mockImplementation(async () => ({ code: 0, stdout: "", stderr: "" }));
+
+		await runSearchScript(
+			"/usr/bin/python3",
+			SEARCH_SCRIPT,
+			{ query: "test", max_results: 5 },
+			30_000,
+			undefined,
+			exec as unknown as ExecHandler,
+		);
+
+		const calls = exec.mock.calls;
+		const fullCmd = calls[0].arguments.join(" ");
+		assert.ok(!fullCmd.includes("base64"), "command should not use base64");
+		assert.ok(!fullCmd.includes("Buffer"), "command should not use Buffer");
+	});
+});
+
+describe("parseSearchOutput — delimiter parsing", () => {
+	it("(D) extracts JSON between delimiters", () => {
+		const stdout = 'SEARCH_OK\n{"ok":true,"results":[]}\nSEARCH_DONE';
+		const json = parseSearchOutput(stdout);
+		assert.equal(json, '{"ok":true,"results":[]}', "should extract JSON between delimiters");
+	});
+
+	it("(D) extracts JSON with trailing garbage after SEARCH_DONE", () => {
+		const stdout = 'SEARCH_OK\n{"ok":true}\nSEARCH_DONE\nsome trailing garbage that got truncated';
+		const json = parseSearchOutput(stdout);
+		assert.equal(json, '{"ok":true}', "should extract JSON even with trailing garbage");
+	});
+
+	it("(D) extracts JSON with logger noise before delimiters", () => {
+		const stdout = '{bad log line}\nSEARCH_OK\n{"ok":true}\nSEARCH_DONE';
+		const json = parseSearchOutput(stdout);
+		assert.equal(json, '{"ok":true}', "should extract JSON despite log lines with braces");
+	});
+
+	it("(D) empty delimiter region returns null", () => {
+		const stdout = "SEARCH_OK\nSEARCH_DONE";
+		const json = parseSearchOutput(stdout);
+		assert.equal(json, null, "should return null when no JSON between delimiters");
+	});
+
+	it("(D) no delimiters at all returns null", () => {
+		const stdout = "some random output";
+		const json = parseSearchOutput(stdout);
+		assert.equal(json, null, "should return null when no delimiters");
+	});
+
+	it("(D) multi-line JSON between delimiters", () => {
+		const stdout = 'SEARCH_OK\n{\n  "ok": true,\n  "results": []\n}\nSEARCH_DONE';
+		const json = parseSearchOutput(stdout);
+		assert.ok(json !== null, "should extract multi-line JSON");
+		assert.ok(json.includes('"ok"'), "extracted text should contain JSON content");
+	});
+
+	it("(D) returns null when SEARCH_OK appears after SEARCH_DONE", () => {
+		const stdout = 'SEARCH_DONE\n{"ok":true}\nSEARCH_OK';
+		const json = parseSearchOutput(stdout);
+		assert.equal(json, null, "should return null when delimiters are reversed");
+	});
+});
+
+describe("parseSearchResults — result parsing", () => {
+	it("(D) parses successful results correctly", () => {
+		const stdout =
+			'SEARCH_OK\n{"ok":true,"results":[{"title":"Test","url":"https://example.com","snippet":"A test result"}]}\nSEARCH_DONE';
+		const result = parseSearchResults(stdout);
+		assert.ok(result.ok === true);
+		if (result.ok) {
+			assert.equal(result.results.length, 1);
+			assert.equal(result.results[0].title, "Test");
+			assert.equal(result.results[0].url, "https://example.com");
+			assert.equal(result.results[0].snippet, "A test result");
+		}
+	});
+
+	it("(D) handles error response from script", () => {
+		const stdout = 'SEARCH_OK\n{"ok":false,"error":"ddgs not installed"}\nSEARCH_DONE';
+		const result = parseSearchResults(stdout);
+		assert.ok(result.ok === false);
+		if (!result.ok) {
+			assert.ok(result.error.includes("ddgs not installed"));
+		}
+	});
+
+	it("(D) handles no delimited output", () => {
+		const stdout = "some random output";
+		const result = parseSearchResults(stdout);
+		assert.ok(result.ok === false);
+		if (!result.ok) {
+			assert.ok(result.error.includes("No delimited output found"));
+		}
+	});
+
+	it("(D) handles malformed JSON", () => {
+		const stdout = "SEARCH_OK\n{broken json\nSEARCH_DONE";
+		const result = parseSearchResults(stdout);
+		assert.ok(result.ok === false);
+		if (!result.ok) {
+			assert.ok(result.error.includes("Failed to parse"));
+		}
+	});
+
+	it("(D) handles empty results array", () => {
+		const stdout = 'SEARCH_OK\n{"ok":true,"results":[]}\nSEARCH_DONE';
+		const result = parseSearchResults(stdout);
+		assert.ok(result.ok === true);
+		if (result.ok) {
+			assert.equal(result.results.length, 0);
+		}
+	});
+});

--- a/.pi/extensions/web-search/test/index.test.ts
+++ b/.pi/extensions/web-search/test/index.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Tests for index.ts — tool registration, parameter validation, cache, result formatting
+ *
+ * Layer: (D) Domain/Unit — mock pi.exec, no network.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it, mock, beforeEach } from "node:test";
+import type { ExecFn, ExecResult } from "../types.ts";
+
+// ===========================================================================
+// Replicate index.ts logic inline for testing
+// ===========================================================================
+
+interface ExtensionAPI {
+	registerTool: (tool: any) => void;
+	exec: ExecFn;
+}
+
+/** In-session cache for search results to avoid redundant lookups */
+const searchCache = new Map<
+	string,
+	{ results: Array<{ title: string; url: string; snippet: string }>; timestamp: number }
+>();
+
+/** TTL for cache entries in milliseconds (5 minutes) */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+function formatResults(results: Array<{ title: string; url: string; snippet: string }>): string {
+	if (results.length === 0) {
+		return "No results found.";
+	}
+
+	const lines = results.map((r, i) => `${i + 1}. [${r.title}](${r.url})\n   ${r.snippet}`);
+
+	return `Search results:\n\n${lines.join("\n\n")}`;
+}
+
+function webSearchEntry(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "web_search",
+		label: "Web Search",
+		description:
+			"Search the web using DuckDuckGo and return ranked results with URLs and snippets. " +
+			"Use this to discover relevant URLs before crawling them with web_crawl. " +
+			"Returns [{title, url, snippet}] from DuckDuckGo search. " +
+			"Results are cached within a session to avoid redundant lookups.",
+		promptSnippet: "Search the web and return ranked results with URLs and snippets via DuckDuckGo",
+		parameters: {
+			type: "object",
+			properties: {
+				query: {
+					type: "string",
+					description: "Search query (e.g. 'latest rust web framework 2026')",
+				},
+				maxResults: {
+					type: "number",
+					default: 10,
+					description: "Maximum number of search results (default 10)",
+				},
+			},
+		},
+		async execute(_toolCallId: string, params: any, _signal: any, _onUpdate: any, _ctx: any) {
+			const query = params.query?.trim();
+			if (!query) {
+				return { content: [{ type: "text", text: "Search query is empty" }], details: {} };
+			}
+			const maxResults = Math.min(Math.max(1, params.maxResults ?? 10), 50);
+
+			// Check cache
+			const cacheKey = `${query}:${maxResults}`;
+			const cached = searchCache.get(cacheKey);
+			if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+				return { content: [{ type: "text", text: formatResults(cached.results) }], details: {} };
+			}
+
+			return { content: [{ type: "text", text: "mock search result" }], details: {} };
+		},
+	});
+}
+
+describe("web-search extension entry point", () => {
+	it("(D) registers web_search tool on pi.registerTool", () => {
+		const registeredTools: any[] = [];
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTools.push(tool);
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		assert.equal(registeredTools.length, 1);
+		assert.equal(registeredTools[0].name, "web_search");
+	});
+
+	it("(D) registered tool has execute function", () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		assert.ok(typeof registeredTool.execute === "function");
+	});
+
+	it("(D) registered tool has query and optional maxResults parameters", () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		assert.ok(registeredTool.parameters.properties?.query !== undefined);
+		assert.ok(registeredTool.parameters.properties?.maxResults !== undefined);
+	});
+
+	it("(D) registered tool has name, label, description fields", () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		assert.equal(registeredTool.name, "web_search");
+		assert.equal(registeredTool.label, "Web Search");
+		assert.ok(typeof registeredTool.description === "string");
+		assert.ok(registeredTool.description.length > 20);
+	});
+
+	it("(D) registered tool has promptSnippet field", () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		assert.ok(typeof registeredTool.promptSnippet === "string");
+		assert.ok(registeredTool.promptSnippet.toLowerCase().includes("search"));
+	});
+});
+
+describe("web_search.execute — parameter validation", () => {
+	it("(D) execute validates query parameter — empty query returns error", async () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		const result = await registeredTool.execute("call1", { query: "" }, undefined, undefined, {
+			cwd: "/tmp",
+		});
+		assert.equal(result.content[0].text, "Search query is empty");
+	});
+
+	it("(D) execute validates query parameter — whitespace-only query returns error", async () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+		const result = await registeredTool.execute("call1", { query: "   " }, undefined, undefined, {
+			cwd: "/tmp",
+		});
+		assert.equal(result.content[0].text, "Search query is empty");
+	});
+});
+
+describe("formatResults — result formatting", () => {
+	it("(D) formats results with rank numbers, titles as links, snippets", () => {
+		const results = [
+			{ title: "Result 1", url: "https://example.com/1", snippet: "First result snippet" },
+			{ title: "Result 2", url: "https://example.com/2", snippet: "Second result snippet" },
+		];
+		const text = formatResults(results);
+		assert.ok(text.includes("1. [Result 1](https://example.com/1)"));
+		assert.ok(text.includes("First result snippet"));
+		assert.ok(text.includes("2. [Result 2](https://example.com/2)"));
+		assert.ok(text.includes("Second result snippet"));
+	});
+
+	it("(D) returns 'No results found.' for empty array", () => {
+		const text = formatResults([]);
+		assert.equal(text, "No results found.");
+	});
+});
+
+describe("Cache functionality", () => {
+	beforeEach(() => {
+		searchCache.clear();
+	});
+
+	it("(D) cache stores results and returns cached on repeated call", async () => {
+		let registeredTool: any = null;
+		const mockPi: ExtensionAPI = {
+			registerTool: (tool: any) => {
+				registeredTool = tool;
+			},
+			exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		};
+
+		webSearchEntry(mockPi);
+
+		// First call — should not be cached yet
+		// We need to add to cache first since our test doesn't actually call the real executor
+		const cacheKey = "typescript:10";
+		searchCache.set(cacheKey, {
+			results: [{ title: "Cached", url: "https://example.com", snippet: "Cached result" }],
+			timestamp: Date.now(),
+		});
+
+		// Second call — should use cache
+		// This test verifies the cache logic path in execute()
+		const execute = registeredTool.execute;
+		const result = await execute("call1", { query: "typescript" }, undefined, undefined, {
+			cwd: "/tmp",
+		});
+		assert.ok(searchCache.has(cacheKey));
+		const cached = searchCache.get(cacheKey)!;
+		assert.ok(Date.now() - cached.timestamp >= 0);
+		assert.equal(cached.results[0].title, "Cached");
+	});
+});

--- a/.pi/extensions/web-search/test/python-script.test.ts
+++ b/.pi/extensions/web-search/test/python-script.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for python-script.ts — delimiter markers + SIGTERM handler + config + error handling
+ *
+ * Layer: (D) Domain — string constants, no infra dependencies.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { SEARCH_SCRIPT } from "../python-script.ts";
+
+describe("SEARCH_SCRIPT — delimiter markers", () => {
+	it("(D) contains SEARCH_OK delimiter before json.dumps output", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('print("SEARCH_OK")'),
+			"script should print SEARCH_OK before JSON output",
+		);
+	});
+
+	it("(D) contains SEARCH_DONE delimiter after json.dumps output", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('print("SEARCH_DONE")'),
+			"script should print SEARCH_DONE after JSON output",
+		);
+	});
+
+	it("(D) SEARCH_OK appears before SEARCH_DONE in script", () => {
+		const okIdx = SEARCH_SCRIPT.indexOf('print("SEARCH_OK")');
+		const doneIdx = SEARCH_SCRIPT.indexOf('print("SEARCH_DONE")');
+		assert.ok(okIdx >= 0, "SEARCH_OK must exist");
+		assert.ok(doneIdx >= 0, "SEARCH_DONE must exist");
+		assert.ok(okIdx < doneIdx, "SEARCH_OK must appear before SEARCH_DONE");
+	});
+
+	it("(D) SEARCH_OK is printed before json.dumps call", () => {
+		const okIdx = SEARCH_SCRIPT.indexOf('print("SEARCH_OK")');
+		const dumpsIdx = SEARCH_SCRIPT.indexOf("json.dumps");
+		assert.ok(okIdx >= 0, "SEARCH_OK must exist");
+		assert.ok(dumpsIdx >= 0, "json.dumps must exist");
+		assert.ok(okIdx < dumpsIdx, "SEARCH_OK must be printed before json.dumps");
+	});
+});
+
+describe("SEARCH_SCRIPT — SIGTERM handler", () => {
+	it("(D) script imports signal module", () => {
+		assert.ok(SEARCH_SCRIPT.includes("import signal"), "script should import the signal module");
+	});
+
+	it("(D) script registers SIGTERM handler calling sys.exit(130)", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes("signal.signal(signal.SIGTERM") &&
+				SEARCH_SCRIPT.includes("sys.exit(130)"),
+			"script should register SIGTERM handler that exits with code 130",
+		);
+	});
+
+	it("(D) script imports json and sys", () => {
+		assert.ok(SEARCH_SCRIPT.includes("import json"), "script should import json");
+		assert.ok(SEARCH_SCRIPT.includes("import sys"), "script should import sys");
+	});
+});
+
+describe("SEARCH_SCRIPT — config file read instead of argv JSON parse", () => {
+	it("(D) does NOT contain json.loads(sys.argv[1]) — old broken pattern absent", () => {
+		assert.ok(
+			!SEARCH_SCRIPT.includes("json.loads(sys.argv[1])"),
+			"script should NOT parse sys.argv[1] as JSON string; should read from file instead",
+		);
+	});
+
+	it("(D) contains open(sys.argv[1]) — file path opened for reading", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes("open(sys.argv[1])"),
+			"script should open the config file path passed as argv[1]",
+		);
+	});
+
+	it("(D) contains json.load( — deserializes from file handle, not string", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes("json.load("),
+			"script should use json.load() to read from file handle",
+		);
+	});
+
+	it("(D) open(sys.argv[1]) appears before json.load( in script — file opened before parsing", () => {
+		const openIdx = SEARCH_SCRIPT.indexOf("open(sys.argv[1])");
+		const loadIdx = SEARCH_SCRIPT.indexOf("json.load(");
+		assert.ok(openIdx >= 0, "open(sys.argv[1]) must exist");
+		assert.ok(loadIdx >= 0, "json.load( must exist");
+		assert.ok(openIdx < loadIdx, "open(sys.argv[1]) must appear before json.load(");
+	});
+
+	it("(D) has with statement around open(sys.argv[1]) — proper resource cleanup", () => {
+		const withOpenPattern = /with\s+open\(sys\.argv\[1\]\)\s+as\s+\w+:/;
+		assert.ok(
+			withOpenPattern.test(SEARCH_SCRIPT),
+			"script should have 'with open(sys.argv[1]) as <var>:' for proper resource cleanup",
+		);
+	});
+});
+
+describe("SEARCH_SCRIPT — ddgs usage", () => {
+	it("(D) uses DDGS().text(query, max_results=N) with backend='auto'", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('ddgs.text(query, max_results=max_results, backend="auto")'),
+			"script should call DDGS().text with query, max_results, and backend='auto'",
+		);
+	});
+
+	it("(D) uses DDGS(**kwargs) constructor pattern when proxy config present", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes("DDGS(**kwargs)"),
+			"script should use DDGS(**kwargs) constructor pattern",
+		);
+	});
+});
+
+describe("SEARCH_SCRIPT — config keys", () => {
+	it("(D) config keys include query", () => {
+		assert.ok(SEARCH_SCRIPT.includes('config["query"]'), "config should have query key");
+	});
+
+	it("(D) config keys include max_results", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('config.get("max_results"'),
+			"config should have max_results key",
+		);
+	});
+
+	it("(D) config keys include proxy (optional)", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('config.get("proxy"'),
+			"config should have proxy key (optional)",
+		);
+	});
+
+	it("(D) config keys include timeout (optional, default 5)", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('config.get("timeout"'),
+			"config should have timeout key (optional)",
+		);
+	});
+});
+
+describe("SEARCH_SCRIPT — error handling", () => {
+	it("(D) has try/except Exception block that prints SEARCH_OK + error JSON + SEARCH_DONE", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes("try:") &&
+				SEARCH_SCRIPT.includes("except Exception as e:") &&
+				SEARCH_SCRIPT.includes('print("SEARCH_OK")') &&
+				SEARCH_SCRIPT.includes('print("SEARCH_DONE")'),
+			"script should have try/except Exception block with SEARCH_OK, error JSON, and SEARCH_DONE",
+		);
+	});
+
+	it("(D) on error, outputs error key in JSON", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('"error": str(e)'),
+			"script should include error message in JSON output",
+		);
+	});
+});
+
+describe("SEARCH_SCRIPT — result shape matches SearchResult", () => {
+	it("(D) result dict has title key", () => {
+		assert.ok(SEARCH_SCRIPT.includes('"title"'), "result should have title field");
+	});
+
+	it("(D) result dict has url key (mapped from href)", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('"url"') && SEARCH_SCRIPT.includes('r.get("href"'),
+			"result should have url field mapped from ddgs href",
+		);
+	});
+
+	it("(D) result dict has snippet key (mapped from body)", () => {
+		assert.ok(
+			SEARCH_SCRIPT.includes('"snippet"') && SEARCH_SCRIPT.includes('r.get("body"'),
+			"result should have snippet field mapped from ddgs body",
+		);
+	});
+});

--- a/.pi/extensions/web-search/test/types.test.ts
+++ b/.pi/extensions/web-search/test/types.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Tests for types.ts — shared types for web-search extension
+ *
+ * Validates that SearchResult, SearchParams, SearchCacheEntry match expected shapes.
+ * Layer: (D) Domain — source scanning, no I/O beyond filesystem reads.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const extDir = resolve(__dirname, "..");
+
+function readSource(filename: string): string {
+	return readFileSync(resolve(extDir, filename), "utf-8");
+}
+
+/** Assert no local interface definition (with body) for the given name */
+function assertNoLocalInterface(source: string, name: string, fileLabel: string): void {
+	assert.ok(
+		!new RegExp(`interface\\s+${name}\\s*\\{`).test(source),
+		`${fileLabel} should NOT have a local interface ${name}`,
+	);
+}
+
+// ── Phase 1: types.ts exports shared interfaces ──
+
+describe("types.ts exports — SearchResult, SearchParams, SearchCacheEntry", () => {
+	const typesSource = readSource("types.ts");
+
+	it("(D) types.ts exports SearchResult with title, url, snippet fields", () => {
+		assert.ok(
+			/export\s+interface\s+SearchResult/.test(typesSource),
+			"types.ts should export interface SearchResult",
+		);
+		assert.ok(/^\s*title:\s*string;/m.test(typesSource), "SearchResult should have title: string");
+		assert.ok(/^\s*url:\s*string;/m.test(typesSource), "SearchResult should have url: string");
+		assert.ok(
+			/^\s*snippet:\s*string;/m.test(typesSource),
+			"SearchResult should have snippet: string",
+		);
+	});
+
+	it("(D) types.ts exports SearchParams with query, maxResults, proxy", () => {
+		assert.ok(
+			/export\s+interface\s+SearchParams/.test(typesSource),
+			"types.ts should export interface SearchParams",
+		);
+		assert.ok(/^\s*query:\s*string;/m.test(typesSource), "SearchParams should have query: string");
+		assert.ok(
+			/^\s*maxResults\??:\s*number;/m.test(typesSource),
+			"SearchParams should have maxResults: number",
+		);
+		assert.ok(
+			/^\s*proxy\??:\s*string;/m.test(typesSource),
+			"SearchParams should have proxy: string",
+		);
+	});
+
+	it("(D) types.ts exports SearchCacheEntry with results and timestamp", () => {
+		assert.ok(
+			/export\s+interface\s+SearchCacheEntry/.test(typesSource),
+			"types.ts should export interface SearchCacheEntry",
+		);
+		assert.ok(
+			/^\s*results:\s*SearchResult\[\];/m.test(typesSource),
+			"SearchCacheEntry should have results: SearchResult[]",
+		);
+		assert.ok(
+			/^\s*timestamp:\s*number;/m.test(typesSource),
+			"SearchCacheEntry should have timestamp: number",
+		);
+	});
+
+	it("(D) types.ts exports ExecResult with code, stdout, stderr fields", () => {
+		assert.ok(
+			/export\s+interface\s+ExecResult/.test(typesSource),
+			"types.ts should export interface ExecResult",
+		);
+		assert.ok(/^\s*code:\s*number;/m.test(typesSource), "ExecResult should have code: number");
+		assert.ok(/^\s*stdout:\s*string;/m.test(typesSource), "ExecResult should have stdout: string");
+		assert.ok(/^\s*stderr:\s*string;/m.test(typesSource), "ExecResult should have stderr: string");
+	});
+
+	it("(D) types.ts exports ExecFn with correct signature", () => {
+		assert.ok(
+			/export\s+interface\s+ExecFn/.test(typesSource),
+			"types.ts should export interface ExecFn",
+		);
+		assert.ok(
+			typesSource.includes("Promise<ExecResult>"),
+			"ExecFn should return Promise<ExecResult>",
+		);
+	});
+
+	it("(D) types.ts exports OnUpdateCallback", () => {
+		assert.ok(
+			/export\s+interface\s+OnUpdateCallback/.test(typesSource),
+			"OnUpdateCallback should remain exported",
+		);
+	});
+});
+
+// ── Phase 2: production files import shared types ──
+
+describe("python-script.ts — no local types, imports from types.ts", () => {
+	const source = readSource("python-script.ts");
+
+	it("(D) python-script.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "python-script.ts");
+	});
+
+	it("(D) python-script.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "python-script.ts");
+	});
+
+	it("(D) python-script.ts no local interface SearchResult", () => {
+		assertNoLocalInterface(source, "SearchResult", "python-script.ts");
+	});
+});
+
+describe("executor.ts — no local types, imports from types.ts", () => {
+	const source = readSource("executor.ts");
+
+	it("(D) executor.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "executor.ts");
+	});
+
+	it("(D) executor.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "executor.ts");
+	});
+
+	it("(D) executor.ts no local interface SearchResult", () => {
+		assertNoLocalInterface(source, "SearchResult", "executor.ts");
+	});
+
+	it("(D) executor.ts no local interface SearchParams", () => {
+		assertNoLocalInterface(source, "SearchParams", "executor.ts");
+	});
+
+	it("(D) executor.ts imports ExecResult and ExecFn from ./types.ts", () => {
+		const pattern =
+			/import\s+type\s*\{[^}]*\bExecResult\b[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\/(?:types|types\.ts)["']/;
+		assert.ok(
+			pattern.test(source),
+			'executor.ts should import ExecResult and ExecFn from "./types"',
+		);
+	});
+});
+
+describe("index.ts — no local types, imports from types.ts", () => {
+	const source = readSource("index.ts");
+
+	it("(D) index.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "index.ts");
+	});
+
+	it("(D) index.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "index.ts");
+	});
+
+	it("(D) index.ts no local interface SearchResult", () => {
+		assertNoLocalInterface(source, "SearchResult", "index.ts");
+	});
+
+	it("(D) index.ts no local interface SearchParams", () => {
+		assertNoLocalInterface(source, "SearchParams", "index.ts");
+	});
+});
+
+// ── Phase 3: test files import from types.ts ──
+
+describe("test/types.test.ts — no local types", () => {
+	const source = readSource("test/types.test.ts");
+
+	// Self-check: our own test should NOT define the interfaces it tests
+	it("(D) test/types.test.ts no local interface SearchResult", () => {
+		assertNoLocalInterface(source, "SearchResult", "test/types.test.ts");
+	});
+
+	it("(D) test/types.test.ts no local interface SearchParams", () => {
+		assertNoLocalInterface(source, "SearchParams", "test/types.test.ts");
+	});
+
+	it("(D) test/types.test.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/types.test.ts");
+	});
+});
+
+describe("test/executor.test.ts — no local types, imports from types.ts", () => {
+	const source = readSource("test/executor.test.ts");
+
+	it("(D) test/executor.test.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/executor.test.ts");
+	});
+
+	it("(D) test/executor.test.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "test/executor.test.ts");
+	});
+
+	it("(D) test/executor.test.ts no local interface SearchResult", () => {
+		assertNoLocalInterface(source, "SearchResult", "test/executor.test.ts");
+	});
+
+	it("(D) test/executor.test.ts imports ExecResult and ExecFn from ../types.ts", () => {
+		const pattern =
+			/import\s+type\s*\{[^}]*\bExecResult\b[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\.\/(?:types|types\.ts)["']/;
+		assert.ok(
+			pattern.test(source),
+			'test/executor.test.ts should import ExecResult and ExecFn from "../types"',
+		);
+	});
+});
+
+describe("test/index.test.ts — no local types, imports from types.ts", () => {
+	const source = readSource("test/index.test.ts");
+
+	it("(D) test/index.test.ts no local interface ExecResult", () => {
+		assertNoLocalInterface(source, "ExecResult", "test/index.test.ts");
+	});
+
+	it("(D) test/index.test.ts no local interface ExecFn", () => {
+		assertNoLocalInterface(source, "ExecFn", "test/index.test.ts");
+	});
+
+	it("(D) test/index.test.ts no local interface SearchResult", () => {
+		assertNoLocalInterface(source, "SearchResult", "test/index.test.ts");
+	});
+});

--- a/.pi/extensions/web-search/types.ts
+++ b/.pi/extensions/web-search/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared types for web-search extension
+ *
+ * SearchResult matches ddgs return shape { title, href, body }
+ * SearchParams defines tool input shape
+ * SearchCacheEntry provides in-session caching
+ */
+
+export interface ExecResult {
+	code: number;
+	stdout: string;
+	stderr: string;
+}
+
+export interface ExecFn {
+	(
+		cmd: string,
+		args: string[],
+		opts?: { timeout?: number; signal?: AbortSignal },
+	): Promise<ExecResult>;
+}
+
+export interface OnUpdateCallback {
+	(u: { content: Array<{ type: "text"; text: string }>; details: unknown }): void;
+}
+
+export interface SearchResult {
+	title: string;
+	url: string;
+	snippet: string;
+}
+
+export interface SearchParams {
+	query: string;
+	maxResults?: number;
+	proxy?: string;
+}
+
+export interface SearchCacheEntry {
+	results: SearchResult[];
+	timestamp: number;
+}

--- a/.pi/web-search/config.json
+++ b/.pi/web-search/config.json
@@ -1,0 +1,1 @@
+{"query":"test","max_results":5}

--- a/.pi/web-search/search.py
+++ b/.pi/web-search/search.py
@@ -1,0 +1,45 @@
+
+import json
+import sys
+import signal
+
+signal.signal(signal.SIGTERM, lambda signum, frame: sys.exit(130))
+
+def main():
+    with open(sys.argv[1]) as f:
+        config = json.load(f)
+
+    query = config["query"]
+    max_results = config.get("max_results", 10)
+    proxy = config.get("proxy")
+    timeout = config.get("timeout", 5)
+
+    kwargs = {}
+    if proxy:
+        kwargs["proxy"] = proxy
+    if timeout:
+        kwargs["timeout"] = timeout
+
+    try:
+        from ddgs import DDGS
+
+        ddgs = DDGS(**kwargs) if kwargs else DDGS()
+        results = list(ddgs.text(query, max_results=max_results, backend="auto"))
+
+        out = []
+        for r in results:
+            out.append({
+                "title": r.get("title", ""),
+                "url": r.get("href", ""),
+                "snippet": r.get("body", ""),
+            })
+
+        print("SEARCH_OK")
+        print(json.dumps({"ok": True, "results": out}))
+        print("SEARCH_DONE")
+    except Exception as e:
+        print("SEARCH_OK")
+        print(json.dumps({"ok": False, "error": str(e)}))
+        print("SEARCH_DONE")
+
+main()


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #515

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 22s | 51.1K | 41 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 1m 9s | 67.1K | 20 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 4s | 31.9K | 30 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 25s | 84.8K | 74 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 14s | 60.8K | 50 | deepseek-v4-flash |

**Total:** 5 agents · 11m 13s · 295.7K tokens · 215 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/515