### PR TITLE
feat(#526): ranked_map: absolute directory breaks symbol extraction (all files show '(no symbols)')

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -10,7 +10,7 @@
   - Query-free fallback to recency-only ranking
   - Structural overview in recency-only mode — one file per top-level directory ensures broad repo awareness
 - **Configurable token budget** — Default 4096 tokens, adjustable per call
-- **Caching** — Symbol index cached to `.pi/cache/ranked-map-index.json` keyed by git HEAD
+- **Caching** — Symbol index cached to `.pi/cache/ranked-map-index.json` keyed by git HEAD and config hash (config changes invalidate the cache)
 - **Test-file penalty** — Test files (`.test.`, `.spec.`, `/test/`) receive 0.5x score penalty to favor source files
 - **.piignore integration** — Patterns from `.piignore` are automatically added as ctags excludes
 - **Improved previews** — Shows ctag definition lines (from pattern field) instead of first 5 comment/import lines
@@ -32,7 +32,7 @@ Each phase accepts `ExecFn` + config via constructor, making all methods testabl
 ## How it works
 
 1. On first call, the extension builds a symbol index via `ctags --output-format=json -R` over the target directory
-   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `.pi/context/`, `.pi/sessions/`, `.pi/npm/`, `.pi/chromium-deps/`, `.pi/crawl4ai-venv/`, `flask_blogs/`, `benchmarks/`
+   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `.pi/context/`, `.pi/sessions/`, `.pi/npm/`, `.pi/chromium-deps/`, `.pi/crawl4ai-venv/`, `benchmarks/`
    - Also reads `.piignore` for additional exclusion patterns
 2. The index is cached to disk keyed by current git HEAD
 3. When called, the extension selects mode:

--- a/.pi/extensions/ranked-map/cache.ts
+++ b/.pi/extensions/ranked-map/cache.ts
@@ -6,13 +6,47 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import type { CachedIndex, SymbolEntry } from "./types.ts";
+import type { CachedIndex, RankedMapConfig, SymbolEntry } from "./types.ts";
+
+/**
+ * Compute a deterministic hash from config values for cache invalidation.
+ *
+ * Serializes only the numeric/config fields (not builtAt or other timestamps)
+ * to produce a stable hash that changes when any config value changes.
+ */
+export function computeConfigHash(config: RankedMapConfig): string {
+	const fields = {
+		tokenBudget: config.tokenBudget,
+		recencyWindowDays: config.recencyWindowDays,
+		cacheTtlHours: config.cacheTtlHours,
+		autoThreshold: config.autoThreshold,
+		wKw: config.weights.keyword,
+		wRec: config.weights.recency,
+	};
+	const str = JSON.stringify(fields, Object.keys(fields).sort());
+	// Simple djb2 hash
+	let hash = 5381;
+	for (let i = 0; i < str.length; i++) {
+		hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+	}
+	return Math.abs(hash).toString(16);
+}
 
 /**
  * Load cached index from disk.
- * Returns null if cache missing, malformed, HEAD mismatch, or missing required keys.
+ * Returns null if cache missing, malformed, HEAD mismatch, configHash mismatch, or missing required keys.
+ *
+ * @param cachePath - Path to cached index file
+ * @param currentHead - Current git HEAD for staleness check
+ * @param configHash - Optional config hash. When provided and cached index has configHash,
+ *                     mismatch invalidates the cache. Absent configHash in cached index is
+ *                     accepted for backward compatibility.
  */
-export function loadCachedIndex(cachePath: string, currentHead: string): CachedIndex | null {
+export function loadCachedIndex(
+	cachePath: string,
+	currentHead: string,
+	configHash?: string,
+): CachedIndex | null {
 	try {
 		if (!existsSync(cachePath)) return null;
 		const raw = readFileSync(cachePath, "utf-8");
@@ -26,10 +60,20 @@ export function loadCachedIndex(cachePath: string, currentHead: string): CachedI
 		// HEAD mismatch → stale
 		if (parsed.head !== currentHead) return null;
 
+		// configHash mismatch → stale (if both present)
+		if (
+			configHash !== undefined &&
+			parsed.configHash !== undefined &&
+			parsed.configHash !== configHash
+		) {
+			return null;
+		}
+
 		return {
 			head: parsed.head,
 			builtAt: parsed.builtAt,
 			symbols: parsed.symbols as Record<string, SymbolEntry[]>,
+			configHash: typeof parsed.configHash === "string" ? parsed.configHash : undefined,
 		};
 	} catch {
 		return null;

--- a/.pi/extensions/ranked-map/ctags.ts
+++ b/.pi/extensions/ranked-map/ctags.ts
@@ -108,7 +108,7 @@ export function buildCtagsArgs(
 		}
 	}
 
-	const args: string[] = ["-R", "--output-format=json"];
+	const args: string[] = ["-R", "--output-format=json", "--tag-relative=always"];
 
 	for (const ex of excludes) {
 		args.push(`--exclude=${ex}`);
@@ -124,22 +124,42 @@ export function buildCtagsArgs(
 }
 
 /**
+ * Normalize absolute paths relative to targetDir.
+ * If the path starts with targetDir + "/", strip the prefix.
+ * Returns the path unchanged if no prefix match or no targetDir.
+ */
+export function normalizeCtagsPath(path: string, targetDir?: string): string {
+	if (!targetDir || !path) return path;
+	const prefix = targetDir.endsWith("/") ? targetDir : targetDir + "/";
+	if (path.startsWith(prefix)) {
+		return path.slice(prefix.length);
+	}
+	return path;
+}
+
+/**
  * Build symbol index from ctags JSONL output.
  * Groups symbols by file path and sorts by line number.
+ *
+ * When targetDir is provided, absolute paths are normalized to relative
+ * by stripping the targetDir prefix. This ensures symbol keys match
+ * the relative paths used by git and ripgrep.
  */
 export function buildSymbolIndex(
 	ctagsJsonl: string,
 	head: string,
 	now: number = Date.now(),
+	targetDir?: string,
 ): CachedIndex {
 	const tags = parseCtagsOutput(ctagsJsonl);
 	const symbols: Record<string, SymbolEntry[]> = {};
 
 	for (const tag of tags) {
-		if (!symbols[tag.path]) {
-			symbols[tag.path] = [];
+		const normalizedPath = normalizeCtagsPath(tag.path, targetDir);
+		if (!symbols[normalizedPath]) {
+			symbols[normalizedPath] = [];
 		}
-		symbols[tag.path]!.push({
+		symbols[normalizedPath]!.push({
 			type: tag.kind,
 			name: tag.name,
 			line: tag.line ?? 0,

--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -18,7 +18,7 @@ import {
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { buildCtagsArgs, buildSymbolIndex } from "./ctags.ts";
-import { loadCachedIndex } from "./cache.ts";
+import { loadCachedIndex, computeConfigHash } from "./cache.ts";
 import {
 	selectMode,
 	dumpAllFiles,
@@ -76,10 +76,11 @@ export class RankedMapEngine {
 	): Promise<CachedIndex> {
 		const cachePath = resolve(cacheDir, "ranked-map-index.json");
 		const currentHead = await getGitHead(this.exec, this.cwd, signal);
+		const configHash = computeConfigHash(this.config);
 
 		// Try cache first
 		if (currentHead) {
-			const cached = loadCachedIndex(cachePath, currentHead);
+			const cached = loadCachedIndex(cachePath, currentHead, configHash);
 			if (cached) return cached;
 		}
 
@@ -109,7 +110,8 @@ export class RankedMapEngine {
 			);
 		}
 
-		const index = buildSymbolIndex(result.stdout, currentHead || "unknown");
+		const index = buildSymbolIndex(result.stdout, currentHead || "unknown", undefined, targetDir);
+		index.configHash = configHash;
 
 		try {
 			writeFileSync(cachePath, JSON.stringify(index), "utf-8");

--- a/.pi/extensions/ranked-map/test/ranked-map.test.mts
+++ b/.pi/extensions/ranked-map/test/ranked-map.test.mts
@@ -41,10 +41,15 @@ import type {
 import { loadRankedMapConfig, DEFAULT_CONFIG, MAX_RECENCY_WINDOW_DAYS } from "../config.ts";
 
 // Ctags
-import { parseCtagsOutput, buildCtagsArgs, buildSymbolIndex } from "../ctags.ts";
+import {
+	parseCtagsOutput,
+	buildCtagsArgs,
+	buildSymbolIndex,
+	normalizeCtagsPath,
+} from "../ctags.ts";
 
 // Cache
-import { loadCachedIndex } from "../cache.ts";
+import { loadCachedIndex, computeConfigHash } from "../cache.ts";
 
 // Format
 import {
@@ -715,6 +720,59 @@ describe("buildCtagsArgs", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════
+// Phase 2b-ii: --tag-relative=always ctags flag
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("buildCtagsArgs — --tag-relative=always", () => {
+	it("includes --tag-relative=always with absolute targetDir", () => {
+		const result = buildCtagsArgs("/home/user/project", 0);
+		assert.ok(result.args.includes("--tag-relative=always"));
+	});
+
+	it("includes --tag-relative=always with relative targetDir", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--tag-relative=always"));
+	});
+
+	it("--tag-relative=always appears before targetDir in args", () => {
+		const result = buildCtagsArgs("/home/user/project", 0);
+		const tagRelativeIdx = result.args.indexOf("--tag-relative=always");
+		const targetIdx = result.args.indexOf("/home/user/project");
+		assert.ok(tagRelativeIdx >= 0, "--tag-relative=always should be present");
+		assert.ok(tagRelativeIdx < targetIdx, "--tag-relative=always should appear before targetDir");
+	});
+
+	it("regression: existing excludes still present when --tag-relative=always added", () => {
+		const result = buildCtagsArgs("/home/user/project", 0);
+		assert.ok(result.args.includes("--exclude=node_modules"));
+		assert.ok(result.args.includes("--exclude=.git"));
+		assert.ok(result.args.includes("--exclude=*.json"));
+		assert.ok(result.args.includes("--exclude=*.jsonl"));
+		assert.ok(result.args.includes("--exclude=*.md"));
+	});
+
+	it("regression: --output-format=json still present", () => {
+		const result = buildCtagsArgs("/home/user/project", 0);
+		assert.ok(result.args.includes("--output-format=json"));
+	});
+
+	it("regression: targetDir is still last arg", () => {
+		const result = buildCtagsArgs("/home/user/project", 0);
+		assert.strictEqual(result.args[result.args.length - 1], "/home/user/project");
+	});
+
+	it("dedup works, --tag-relative=always present with extraExcludes+absolute dir", () => {
+		const result = buildCtagsArgs("/home/user/project", 0, ["extra_dir", "*.extra"]);
+		assert.ok(result.args.includes("--tag-relative=always"));
+		assert.ok(result.args.includes("--exclude=extra_dir"));
+		assert.ok(result.args.includes("--exclude=*.extra"));
+		// node_modules should not be duplicated
+		const nodeModulesCount = result.args.filter((a) => a === "--exclude=node_modules").length;
+		assert.equal(nodeModulesCount, 1, "node_modules should not be duplicated");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
 // Phase 2c: Symbol Index Build
 // ═══════════════════════════════════════════════════════════════════════
 
@@ -753,6 +811,136 @@ describe("buildSymbolIndex", () => {
 		});
 		const result = buildSymbolIndex(ptagOutput, SAMPLE_HEAD);
 		assert.strictEqual(Object.keys(result.symbols).length, 0);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2c-ii: Path normalization (defense-in-depth)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("normalizeCtagsPath", () => {
+	it("strips targetDir prefix from absolute paths", () => {
+		const result = normalizeCtagsPath("/home/user/project/src/foo.ts", "/home/user/project");
+		assert.equal(result, "src/foo.ts");
+	});
+
+	it("handles targetDir with trailing slash", () => {
+		const result = normalizeCtagsPath("/home/user/project/src/foo.ts", "/home/user/project/");
+		assert.equal(result, "src/foo.ts");
+	});
+
+	it("returns path unchanged when no targetDir", () => {
+		const result = normalizeCtagsPath("/absolute/path/to/file.ts", undefined);
+		assert.equal(result, "/absolute/path/to/file.ts");
+	});
+
+	it("returns path unchanged when targetDir is empty string", () => {
+		const result = normalizeCtagsPath("/absolute/path/to/file.ts", "");
+		assert.equal(result, "/absolute/path/to/file.ts");
+	});
+
+	it("does not modify relative paths", () => {
+		const result = normalizeCtagsPath("src/foo.ts", "/home/user/project");
+		assert.equal(result, "src/foo.ts");
+	});
+
+	it("does not modify paths that don't start with targetDir prefix", () => {
+		const result = normalizeCtagsPath("/other/dir/file.ts", "/home/user/project");
+		assert.equal(result, "/other/dir/file.ts");
+	});
+
+	it("handles empty path", () => {
+		const result = normalizeCtagsPath("", "/home/user/project");
+		assert.equal(result, "");
+	});
+});
+
+describe("buildSymbolIndex — targetDir normalization", () => {
+	it("normalizes absolute ctags paths when targetDir provided", () => {
+		const jsonl = JSON.stringify({
+			_type: "tag",
+			name: "foo",
+			kind: "function",
+			path: "/home/user/project/src/foo.ts",
+			pattern: "/^foo()$/",
+			line: 1,
+		});
+		const index = buildSymbolIndex(jsonl, "head", undefined, "/home/user/project");
+		const keys = Object.keys(index.symbols);
+		assert.equal(keys.length, 1);
+		assert.equal(keys[0], "src/foo.ts");
+	});
+
+	it("preserves absolute paths when targetDir not provided", () => {
+		const jsonl = JSON.stringify({
+			_type: "tag",
+			name: "foo",
+			kind: "function",
+			path: "/home/user/project/src/foo.ts",
+			pattern: "/^foo()$/",
+			line: 1,
+		});
+		const index = buildSymbolIndex(jsonl, "head");
+		const keys = Object.keys(index.symbols);
+		assert.equal(keys.length, 1);
+		assert.equal(keys[0], "/home/user/project/src/foo.ts");
+	});
+
+	it("does not modify relative paths when targetDir provided", () => {
+		const jsonl = JSON.stringify({
+			_type: "tag",
+			name: "foo",
+			kind: "function",
+			path: "src/foo.ts",
+			pattern: "/^foo()$/",
+			line: 1,
+		});
+		const index = buildSymbolIndex(jsonl, "head", undefined, "/home/user/project");
+		const keys = Object.keys(index.symbols);
+		assert.equal(keys.length, 1);
+		assert.equal(keys[0], "src/foo.ts");
+	});
+
+	it("does not modify paths not matching targetDir prefix", () => {
+		const jsonl = JSON.stringify({
+			_type: "tag",
+			name: "foo",
+			kind: "function",
+			path: "/other/dir/src/foo.ts",
+			pattern: "/^foo()$/",
+			line: 1,
+		});
+		const index = buildSymbolIndex(jsonl, "head", undefined, "/home/user/project");
+		const keys = Object.keys(index.symbols);
+		assert.equal(keys.length, 1);
+		assert.equal(keys[0], "/other/dir/src/foo.ts");
+	});
+
+	it("handles empty ctags output with targetDir (no crash)", () => {
+		const index = buildSymbolIndex("", "head", undefined, "/home/user/project");
+		assert.equal(Object.keys(index.symbols).length, 0);
+	});
+
+	it("normalizes paths when some are absolute and some relative", () => {
+		const jsonl = [
+			JSON.stringify({
+				_type: "tag",
+				name: "foo",
+				kind: "function",
+				path: "/home/user/project/src/foo.ts",
+				line: 1,
+			}),
+			JSON.stringify({
+				_type: "tag",
+				name: "bar",
+				kind: "function",
+				path: "src/bar.ts",
+				line: 10,
+			}),
+		].join("\n");
+		const index = buildSymbolIndex(jsonl, "head", undefined, "/home/user/project");
+		const keys = Object.keys(index.symbols).sort();
+		assert.deepEqual(keys, ["src/bar.ts", "src/foo.ts"]);
 	});
 });
 
@@ -855,6 +1043,165 @@ describe("loadCachedIndex", () => {
 			const result = loadCachedIndex(cachePath, SAMPLE_HEAD);
 			assert.ok(result !== null);
 			assert.strictEqual(Object.keys(result!.symbols).length, 0);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2e: Config Hash Cache Invalidation
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("computeConfigHash", () => {
+	it("returns deterministic hash for same config", () => {
+		const config: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3 },
+		};
+		const hash1 = computeConfigHash(config);
+		const hash2 = computeConfigHash(config);
+		assert.equal(hash1, hash2);
+	});
+
+	it("returns different hash for different config", () => {
+		const configA: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3 },
+		};
+		const configB: RankedMapConfig = {
+			tokenBudget: 8192,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3 },
+		};
+		assert.notEqual(computeConfigHash(configA), computeConfigHash(configB));
+	});
+
+	it("returns hex string", () => {
+		const config: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3 },
+		};
+		const hash = computeConfigHash(config);
+		assert.ok(/^[0-9a-f]+$/.test(hash), "hash should be hex string, got: " + hash);
+	});
+});
+
+describe("loadCachedIndex — configHash validation", () => {
+	function setupCacheDir(): string {
+		const dir = mkdtempSync(join(tmpdir(), "ranked-cfgcache-"));
+		mkdirSync(join(dir, ".pi", "cache"), { recursive: true });
+		return dir;
+	}
+
+	function cleanupDir(dir: string) {
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			/* ignore */
+		}
+	}
+
+	it("returns cached index when configHash matches", () => {
+		const dir = setupCacheDir();
+		try {
+			const cachePath = join(dir, ".pi", "cache", "ranked-map-index.json");
+			const valid = {
+				head: SAMPLE_HEAD,
+				builtAt: Date.now(),
+				symbols: { "a.ts": [{ type: "class", name: "A", line: 1 }] },
+				configHash: "abc123",
+			};
+			writeFileSync(cachePath, JSON.stringify(valid));
+			const result = loadCachedIndex(cachePath, SAMPLE_HEAD, "abc123");
+			assert.ok(result !== null);
+			assert.equal(result!.head, SAMPLE_HEAD);
+			assert.equal(result!.configHash, "abc123");
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("returns null when configHash mismatches", () => {
+		const dir = setupCacheDir();
+		try {
+			const cachePath = join(dir, ".pi", "cache", "ranked-map-index.json");
+			const stale = {
+				head: SAMPLE_HEAD,
+				builtAt: Date.now(),
+				symbols: { "a.ts": [{ type: "class", name: "A", line: 1 }] },
+				configHash: "oldhash",
+			};
+			writeFileSync(cachePath, JSON.stringify(stale));
+			const result = loadCachedIndex(cachePath, SAMPLE_HEAD, "newhash");
+			assert.strictEqual(result, null);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("accepts cached index without configHash (backward compat)", () => {
+		const dir = setupCacheDir();
+		try {
+			const cachePath = join(dir, ".pi", "cache", "ranked-map-index.json");
+			const valid = {
+				head: SAMPLE_HEAD,
+				builtAt: Date.now(),
+				symbols: { "a.ts": [{ type: "class", name: "A", line: 1 }] },
+				// no configHash
+			};
+			writeFileSync(cachePath, JSON.stringify(valid));
+			// When current configHash is provided but cached index has none, accept it
+			const result = loadCachedIndex(cachePath, SAMPLE_HEAD, "currenthash");
+			assert.ok(result !== null);
+			assert.equal(result!.configHash, undefined);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("accepted when no configHash provided and cached has none", () => {
+		const dir = setupCacheDir();
+		try {
+			const cachePath = join(dir, ".pi", "cache", "ranked-map-index.json");
+			const valid = {
+				head: SAMPLE_HEAD,
+				builtAt: Date.now(),
+				symbols: { "a.ts": [{ type: "class", name: "A", line: 1 }] },
+			};
+			writeFileSync(cachePath, JSON.stringify(valid));
+			// No configHash argument: backward compat, no validation
+			const result = loadCachedIndex(cachePath, SAMPLE_HEAD);
+			assert.ok(result !== null);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("accepted when configHash provided but cached has none (backward compat)", () => {
+		const dir = setupCacheDir();
+		try {
+			const cachePath = join(dir, ".pi", "cache", "ranked-map-index.json");
+			const valid = {
+				head: SAMPLE_HEAD,
+				builtAt: Date.now(),
+				symbols: { "a.ts": [{ type: "class", name: "A", line: 1 }] },
+			};
+			writeFileSync(cachePath, JSON.stringify(valid));
+			const result = loadCachedIndex(cachePath, SAMPLE_HEAD, "anyhash");
+			assert.ok(result !== null);
+			assert.equal(result!.configHash, undefined);
 		} finally {
 			cleanupDir(dir);
 		}

--- a/.pi/extensions/ranked-map/types.ts
+++ b/.pi/extensions/ranked-map/types.ts
@@ -19,6 +19,8 @@ export interface CachedIndex {
 	head: string;
 	builtAt: number;
 	symbols: Record<string, SymbolEntry[]>;
+	/** Optional config hash for cache invalidation when settings change. */
+	configHash?: string;
 }
 
 /** A single symbol entry within a file. */


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #526

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 5s | 59.4K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 51s | 55.2K | 19 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 7m 37s | 110.5K | 103 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 27s | 46.5K | 29 | deepseek-v4-flash |

**Total:** 4 agents · 12m 1s · 271.6K tokens · 163 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/526