### PR TITLE
feat(#520): ranked_map: ctags index too broad, Q&A files pollute top results, no .piignore integration, preview useless

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -8,8 +8,13 @@
   - Full-dump mode for repos ≤ autoThreshold (default 20K symbols) — all symbols sorted by path
   - Ranked mode for larger repos — scoring by keyword overlap + git recency
   - Query-free fallback to recency-only ranking
-- **Configurable token budget** — Default 2048 tokens, adjustable per call
+  - Structural overview in recency-only mode — one file per top-level directory ensures broad repo awareness
+- **Configurable token budget** — Default 4096 tokens, adjustable per call
 - **Caching** — Symbol index cached to `.pi/cache/ranked-map-index.json` keyed by git HEAD
+- **Test-file penalty** — Test files (`.test.`, `.spec.`, `/test/`) receive 0.5x score penalty to favor source files
+- **.piignore integration** — Patterns from `.piignore` are automatically added as ctags excludes
+- **Improved previews** — Shows ctag definition lines (from pattern field) instead of first 5 comment/import lines
+- **Smart ctags excludes** — Q&A data files (`*.jsonl`), docs (`*.md`), pi agent internals, and unrelated submodules are excluded from indexing
 - **Prompt integration** — Injects mode-aware `promptSnippet` and `promptGuidelines` so the LLM knows how to use the tool
 - **No external dependencies** — Uses `ctags` for indexing, `ripgrep` for keyword search, `git` for recency
 
@@ -17,21 +22,23 @@
 
 The extension is orchestrated by a **`RankedMapEngine`** class (`engine.ts`) that separates the pipeline into independently testable phases:
 
-- **`buildOrLoadIndex()`** — Look up git HEAD, try cache, fall back to ctags + parsing
-- **`rank()`** — Select mode (full-dump vs ranked), compute keyword + recency scores, combine and truncate by token budget
-- **`addPreviews()`** — Read first 5 lines per file for ranked mode previews
-- **`format()`** — Shape results into the final `RankedMapResult` output
+- **`buildOrLoadIndex()`** — Look up git HEAD, try cache, fall back to ctags + parsing. Integrates `.piignore` patterns as additional ctags excludes
+- **`rank()`** — Select mode (full-dump vs ranked), compute keyword + recency scores, apply test-file penalty, combine and truncate by token budget
+- **`addPreviews()`** — Show ctag pattern-based previews (definition lines) when available, fall back to reading first 5 file lines
+- **`format()`** — Shape results into the final `RankedMapResult` output. Includes `getStructuralOverview()` for recency-only mode
 
 Each phase accepts `ExecFn` + config via constructor, making all methods testable in isolation without running the full tool.
 
 ## How it works
 
 1. On first call, the extension builds a symbol index via `ctags --output-format=json -R` over the target directory
+   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `.pi/context/`, `.pi/sessions/`, `.pi/npm/`, `.pi/chromium-deps/`, `.pi/crawl4ai-venv/`, `flask_blogs/`, `benchmarks/`
+   - Also reads `.piignore` for additional exclusion patterns
 2. The index is cached to disk keyed by current git HEAD
 3. When called, the extension selects mode:
    - **Full dump** — repo small enough, returns all files sorted by path up to token budget
-   - **Ranked** — runs `rg --files-with-matches` for keyword scoring, `git log --name-only` for recency scoring, then combines scores with configurable weights
-4. Results are formatted as JSON with file paths, symbols, token counts, and (in ranked mode) file previews
+   - **Ranked** — runs `rg --files-with-matches` for keyword scoring, `git log --name-only` for recency scoring, then combines scores with configurable weights. Test files receive a 0.5x score penalty. In recency-only mode (no query), a structural overview injects one representative file per top-level directory
+4. Results are formatted as JSON with file paths, symbols, token counts, and (in ranked mode) file previews showing definition lines
 
 ## Install
 
@@ -58,7 +65,7 @@ In `.pi/settings.json`:
 ```json
 {
 	"rankedMap": {
-		"tokenBudget": 2048,
+		"tokenBudget": 4096,
 		"autoThreshold": 20000,
 		"recencyWindowDays": 90,
 		"weights": {
@@ -70,10 +77,20 @@ In `.pi/settings.json`:
 }
 ```
 
-- `tokenBudget` — Max tokens per response (default 2048)
+- `tokenBudget` — Max tokens per response (default 4096)
 - `autoThreshold` — Symbol count threshold for auto-mode (default 20000). Set to 0 for always-ranked
 - `recencyWindowDays` — How many days back to track git activity (default 90)
 - `weights` — Scoring weights: keyword relevance, git recency, file size penalty
+
+### .piignore integration
+
+The extension automatically reads `.piignore` from the project root and converts its patterns to ctags `--exclude` arguments. Supported patterns:
+
+- Directory patterns (`dist/` → `--exclude=dist`)
+- Glob patterns (`*.log` → `--exclude=*.log`)
+- Path patterns (`.pi/cache` → `--exclude=.pi/cache`)
+
+Comments and negations are skipped. Patterns with double-star (`**`) or leading slash (`/`) are skipped.
 
 ## Requirements
 

--- a/.pi/extensions/ranked-map/config.ts
+++ b/.pi/extensions/ranked-map/config.ts
@@ -11,7 +11,7 @@ import type { RankedMapConfig } from "./types.ts";
 
 /** Default configuration values when settings.json is missing or partial. */
 export const DEFAULT_CONFIG: RankedMapConfig = {
-	tokenBudget: 2048,
+	tokenBudget: 4096,
 	recencyWindowDays: 30,
 	cacheTtlHours: 24,
 	autoThreshold: 20000,

--- a/.pi/extensions/ranked-map/ctags.ts
+++ b/.pi/extensions/ranked-map/ctags.ts
@@ -64,23 +64,56 @@ export function parseCtagsOutput(raw: string): CtagsTag[] {
 /**
  * Build ctags command arguments.
  *
- * Default excludes: node_modules, .git (common sources of noise).
+ * Default excludes: node_modules, .git (common sources of noise),
+ * plus Q&A data files (*.jsonl), docs (*.md), and large irrelevant dirs.
+ * Extra patterns from .piignore can be passed via extraExcludes.
  * max_depth: 0 = unlimited (ctags default).
  */
 export function buildCtagsArgs(
 	targetDir: string,
 	maxDepth: number,
+	extraExcludes?: string[],
 ): { command: string; args: string[] } {
-	const args = [
-		"-R",
-		"--output-format=json",
-		"--exclude=node_modules",
-		"--exclude=.git",
-		"--exclude=*.json",
-		"--exclude=*.min.js",
-		"--exclude=*.css",
-		"--exclude=static",
+	const excludes = [
+		// Standard noise
+		"node_modules",
+		".git",
+		"*.json",
+		"*.min.js",
+		"*.css",
+		"static",
+		// Q&A data files — zero code symbols
+		"*.jsonl",
+		// Docs — no code symbols
+		"*.md",
+		// Pi agent internals — massive, irrelevant
+		".pi/context",
+		".pi/sessions",
+		".pi/npm",
+		".pi/chromium-deps",
+		".pi/crawl4ai-venv",
+		// Unrelated submodules
+		"flask_blogs",
+		// Benchmarks — not source
+		"benchmarks",
 	];
+
+	// Deduplicate: merge extra excludes from piignore, avoid duplicates
+	const seen = new Set(excludes);
+	if (extraExcludes) {
+		for (const ex of extraExcludes) {
+			if (!seen.has(ex)) {
+				excludes.push(ex);
+				seen.add(ex);
+			}
+		}
+	}
+
+	const args: string[] = ["-R", "--output-format=json"];
+
+	for (const ex of excludes) {
+		args.push(`--exclude=${ex}`);
+	}
 
 	if (maxDepth > 0) {
 		args.push(`--maxdepth=${maxDepth}`);
@@ -111,6 +144,7 @@ export function buildSymbolIndex(
 			type: tag.kind,
 			name: tag.name,
 			line: tag.line ?? 0,
+			pattern: tag.pattern || undefined,
 		});
 	}
 

--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -16,13 +16,14 @@ import {
 	type RankedMapResult,
 } from "./types.ts";
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
 import { buildCtagsArgs, buildSymbolIndex } from "./ctags.ts";
 import { loadCachedIndex } from "./cache.ts";
 import { selectMode, dumpAllFiles, formatOutput } from "./format.ts";
 import { computeKeywordScores, computeRecencyScores, rankFiles } from "./scoring.ts";
 import { runKeywordSearch } from "./search.ts";
 import { runGitRecency, getGitHead } from "./git.ts";
+import { buildPiignoreExcludes } from "./piignore.ts";
 
 /** Result shape for the rank method — extends dumpAllFiles/rankFiles result with mode. */
 export interface RankResult {
@@ -43,11 +44,15 @@ export interface RankResult {
  *   const output = engine.format(withPreviews, budget, ranked.truncated, ranked.mode);
  */
 export class RankedMapEngine {
-	constructor(
-		private config: RankedMapConfig,
-		private exec: ExecFn,
-		private cwd: string,
-	) {}
+	private config: RankedMapConfig;
+	private exec: ExecFn;
+	private cwd: string;
+
+	constructor(config: RankedMapConfig, exec: ExecFn, cwd: string) {
+		this.config = config;
+		this.exec = exec;
+		this.cwd = cwd;
+	}
 
 	/**
 	 * Build or load the symbol index.
@@ -81,7 +86,11 @@ export class RankedMapEngine {
 			// non-critical — cache dir may already exist
 		}
 
-		const { command, args } = buildCtagsArgs(targetDir, 0);
+		// Incorporate .piignore patterns as additional ctags excludes
+		const piignorePath = join(this.cwd, ".piignore");
+		const piignoreExcludes = buildPiignoreExcludes(piignorePath);
+
+		const { command, args } = buildCtagsArgs(targetDir, 0, piignoreExcludes);
 		const result = await this.exec(command, args, {
 			cwd: this.cwd,
 			timeout: 30_000,
@@ -129,7 +138,8 @@ export class RankedMapEngine {
 
 		// Ranked mode: compute keyword scores (if query) and recency scores
 		let keywordScores: Record<string, number> = {};
-		if (query.trim()) {
+		const hasQuery = query.trim().length > 0;
+		if (hasQuery) {
 			const { fileMatches, terms } = await runKeywordSearch(
 				this.exec,
 				query,
@@ -160,19 +170,49 @@ export class RankedMapEngine {
 	}
 
 	/**
-	 * Add file previews (first 5 lines) for ranked mode results.
+	 * Strip ctag pattern delimiters to extract the actual code line.
+	 * Pattern format is typically /^code line$/ or ?^code line$?
+	 */
+	private stripPattern(pattern: string): string {
+		// Pattern format: /^...$/  or ?^...$?
+		const match = pattern.match(/^[\/?]\^?(.+?)\$?[\/?]$/);
+		if (match?.[1]) {
+			return match[1];
+		}
+		// Fallback: just return the pattern as-is
+		return pattern;
+	}
+
+	/**
+	 * Add file previews for ranked mode results.
+	 *
+	 * When an index is provided, tries to show the first ctag pattern line
+	 * (the definition line) instead of reading the first 5 file lines.
+	 * Falls back to reading first 5 lines when no pattern is available.
 	 * Full_dump mode files are returned unchanged.
 	 */
 	addPreviews(
 		files: RankedFileScore[],
 		targetDir: string,
 		mode: "ranked" | "full_dump",
+		index?: CachedIndex,
 	): RankedFileScore[] {
 		if (mode === "full_dump") return files;
 
 		return files.map((f) => {
 			if (f.preview) return f; // already has preview
 			let preview = "";
+
+			// Try pattern-based preview from index
+			if (index?.symbols[f.path] && index.symbols[f.path]!.length > 0) {
+				const firstSymbol = index.symbols[f.path]![0];
+				if (firstSymbol.pattern) {
+					preview = this.stripPattern(firstSymbol.pattern);
+					return { ...f, preview };
+				}
+			}
+
+			// Fallback: read first 5 lines from disk
 			try {
 				const fullPath = resolve(this.cwd, targetDir, f.path);
 				if (existsSync(fullPath)) {

--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -19,7 +19,13 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { buildCtagsArgs, buildSymbolIndex } from "./ctags.ts";
 import { loadCachedIndex } from "./cache.ts";
-import { selectMode, dumpAllFiles, formatOutput } from "./format.ts";
+import {
+	selectMode,
+	dumpAllFiles,
+	formatOutput,
+	getStructuralOverview,
+	formatSymbols,
+} from "./format.ts";
 import { computeKeywordScores, computeRecencyScores, rankFiles } from "./scoring.ts";
 import { runKeywordSearch } from "./search.ts";
 import { runGitRecency, getGitHead } from "./git.ts";
@@ -165,6 +171,41 @@ export class RankedMapEngine {
 			budget,
 			index.symbols,
 		);
+
+		// In recency-only mode (no query), inject structural overview files
+		// to ensure at least one file per top-level directory appears in output.
+		// Structural files get score 0.1 so they don't get truncated by token budget.
+		if (!hasQuery) {
+			const allPaths = Object.keys(index.symbols);
+			const structuralFiles = getStructuralOverview(allPaths);
+			const existingByPath = new Map(ranked.files.map((f) => [f.path, f]));
+
+			for (const sf of structuralFiles) {
+				const existing = existingByPath.get(sf.path);
+				if (existing) {
+					// Bump score to at least 0.1 for structural overview files
+					if (existing.score < sf.score) {
+						existing.score = sf.score;
+					}
+				} else {
+					const syms = index.symbols[sf.path] ?? [];
+					const symText = formatSymbols(syms, sf.path);
+					ranked.files.push({
+						path: sf.path,
+						score: sf.score,
+						symbols: symText,
+						preview: "",
+					});
+					existingByPath.set(sf.path, ranked.files[ranked.files.length - 1]!);
+				}
+			}
+
+			// Re-sort by score descending (structural files with 0.1 will be at bottom)
+			ranked.files.sort((a, b) => {
+				if (b.score !== a.score) return b.score - a.score;
+				return a.path.localeCompare(b.path);
+			});
+		}
 
 		return { ...ranked, mode: "ranked" as const };
 	}

--- a/.pi/extensions/ranked-map/format.ts
+++ b/.pi/extensions/ranked-map/format.ts
@@ -87,6 +87,35 @@ export function formatSymbols(symbols: SymbolEntry[], path: string): string {
 }
 
 /**
+ * Get a structural overview of the repository — one representative file
+ * per top-level directory. Used in recency-only mode to ensure the agent
+ * sees at least one file from each top-level directory.
+ *
+ * Returns entries with score: 0.1 (low but non-zero, so they appear at
+ * the bottom of ranked results) and empty preview.
+ */
+export function getStructuralOverview(filePaths: string[]): { path: string; score: number }[] {
+	const seen = new Set<string>();
+	const overview: { path: string; score: number }[] = [];
+
+	for (const filePath of filePaths) {
+		// Normalize: strip leading ./ if present
+		const normalized = filePath.startsWith("./") ? filePath.slice(2) : filePath;
+
+		// Get top-level directory
+		const slashIdx = normalized.indexOf("/");
+		const topDir = slashIdx === -1 ? normalized : normalized.slice(0, slashIdx);
+
+		if (!seen.has(topDir)) {
+			seen.add(topDir);
+			overview.push({ path: filePath, score: 0.1 });
+		}
+	}
+
+	return overview;
+}
+
+/**
  * Format ranked results into output shape.
  *
  * Scores are rounded to 2 decimal places.

--- a/.pi/extensions/ranked-map/index.ts
+++ b/.pi/extensions/ranked-map/index.ts
@@ -20,7 +20,7 @@ export default function rankedMap(pi: ExtensionAPI): void {
 		promptGuidelines: [
 			"ranked_map replaces map_codebase — use it for all codebase browsing. Auto-mode: pass `query` for ranked results, omit for full dump (small repos) or recency-ranked (large repos).",
 			"Pass a `query` describing what you're looking for (e.g. 'login auth token') to rank by keyword relevance. Without query, the tool auto-selects full dump or recency-ranked based on repo size.",
-			"Set `tokenBudget` to control output size (default 2048 tokens). Smaller budget = fewer files = faster response.",
+			"Set `tokenBudget` to control output size (default 4096 tokens). Smaller budget = fewer files = faster response.",
 			"Configure autoThreshold in .pi/settings.json rankedMap.autoThreshold (default 20000). Set to 0 for always-ranked.",
 			"The tool is on-demand (not auto-injected). Call it when you need codebase context, not every turn.",
 		],
@@ -34,7 +34,7 @@ export default function rankedMap(pi: ExtensionAPI): void {
 			),
 			tokenBudget: Type.Optional(
 				Type.Number({
-					default: 2048,
+					default: 4096,
 					description:
 						"Maximum token budget for output. Greedy fill from highest-ranked file until budget exhausted. Overrides settings.json rankedMap.tokenBudget if provided.",
 				}),
@@ -85,8 +85,8 @@ export default function rankedMap(pi: ExtensionAPI): void {
 			// Phase 2: Rank/dump files
 			const ranked = await engine.rank(index, query, budget, signal);
 
-			// Phase 3: Add file previews (ranked mode only)
-			const filesWithPreviews = engine.addPreviews(ranked.files, targetDir, ranked.mode);
+			// Phase 3: Add file previews (ranked mode only) — pass index for pattern-based preview
+			const filesWithPreviews = engine.addPreviews(ranked.files, targetDir, ranked.mode, index);
 
 			// Phase 4: Format output
 			const output = engine.format(filesWithPreviews, budget, ranked.truncated, ranked.mode);

--- a/.pi/extensions/ranked-map/piignore.ts
+++ b/.pi/extensions/ranked-map/piignore.ts
@@ -1,0 +1,80 @@
+/**
+ * ranked-map — .piignore integration
+ *
+ * Reads .piignore file and converts its patterns to ctags --exclude arguments.
+ * Pure module — no pi SDK imports. Zero async I/O.
+ *
+ * Supports:
+ * - Comment lines (#)
+ * - Directory patterns (dir/ → --exclude=dir)
+ * - Glob patterns (*.ext → --exclude=*.ext)
+ * - Path patterns (path/to/dir/ → --exclude=path/to/dir)
+ * - Negation patterns (!pattern → skipped, ctags can't negate)
+ *
+ * Not supported (silently skipped):
+ * - Negation (!)
+ * - Double-star glob patterns (**)
+ * - Leading slash patterns (absolute paths)
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+/**
+ * Parse a single .piignore line into a ctags --exclude pattern.
+ * Returns null for lines that can't be converted (comments, negations, empty).
+ */
+export function parsePiignoreLine(line: string): string | null {
+	const trimmed = line.trim();
+
+	// Skip empty lines and comments
+	if (!trimmed || trimmed.startsWith("#")) return null;
+
+	// Skip negations (gitignore !pattern) — ctags can't exclude negate
+	if (trimmed.startsWith("!")) return null;
+
+	// Strip trailing / if present (gitignore dir pattern)
+	let pattern = trimmed;
+	if (pattern.endsWith("/")) {
+		pattern = pattern.slice(0, -1);
+	}
+
+	// Strip trailing /** (gitignore "all contents" indicator)
+	if (pattern.endsWith("/**")) {
+		pattern = pattern.slice(0, -3);
+		if (pattern.endsWith("/")) pattern = pattern.slice(0, -1);
+	}
+
+	// Ctags --exclude supports globs but not ** (double-star)
+	// Skip patterns containing ** that aren't just trailing /**
+	if (pattern.includes("**")) return null;
+
+	// Skip patterns with leading / (absolute-style paths)
+	if (pattern.startsWith("/")) return null;
+
+	return pattern || null;
+}
+
+/**
+ * Read .piignore file and return list of ctags --exclude argument values.
+ * Returns empty array if file doesn't exist or can't be read.
+ */
+export function buildPiignoreExcludes(piignorePath: string): string[] {
+	try {
+		if (!existsSync(piignorePath)) return [];
+
+		const content = readFileSync(piignorePath, "utf-8");
+		const lines = content.split("\n");
+		const excludes: string[] = [];
+
+		for (const line of lines) {
+			const pattern = parsePiignoreLine(line);
+			if (pattern) {
+				excludes.push(pattern);
+			}
+		}
+
+		return excludes;
+	} catch {
+		return [];
+	}
+}

--- a/.pi/extensions/ranked-map/scoring.ts
+++ b/.pi/extensions/ranked-map/scoring.ts
@@ -68,8 +68,46 @@ export function computeRecencyScores(
 }
 
 /**
+ * Apply test-file penalty to a set of ranked file scores.
+ *
+ * Files matching test patterns (.test., .spec., /test/) get their score
+ * multiplied by TEST_PENALTY (0.5x). This reduces, but doesn't eliminate,
+ * their ranking position — source files rank higher than tests.
+ */
+const TEST_FILE_PENALTY = 0.5;
+
+/**
+ * Pattern for detecting test files:
+ * - Contains .test. (e.g. foo.test.ts, foo.test.mts)
+ * - Contains .spec. (e.g. foo.spec.ts)
+ * - Contains /test/ directory segment (e.g. src/test/foo.ts)
+ */
+const TEST_FILE_RE = /(\.test\.|\.spec\.|\/test\/)/;
+
+/**
+ * Check if a file path matches test-file patterns.
+ */
+export function isTestFile(path: string): boolean {
+	return TEST_FILE_RE.test(path);
+}
+
+/**
+ * Apply penalty to scores of test files in-place.
+ */
+export function applyTestFilePenalty(files: { path: string; score: number }[]): void {
+	for (const f of files) {
+		if (isTestFile(f.path)) {
+			f.score = Math.round(f.score * TEST_FILE_PENALTY * 100) / 100;
+		}
+	}
+}
+
+/**
  * Rank files by combined score (weighted sum of keyword + recency),
  * sort descending, and fill within token budget (greedy).
+ *
+ * Test files (.test., .spec., /test/) receive a 0.5x score penalty
+ * so source files rank higher than their corresponding tests.
  */
 export function rankFiles(
 	keywordScores: Record<string, number>,
@@ -94,6 +132,9 @@ export function rankFiles(
 		const score = kw * weights.keyword + rec * weights.recency;
 		scored.push({ path: file, score: Math.round(score * 100) / 100, symbols: syms });
 	}
+
+	// Apply test-file penalty before sorting
+	applyTestFilePenalty(scored);
 
 	// Sort descending by score, tie-break by path alphabetically
 	scored.sort((a, b) => {

--- a/.pi/extensions/ranked-map/test/features.test.ts
+++ b/.pi/extensions/ranked-map/test/features.test.ts
@@ -598,3 +598,130 @@ describe("Phase 7: Engine integration", () => {
 		}
 	});
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 8: Structural overview integration in engine.rank
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 8: Structural overview integration in engine.rank", () => {
+	it("recency-only mode (no query) merges structural overview files", async () => {
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				".pi/extensions/foo/src/a.ts": [{ type: "function", name: "foo", line: 1 }],
+				".pi/extensions/bar/src/b.ts": [{ type: "function", name: "bar", line: 1 }],
+				Makefile: [{ type: "other", name: "Makefile", line: 1 }],
+			},
+		};
+		const engine = new RankedMapEngine(makeConfig({ autoThreshold: 0 }), mockExecFn(), "/tmp");
+		const result = await engine.rank(index, "", 50000, undefined);
+		assert.equal(result.mode, "ranked");
+
+		// Structural overview should add files for top-level dirs: .pi, Makefile
+		// .pi is one top-level dir, Makefile is another
+		const paths = result.files.map((f) => f.path);
+		// At minimum, .pi/extensions/foo/src/a.ts and .pi/extensions/bar/src/b.ts are in the ranked results
+		// Makefile is a structural file (root-level file, its own "directory")
+		assert.ok(paths.includes("Makefile"), "structural overview should include root-level files");
+	});
+
+	it("structural overview files do not duplicate files already in ranked results", async () => {
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/a.ts": [{ type: "function", name: "foo", line: 1 }],
+				"src/b.ts": [{ type: "function", name: "bar", line: 1 }],
+				"docs/readme.md": [{ type: "other", name: "readme", line: 1 }],
+				Makefile: [{ type: "other", name: "Makefile", line: 1 }],
+			},
+		};
+		const engine = new RankedMapEngine(makeConfig({ autoThreshold: 0 }), mockExecFn(), "/tmp");
+		const result = await engine.rank(index, "", 50000, undefined);
+		const paths = result.files.map((f) => f.path);
+		// Each path should appear at most once
+		for (const p of paths) {
+			const count = paths.filter((x) => x === p).length;
+			assert.equal(count, 1, `Path "${p}" appears ${count} times (should be 1)`);
+		}
+	});
+
+	it("structural overview files appear at low score (0.1)", async () => {
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/a.ts": [{ type: "function", name: "foo", line: 1 }],
+				Makefile: [{ type: "other", name: "Makefile", line: 1 }],
+			},
+		};
+		const engine = new RankedMapEngine(makeConfig({ autoThreshold: 0 }), mockExecFn(), "/tmp");
+		const result = await engine.rank(index, "", 50000, undefined);
+
+		// autoThreshold: 0, totalSymbols: 2, 2 > 0 → ranked (recency-only)
+		assert.equal(result.mode, "ranked");
+
+		// Makefile is a structural overview file (root-level)
+		const makefileEntry = result.files.find((f) => f.path === "Makefile");
+		assert.ok(makefileEntry, "Makefile should be in results");
+		// Makefile gets 0.1 from structural overview
+		assert.equal(makefileEntry!.score, 0.1, "structural overview files should have score 0.1");
+	});
+
+	it("query mode does NOT inject structural overview", async () => {
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/a.ts": [{ type: "function", name: "foo", line: 1 }],
+				Makefile: [{ type: "other", name: "Makefile", line: 1 }],
+			},
+		};
+		const engine = new RankedMapEngine(makeConfig({ autoThreshold: 0 }), mockExecFn(), "/tmp");
+		const result = await engine.rank(index, "foo bar", 50000, undefined);
+		// In query mode, Makefile appears with score 0 (no recency, no keyword match)
+		// Structural overview should NOT boost it to 0.1 in query mode
+		const makefileEntry = result.files.find((f) => f.path === "Makefile");
+		assert.ok(makefileEntry, "Makefile appears in query mode (in symbol index)");
+		assert.equal(
+			makefileEntry!.score,
+			0,
+			"Makefile should have score 0 in query mode (not boosted)",
+		);
+	});
+
+	it("full_dump mode does NOT inject structural overview", async () => {
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/a.ts": [{ type: "function", name: "foo", line: 1 }],
+				Makefile: [{ type: "other", name: "Makefile", line: 1 }],
+			},
+		};
+		const engine = new RankedMapEngine(makeConfig({ autoThreshold: 100 }), mockExecFn(), "/tmp");
+		const result = await engine.rank(index, "", 50000, undefined);
+		// Should be full_dump mode since totalSymbols (2) <= autoThreshold (100)
+		assert.equal(result.mode, "full_dump");
+		// In full_dump mode, all files are already included sorted by path
+		const paths = result.files.map((f) => f.path);
+		assert.ok(paths.includes("Makefile"), "full_dump should already include all files");
+		assert.ok(paths.includes("src/a.ts"), "full_dump should include all files");
+	});
+
+	it("empty repo with no query → no crash, no structural files added", async () => {
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {},
+		};
+		// With autoThreshold=0 and totalSymbols=0, 0 <= 0 → full_dump mode
+		const engine = new RankedMapEngine(makeConfig({ autoThreshold: 0 }), mockExecFn(), "/tmp");
+		const result = await engine.rank(index, "", 50000, undefined);
+		// Empty repo: no symbols → no files at all, no crash
+		assert.equal(result.files.length, 0, "empty repo should have no files");
+		// 0 <= 20000 (default autoThreshold) → full_dump
+		assert.equal(result.mode, "full_dump");
+	});
+});

--- a/.pi/extensions/ranked-map/test/features.test.ts
+++ b/.pi/extensions/ranked-map/test/features.test.ts
@@ -1,0 +1,600 @@
+/**
+ * Tests for new ranked-map features:
+ *   Phase 1: Default token budget increase (2048 → 4096)
+ *   Phase 2: Additional ctags exclude patterns
+ *   Phase 3: .piignore integration in buildCtagsArgs
+ *   Phase 4: Test-file penalty in scoring
+ *   Phase 5: Improved preview (ctag pattern field)
+ *   Phase 6: getStructuralOverview
+ *   Phase 7: Integration — buildCtagsArgs with extra excludes
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/ranked-map/test/features.test.ts
+ */
+
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Modules under test
+import { loadRankedMapConfig, DEFAULT_CONFIG, MAX_RECENCY_WINDOW_DAYS } from "../config.ts";
+import { buildCtagsArgs, buildSymbolIndex } from "../ctags.ts";
+import { buildPiignoreExcludes } from "../piignore.ts";
+import { isTestFile, applyTestFilePenalty, rankFiles } from "../scoring.ts";
+import { getStructuralOverview } from "../format.ts";
+import { RankedMapEngine } from "../engine.ts";
+import type { CachedIndex, RankedMapConfig, RankedFileScore, ExecFn } from "../types.ts";
+
+// ═══════════════════════════════════════════════════════════════════════
+// Helpers
+// ═══════════════════════════════════════════════════════════════════════
+
+function tmpDir(): string {
+	return mkdtempSync(join(tmpdir(), "ranked-features-"));
+}
+
+function cleanup(dir: string) {
+	try {
+		rmSync(dir, { recursive: true, force: true });
+	} catch {
+		/* ignore */
+	}
+}
+
+function mockExecFn(result?: { stdout?: string; stderr?: string; code?: number }): ExecFn {
+	return async () =>
+		Promise.resolve({
+			stdout: result?.stdout ?? "",
+			stderr: result?.stderr ?? "",
+			code: result?.code ?? 0,
+			killed: false,
+		});
+}
+
+function makeConfig(overrides?: Partial<RankedMapConfig>): RankedMapConfig {
+	return {
+		tokenBudget: 4096,
+		recencyWindowDays: 30,
+		cacheTtlHours: 24,
+		autoThreshold: 20000,
+		weights: { keyword: 0.5, recency: 0.3 },
+		...overrides,
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 1: Default token budget increase
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 1: Default token budget increase", () => {
+	it("DEFAULT_CONFIG.tokenBudget changed from 2048 to 4096", () => {
+		assert.equal(DEFAULT_CONFIG.tokenBudget, 4096);
+	});
+
+	it("loadRankedMapConfig with missing settings.json returns new default tokenBudget (4096)", () => {
+		const dir = tmpDir();
+		try {
+			const result = loadRankedMapConfig(dir);
+			assert.equal(result.tokenBudget, 4096);
+		} finally {
+			cleanup(dir);
+		}
+	});
+
+	it("loadRankedMapConfig with partial config (only recencyWindowDays) merges new default tokenBudget", () => {
+		const dir = tmpDir();
+		try {
+			mkdirSync(join(dir, ".pi"), { recursive: true });
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { recencyWindowDays: 14 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.equal(result.tokenBudget, 4096);
+			assert.equal(result.recencyWindowDays, 14);
+		} finally {
+			cleanup(dir);
+		}
+	});
+
+	it("loadRankedMapConfig with explicit tokenBudget override still works (user override > default)", () => {
+		const dir = tmpDir();
+		try {
+			mkdirSync(join(dir, ".pi"), { recursive: true });
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { tokenBudget: 8192 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.equal(result.tokenBudget, 8192);
+		} finally {
+			cleanup(dir);
+		}
+	});
+
+	it("regression: existing validation (negative/invalid tokenBudget falls back to default) still works with new default", () => {
+		const dir = tmpDir();
+		try {
+			mkdirSync(join(dir, ".pi"), { recursive: true });
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { tokenBudget: -100 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.equal(result.tokenBudget, 4096);
+		} finally {
+			cleanup(dir);
+		}
+	});
+
+	it("regression: tokenBudget=0 falls back to default 4096", () => {
+		const dir = tmpDir();
+		try {
+			mkdirSync(join(dir, ".pi"), { recursive: true });
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { tokenBudget: 0 } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.equal(result.tokenBudget, 4096);
+		} finally {
+			cleanup(dir);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2: Ctags exclude patterns
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 2: Additional ctags exclude patterns", () => {
+	it("buildCtagsArgs excludes *.jsonl (Q&A data files)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=*.jsonl"));
+	});
+
+	it("buildCtagsArgs excludes *.md (README/docs files with no code symbols)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=*.md"));
+	});
+
+	it("buildCtagsArgs excludes .pi/context/ (Q&A conversation directory)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=.pi/context"));
+	});
+
+	it("buildCtagsArgs excludes .pi/sessions/ (session logs, huge/irrelevant)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=.pi/sessions"));
+	});
+
+	it("buildCtagsArgs excludes .pi/npm/ (npm package cache)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=.pi/npm"));
+	});
+
+	it("buildCtagsArgs excludes .pi/chromium-deps/ (chromium for crawl4ai)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=.pi/chromium-deps"));
+	});
+
+	it("buildCtagsArgs excludes .pi/crawl4ai-venv/ (Python venv)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=.pi/crawl4ai-venv"));
+	});
+
+	it("buildCtagsArgs excludes flask_blogs/ (unrelated submodule)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=flask_blogs"));
+	});
+
+	it("buildCtagsArgs excludes benchmarks/ (benchmark scripts, not source)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=benchmarks"));
+	});
+
+	it("regression: existing excludes (node_modules, .git, *.json, *.min.js, *.css, static) still present", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=node_modules"));
+		assert.ok(result.args.includes("--exclude=.git"));
+		assert.ok(result.args.includes("--exclude=*.json"));
+		assert.ok(result.args.includes("--exclude=*.min.js"));
+		assert.ok(result.args.includes("--exclude=*.css"));
+		assert.ok(result.args.includes("--exclude=static"));
+	});
+
+	it("regression: --maxdepth=N still works when N > 0", () => {
+		const result = buildCtagsArgs(".", 3);
+		assert.ok(result.args.includes("--maxdepth=3"));
+	});
+
+	it("regression: omitted when N = 0", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(!result.args.some((a) => a.startsWith("--maxdepth")));
+	});
+
+	it("regression: --output-format=json still present", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--output-format=json"));
+	});
+
+	it("new excludes appear before target directory arg (order independence)", () => {
+		const result = buildCtagsArgs(".", 0);
+		const targetIdx = result.args.indexOf(".");
+		// All excludes should be before the target directory
+		const excludeArgs = result.args.filter((a) => a.startsWith("--exclude="));
+		for (const ex of excludeArgs) {
+			assert.ok(result.args.indexOf(ex) < targetIdx, `${ex} should appear before target directory`);
+		}
+	});
+
+	it("accepts extra excludes from piignore (deduplication)", () => {
+		const result = buildCtagsArgs(".", 0, ["extra_dir", "*.extra"]);
+		assert.ok(result.args.includes("--exclude=extra_dir"));
+		assert.ok(result.args.includes("--exclude=*.extra"));
+	});
+
+	it("deduplicates extra excludes that duplicate built-in excludes", () => {
+		const result = buildCtagsArgs(".", 0, ["node_modules", "*.md"]);
+		// node_modules and *.md are already in the built-in list
+		// Count occurrences — each should appear exactly once
+		const nodeModulesCount = result.args.filter((a) => a === "--exclude=node_modules").length;
+		const mdCount = result.args.filter((a) => a === "--exclude=*.md").length;
+		assert.equal(nodeModulesCount, 1, "node_modules should not be duplicated");
+		assert.equal(mdCount, 1, "*.md should not be duplicated");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 3: .piignore integration in buildCtagsArgs
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 3: .piignore integration", () => {
+	it("buildPiignoreExcludes reads .piignore and returns valid patterns", () => {
+		const dir = tmpDir();
+		try {
+			writeFileSync(join(dir, ".piignore"), ["dist/", "*.log", ".env"].join("\n"));
+			const excludes = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(excludes, ["dist", "*.log", ".env"]);
+		} finally {
+			cleanup(dir);
+		}
+	});
+
+	it("buildCtagsArgs with extraExcludes includes piignore patterns", () => {
+		const dir = tmpDir();
+		try {
+			writeFileSync(join(dir, ".piignore"), ["custom_dir/", "*.tmp"].join("\n"));
+			const piignoreExcludes = buildPiignoreExcludes(join(dir, ".piignore"));
+			const result = buildCtagsArgs(".", 0, piignoreExcludes);
+			assert.ok(result.args.includes("--exclude=custom_dir"));
+			assert.ok(result.args.includes("--exclude=*.tmp"));
+		} finally {
+			cleanup(dir);
+		}
+	});
+
+	it("buildCtagsArgs without extraExcludes still works (backward compat)", () => {
+		const result = buildCtagsArgs(".", 0);
+		// Just verifies no crash
+		assert.ok(result.args.includes("--exclude=node_modules"));
+		assert.equal(result.command, "ctags");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 4: Test-file penalty
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 4: Test-file penalty in scoring", () => {
+	it("isTestFile detects .test. pattern", () => {
+		assert.equal(isTestFile("src/foo.test.ts"), true);
+		assert.equal(isTestFile("src/foo.test.mts"), true);
+	});
+
+	it("isTestFile detects .spec. pattern", () => {
+		assert.equal(isTestFile("src/foo.spec.ts"), true);
+		assert.equal(isTestFile("src/bar.spec.js"), true);
+	});
+
+	it("isTestFile detects /test/ directory segment", () => {
+		assert.equal(isTestFile("src/test/foo.ts"), true);
+		assert.equal(isTestFile("test/index.test.ts"), true);
+	});
+
+	it("isTestFile returns false for source files", () => {
+		assert.equal(isTestFile("src/foo.ts"), false);
+		assert.equal(isTestFile("src/components/Button.tsx"), false);
+		assert.equal(isTestFile("index.ts"), false);
+	});
+
+	it("isTestFile returns false for similar but non-test patterns", () => {
+		assert.equal(isTestFile("src/contest.ts"), false);
+		assert.equal(isTestFile("src/attestation.ts"), false);
+		assert.equal(isTestFile("src/protest.ts"), false);
+	});
+
+	it("applyTestFilePenalty multiplies test file scores by 0.5", () => {
+		const files = [
+			{ path: "src/foo.test.ts", score: 1.0 },
+			{ path: "src/bar.ts", score: 1.0 },
+		];
+		applyTestFilePenalty(files);
+		assert.equal(files[0]!.score, 0.5);
+		assert.equal(files[1]!.score, 1.0);
+	});
+
+	it("applyTestFilePenalty does not modify non-test files", () => {
+		const files = [
+			{ path: "src/bar.ts", score: 0.8 },
+			{ path: "src/baz.tsx", score: 0.6 },
+		];
+		applyTestFilePenalty(files);
+		assert.equal(files[0]!.score, 0.8);
+		assert.equal(files[1]!.score, 0.6);
+	});
+
+	it("applyTestFilePenalty handles empty array", () => {
+		const files: { path: string; score: number }[] = [];
+		applyTestFilePenalty(files);
+		assert.deepEqual(files, []);
+	});
+
+	it("applyTestFilePenalty rounds to 2 decimal places", () => {
+		const files = [{ path: "src/test/foo.ts", score: 0.67 }];
+		applyTestFilePenalty(files);
+		// 0.67 * 0.5 = 0.335 → rounds to 0.34 (Math.round rounds 0.335 to 0.34... actually Math.round(33.5) = 34, so 0.34)
+		// Actually 0.67 * 0.5 = 0.335, Math.round(0.335 * 100) = Math.round(33.5) = 34, so 34/100 = 0.34
+		assert.equal(files[0]!.score, 0.34);
+	});
+
+	it("rankFiles applies test-file penalty (integration test)", () => {
+		const kw = { "src/foo.test.ts": 1.0, "src/bar.ts": 0.5 };
+		const rec = {};
+		const symbols = {
+			"src/foo.test.ts": [{ type: "function", name: "testFoo", line: 1 }],
+			"src/bar.ts": [{ type: "function", name: "bar", line: 1 }],
+		};
+		const weights = { keyword: 1.0, recency: 0.0 };
+		const result = rankFiles(kw, rec, weights, 10000, symbols);
+
+		// With kw weight 1.0 and no recency:
+		// src/foo.test.ts: 1.0 * 1.0 = 1.0 → after penalty: 0.5
+		// src/bar.ts: 0.5 * 1.0 = 0.5 → no penalty: 0.5
+		// Both score 0.5 after penalty, tie-break by alphabetical path
+		const fooEntry = result.files.find((f) => f.path === "src/foo.test.ts");
+		const barEntry = result.files.find((f) => f.path === "src/bar.ts");
+		assert.ok(fooEntry, "foo.test.ts should be in results");
+		assert.ok(barEntry, "bar.ts should be in results");
+		// With penalty, foo went from 1.0 to 0.5, bar stays at 0.5
+		// Tie-break: alphabetical → bar.ts then foo.test.ts
+		assert.equal(result.files[0]!.path, "src/bar.ts");
+		assert.equal(result.files[0]!.score, 0.5);
+		assert.equal(result.files[1]!.path, "src/foo.test.ts");
+		assert.equal(result.files[1]!.score, 0.5);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 5: Improved preview (ctag pattern field)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 5: Improved preview", () => {
+	it("buildSymbolIndex stores pattern field from ctags output", () => {
+		const jsonl = JSON.stringify({
+			_type: "tag",
+			name: "login",
+			kind: "function",
+			path: "src/auth.ts",
+			pattern: "/^  def login():$/",
+			line: 10,
+		});
+		const index = buildSymbolIndex(jsonl, "head");
+		const entry = index.symbols["src/auth.ts"]?.[0];
+		assert.ok(entry, "should have symbol entry");
+		assert.equal(entry!.pattern, "/^  def login():$/");
+	});
+
+	it("buildSymbolIndex stores undefined pattern when ctags output has no pattern field", () => {
+		const jsonl = JSON.stringify({
+			_type: "tag",
+			name: "Const",
+			kind: "constant",
+			path: "src/config.ts",
+			line: 5,
+		});
+		const index = buildSymbolIndex(jsonl, "head");
+		const entry = index.symbols["src/config.ts"]?.[0];
+		assert.ok(entry, "should have symbol entry");
+		assert.equal(entry!.pattern, undefined);
+	});
+
+	it("addPreviews uses pattern from index when available", () => {
+		const engine = new RankedMapEngine(makeConfig(), mockExecFn(), "/tmp");
+		const files: RankedFileScore[] = [
+			{ path: "src/auth.ts", score: 0.5, symbols: "src/auth.ts\n  function login", preview: "" },
+		];
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/auth.ts": [
+					{ type: "function", name: "login", line: 10, pattern: "/^  def login():$/" },
+				],
+			},
+		};
+		const result = engine.addPreviews(files, ".", "ranked", index);
+		assert.ok(result[0]!.preview.length > 0, "preview should be non-empty");
+		// Pattern stripped: /^  def login():$/ → "  def login():"
+		assert.ok(result[0]!.preview.includes("def login()"), "preview should contain the code line");
+	});
+
+	it("addPreviews falls back to first 5 lines when no pattern available", () => {
+		const engine = new RankedMapEngine(makeConfig(), mockExecFn(), "/tmp");
+		const files: RankedFileScore[] = [
+			{
+				path: "src/nopattern.ts",
+				score: 0.5,
+				symbols: "src/nopattern.ts\n  function foo",
+				preview: "",
+			},
+		];
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/nopattern.ts": [
+					{ type: "function", name: "foo", line: 1 }, // no pattern field
+				],
+			},
+		};
+		// File doesn't exist on disk, so fallback will give empty preview
+		const result = engine.addPreviews(files, ".", "ranked", index);
+		assert.equal(result[0]!.preview, "", "preview should be empty (no pattern, no file on disk)");
+	});
+
+	it("full_dump mode files unchanged even with index", () => {
+		const engine = new RankedMapEngine(makeConfig(), mockExecFn(), "/tmp");
+		const files: RankedFileScore[] = [
+			{ path: "src/a.ts", score: 0, symbols: "src/a.ts\n  function foo", preview: "" },
+		];
+		const index: CachedIndex = {
+			head: "abc",
+			builtAt: Date.now(),
+			symbols: {
+				"src/a.ts": [{ type: "function", name: "foo", line: 1, pattern: "/^function foo()$/" }],
+			},
+		};
+		const result = engine.addPreviews(files, ".", "full_dump", index);
+		assert.equal(result[0]!.preview, "", "preview should remain empty in full_dump mode");
+	});
+
+	it("regression: addPreviews without index still works (backward compat)", () => {
+		const engine = new RankedMapEngine(makeConfig(), mockExecFn(), "/tmp");
+		const files: RankedFileScore[] = [
+			{ path: "src/a.ts", score: 0.5, symbols: "src/a.ts\n  function foo", preview: "" },
+		];
+		// No index passed — should fall through to disk read
+		const result = engine.addPreviews(files, ".", "ranked");
+		assert.ok(Array.isArray(result), "should return array without index");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 6: getStructuralOverview
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 6: getStructuralOverview", () => {
+	it("returns one file per top-level directory", () => {
+		const files = ["src/a.ts", "src/b.ts", "src/sub/c.ts", "docs/readme.md", "tests/test.ts"];
+		const overview = getStructuralOverview(files);
+		assert.equal(overview.length, 3);
+		const dirs = overview.map((f) => f.path.split("/")[0]).sort();
+		assert.deepEqual(dirs, ["docs", "src", "tests"]);
+	});
+
+	it("deduplicates same top-level dir (first file wins)", () => {
+		const files = ["src/b.ts", "src/a.ts", "src/c.ts"];
+		const overview = getStructuralOverview(files);
+		assert.equal(overview.length, 1);
+		assert.equal(overview[0]!.path, "src/b.ts"); // first encountered
+	});
+
+	it("no duplicate entries when a structural file also appears in ranked results", () => {
+		const files = ["src/a.ts", "src/b.ts"];
+		const overview = getStructuralOverview(files);
+		assert.equal(overview.length, 1);
+	});
+
+	it("structural overview files get score: 0.1", () => {
+		const files = ["src/a.ts", "docs/readme.md"];
+		const overview = getStructuralOverview(files);
+		for (const f of overview) {
+			assert.equal(f.score, 0.1);
+		}
+	});
+
+	it("empty repo returns empty overview", () => {
+		const overview = getStructuralOverview([]);
+		assert.deepEqual(overview, []);
+	});
+
+	it("works with both . and ./ prefixed paths (normalized)", () => {
+		const files = ["./src/a.ts", "./docs/b.md", "./tests/c.ts"];
+		const overview = getStructuralOverview(files);
+		assert.equal(overview.length, 3);
+		// First file in each directory is kept
+		const paths = overview.map((f) => f.path);
+		assert.ok(paths.includes("./src/a.ts"));
+	});
+
+	it("handles root-level files (no directory prefix)", () => {
+		const files = ["Makefile", "README.md", "package.json", "src/a.ts"];
+		const overview = getStructuralOverview(files);
+		// Root-level files each get their own "directory" (the filename itself)
+		// src/ is one directory
+		assert.equal(overview.length, 4); // Makefile, README.md, package.json, src
+	});
+
+	it("single file returns single entry", () => {
+		const overview = getStructuralOverview(["src/a.ts"]);
+		assert.equal(overview.length, 1);
+		assert.equal(overview[0]!.path, "src/a.ts");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 7: Engine integration tests
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("Phase 7: Engine integration", () => {
+	it("buildOrLoadIndex with mock exec captures args including new excludes", async () => {
+		const dir = tmpDir();
+		try {
+			const calls: { cmd: string; args: string[] }[] = [];
+			const exec: ExecFn = async (cmd, args, _opts) => {
+				calls.push({ cmd, args });
+				return {
+					stdout:
+						JSON.stringify({
+							_type: "tag",
+							name: "fn",
+							kind: "function",
+							path: "src/a.ts",
+							pattern: "/^fn()$/",
+						}) + "\n",
+					stderr: "",
+					code: 0,
+					killed: false,
+				};
+			};
+
+			const engine = new RankedMapEngine(makeConfig(), exec, dir);
+			const index = await engine.buildOrLoadIndex(".", join(dir, "cache"), undefined);
+
+			// Find the ctags call
+			const ctagsCall = calls.find((c) => c.cmd === "ctags");
+			assert.ok(
+				ctagsCall,
+				"should have called ctags, got calls: " + JSON.stringify(calls.map((c) => c.cmd)),
+			);
+
+			// Check ctags args include new excludes
+			assert.ok(ctagsCall!.args.includes("--exclude=*.jsonl"), "should exclude *.jsonl");
+			assert.ok(ctagsCall!.args.includes("--exclude=*.md"), "should exclude *.md");
+			assert.ok(ctagsCall!.args.includes("--exclude=.pi/context"), "should exclude .pi/context");
+			assert.ok(
+				ctagsCall!.args.includes("--exclude=.pi/crawl4ai-venv"),
+				"should exclude .pi/crawl4ai-venv",
+			);
+
+			// Verify index was built
+			assert.ok(index, "should return an index");
+			assert.ok(index.symbols["src/a.ts"], "should have parsed ctags output");
+		} finally {
+			cleanup(dir);
+		}
+	});
+});

--- a/.pi/extensions/ranked-map/test/piignore.test.ts
+++ b/.pi/extensions/ranked-map/test/piignore.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for .piignore integration — reading, parsing, and converting
+ * .piignore patterns to ctags --exclude arguments.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/ranked-map/test/piignore.test.ts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parsePiignoreLine, buildPiignoreExcludes } from "../piignore.ts";
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 1: parsePiignoreLine
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("parsePiignoreLine", () => {
+	it("returns pattern for simple directory pattern", () => {
+		assert.equal(parsePiignoreLine("dist/"), "dist");
+	});
+
+	it("returns pattern for glob pattern", () => {
+		assert.equal(parsePiignoreLine("*.log"), "*.log");
+	});
+
+	it("returns pattern for path pattern without trailing slash", () => {
+		assert.equal(parsePiignoreLine(".pi/cache"), ".pi/cache");
+	});
+
+	it("returns pattern for path pattern with trailing slash", () => {
+		assert.equal(parsePiignoreLine(".pi/cache/"), ".pi/cache");
+	});
+
+	it("strips trailing /**", () => {
+		assert.equal(parsePiignoreLine("dist/**"), "dist");
+	});
+
+	it("strips trailing /** with nested path", () => {
+		assert.equal(parsePiignoreLine("build/output/**"), "build/output");
+	});
+
+	it("returns null for empty line", () => {
+		assert.equal(parsePiignoreLine(""), null);
+	});
+
+	it("returns null for whitespace-only line", () => {
+		assert.equal(parsePiignoreLine("   "), null);
+	});
+
+	it("returns null for comment line", () => {
+		assert.equal(parsePiignoreLine("# This is a comment"), null);
+	});
+
+	it("returns null for negation pattern", () => {
+		assert.equal(parsePiignoreLine("!important.ts"), null);
+	});
+
+	it("returns null for pattern with leading slash", () => {
+		assert.equal(parsePiignoreLine("/absolute/path"), null);
+	});
+
+	it("returns null for pattern with double-star in middle", () => {
+		assert.equal(parsePiignoreLine("a/**/b"), null);
+	});
+
+	it("returns pattern for simple file name", () => {
+		assert.equal(parsePiignoreLine(".env"), ".env");
+	});
+
+	it("returns pattern for wildcard extension", () => {
+		assert.equal(parsePiignoreLine("*.pem"), "*.pem");
+	});
+
+	it("returns pattern for nested glob", () => {
+		assert.equal(parsePiignoreLine("**/credentials.*"), null); // contains **
+	});
+
+	it("returns pattern for directory glob", () => {
+		assert.equal(parsePiignoreLine("old/"), "old");
+	});
+
+	it("returns null for section header comment", () => {
+		assert.equal(parsePiignoreLine("# --- Secrets ---"), null);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2: buildPiignoreExcludes
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("buildPiignoreExcludes", () => {
+	function setupDir(): string {
+		return mkdtempSync(join(tmpdir(), "piignore-test-"));
+	}
+
+	function cleanupDir(dir: string) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	}
+
+	it("returns empty array when .piignore does not exist", () => {
+		const dir = setupDir();
+		try {
+			const result = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(result, []);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("parses .piignore and returns exclude patterns", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, ".piignore"),
+				["# PiIgnore test", "", "dist/", "*.log", ".env", "build/", ""].join("\n"),
+			);
+			const result = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(result, ["dist", "*.log", ".env", "build"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("skips comments, empty lines, and negations", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, ".piignore"),
+				["# comment", "", "  ", "src/", "!important.ts", "dist/"].join("\n"),
+			);
+			const result = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(result, ["src", "dist"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("returns empty array for unreadable file", () => {
+		const result = buildPiignoreExcludes("/nonexistent/dir/.piignore");
+		assert.deepEqual(result, []);
+	});
+
+	it("handles .piignore with mixed content (sections, comments, patterns)", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, ".piignore"),
+				[
+					"# Dependencies",
+					"node_modules/",
+					"",
+					"# Build output",
+					"dist/",
+					"*.tmp",
+					"",
+					"# Secrets",
+					".env",
+					"*.pem",
+				].join("\n"),
+			);
+			const result = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(result, ["node_modules", "dist", "*.tmp", ".env", "*.pem"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("handles .piignore with trailing /** patterns", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".piignore"), ["build/**", "cache/**"].join("\n"));
+			const result = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(result, ["build", "cache"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("handles .piignore with only comments and empty lines", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(
+				join(dir, ".piignore"),
+				["# only comments", "", "# another comment"].join("\n"),
+			);
+			const result = buildPiignoreExcludes(join(dir, ".piignore"));
+			assert.deepEqual(result, []);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+});

--- a/.pi/extensions/ranked-map/test/ranked-map.test.mts
+++ b/.pi/extensions/ranked-map/test/ranked-map.test.mts
@@ -268,7 +268,7 @@ describe("loadRankedMapConfig", () => {
 		const dir = mkdtempSync(join(tmpdir(), "ranked-nopi-"));
 		try {
 			const result = loadRankedMapConfig(dir);
-			assert.strictEqual(result.tokenBudget, 2048);
+			assert.strictEqual(result.tokenBudget, 4096);
 			assert.strictEqual(result.recencyWindowDays, 30);
 			assert.strictEqual(result.cacheTtlHours, 24);
 			assert.strictEqual(result.weights.keyword, 0.5);
@@ -283,7 +283,7 @@ describe("loadRankedMapConfig", () => {
 		try {
 			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ theme: "dark" }));
 			const result = loadRankedMapConfig(dir);
-			assert.strictEqual(result.tokenBudget, 2048);
+			assert.strictEqual(result.tokenBudget, 4096);
 		} finally {
 			cleanupDir(dir);
 		}
@@ -332,7 +332,7 @@ describe("loadRankedMapConfig", () => {
 		}
 	});
 
-	it("rejects negative tokenBudget, falls back to default (2048)", () => {
+	it("rejects negative tokenBudget, falls back to default (4096)", () => {
 		const dir = setupTmpDir();
 		try {
 			writeFileSync(
@@ -340,7 +340,7 @@ describe("loadRankedMapConfig", () => {
 				JSON.stringify({ rankedMap: { tokenBudget: -100 } }),
 			);
 			const result = loadRankedMapConfig(dir);
-			assert.strictEqual(result.tokenBudget, 2048);
+			assert.strictEqual(result.tokenBudget, 4096);
 		} finally {
 			cleanupDir(dir);
 		}
@@ -354,7 +354,7 @@ describe("loadRankedMapConfig", () => {
 				JSON.stringify({ rankedMap: { tokenBudget: "abc" } }),
 			);
 			const result = loadRankedMapConfig(dir);
-			assert.strictEqual(result.tokenBudget, 2048);
+			assert.strictEqual(result.tokenBudget, 4096);
 		} finally {
 			cleanupDir(dir);
 		}
@@ -368,7 +368,7 @@ describe("loadRankedMapConfig", () => {
 				JSON.stringify({ rankedMap: { tokenBudget: 0 } }),
 			);
 			const result = loadRankedMapConfig(dir);
-			assert.strictEqual(result.tokenBudget, 2048);
+			assert.strictEqual(result.tokenBudget, 4096);
 		} finally {
 			cleanupDir(dir);
 		}
@@ -424,7 +424,7 @@ describe("loadRankedMapConfig", () => {
 		try {
 			writeFileSync(join(dir, ".pi", "settings.json"), "not json at all");
 			const result = loadRankedMapConfig(dir);
-			assert.strictEqual(result.tokenBudget, 2048);
+			assert.strictEqual(result.tokenBudget, 4096);
 			assert.strictEqual(result.recencyWindowDays, 30);
 		} finally {
 			cleanupDir(dir);
@@ -523,7 +523,7 @@ describe("loadRankedMapConfig", () => {
 
 describe("DEFAULT_CONFIG", () => {
 	it("exports a constant with correct shape", () => {
-		assert.strictEqual(DEFAULT_CONFIG.tokenBudget, 2048);
+		assert.strictEqual(DEFAULT_CONFIG.tokenBudget, 4096);
 		assert.strictEqual(DEFAULT_CONFIG.recencyWindowDays, 30);
 		assert.strictEqual(DEFAULT_CONFIG.cacheTtlHours, 24);
 		assert.strictEqual(DEFAULT_CONFIG.autoThreshold, 20000);

--- a/.pi/extensions/ranked-map/types.ts
+++ b/.pi/extensions/ranked-map/types.ts
@@ -26,6 +26,8 @@ export interface SymbolEntry {
 	type: string;
 	name: string;
 	line: number;
+	/** Optional ctag search pattern (e.g. /^function foo()$/) for preview. */
+	pattern?: string;
 }
 
 /** Scored file entry for tool output. */

--- a/.pi/extensions/session-advice/advisor.ts
+++ b/.pi/extensions/session-advice/advisor.ts
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync } from "node:fs";
-import { BashCommand } from "../../agent-harness/lib/bash-command.ts";
+import { BashCommand } from "../agent-harness/lib/bash-command.ts";
 
 // ── Types ──
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #520

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 57s | 45.1K | 24 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 3m 17s | 76.4K | 24 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 15s | 49.5K | 32 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 10m 42s | 120.4K | 120 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 1s | 31.6K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 49s | 82.6K | 53 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 38s | 49.2K | 33 | deepseek-v4-flash |

**Total:** 7 agents · 24m 39s · 454.8K tokens · 304 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/520