### PR TITLE
feat(#527): ranked_map: ctags --exclude basename mismatch lets vendor JS bundles pollute symbol index

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -32,7 +32,8 @@ Each phase accepts `ExecFn` + config via constructor, making all methods testabl
 ## How it works
 
 1. On first call, the extension builds a symbol index via `ctags --output-format=json -R` over the target directory
-   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `.pi/context/`, `.pi/sessions/`, `.pi/npm/`, `.pi/chromium-deps/`, `.pi/crawl4ai-venv/`, `benchmarks/`
+   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `context`, `sessions`, `npm`, `chromium-deps`, `crawl4ai-venv`, `flask_blogs`, `benchmarks`
+     - Basename-only patterns — `ctags --exclude` matches against the basename of each file/directory, so path prefixes like `.pi/` are omitted
    - Also reads `.piignore` for additional exclusion patterns
 2. The index is cached to disk keyed by current git HEAD
 3. When called, the extension selects mode:

--- a/.pi/extensions/ranked-map/ctags.ts
+++ b/.pi/extensions/ranked-map/ctags.ts
@@ -87,12 +87,14 @@ export function buildCtagsArgs(
 		// Docs — no code symbols
 		"*.md",
 		// Pi agent internals — massive, irrelevant
-		".pi/context",
-		".pi/sessions",
-		".pi/npm",
-		".pi/chromium-deps",
-		".pi/crawl4ai-venv",
-		// Submodules (no explicit exclude — let ctags index them)
+		// NOTE: ctags --exclude matches against basename only, so no path prefix allowed
+		"context",
+		"sessions",
+		"npm",
+		"chromium-deps",
+		"crawl4ai-venv",
+		// Submodules
+		"flask_blogs",
 		// Benchmarks — not source
 		"benchmarks",
 	];

--- a/.pi/extensions/ranked-map/test/features.test.ts
+++ b/.pi/extensions/ranked-map/test/features.test.ts
@@ -160,29 +160,29 @@ describe("Phase 2: Additional ctags exclude patterns", () => {
 		assert.ok(result.args.includes("--exclude=*.md"));
 	});
 
-	it("buildCtagsArgs excludes .pi/context/ (Q&A conversation directory)", () => {
+	it("buildCtagsArgs excludes context/ (Q&A conversation directory)", () => {
 		const result = buildCtagsArgs(".", 0);
-		assert.ok(result.args.includes("--exclude=.pi/context"));
+		assert.ok(result.args.includes("--exclude=context"));
 	});
 
-	it("buildCtagsArgs excludes .pi/sessions/ (session logs, huge/irrelevant)", () => {
+	it("buildCtagsArgs excludes sessions/ (session logs, huge/irrelevant)", () => {
 		const result = buildCtagsArgs(".", 0);
-		assert.ok(result.args.includes("--exclude=.pi/sessions"));
+		assert.ok(result.args.includes("--exclude=sessions"));
 	});
 
-	it("buildCtagsArgs excludes .pi/npm/ (npm package cache)", () => {
+	it("buildCtagsArgs excludes npm/ (npm package cache)", () => {
 		const result = buildCtagsArgs(".", 0);
-		assert.ok(result.args.includes("--exclude=.pi/npm"));
+		assert.ok(result.args.includes("--exclude=npm"));
 	});
 
-	it("buildCtagsArgs excludes .pi/chromium-deps/ (chromium for crawl4ai)", () => {
+	it("buildCtagsArgs excludes chromium-deps/ (chromium for crawl4ai)", () => {
 		const result = buildCtagsArgs(".", 0);
-		assert.ok(result.args.includes("--exclude=.pi/chromium-deps"));
+		assert.ok(result.args.includes("--exclude=chromium-deps"));
 	});
 
-	it("buildCtagsArgs excludes .pi/crawl4ai-venv/ (Python venv)", () => {
+	it("buildCtagsArgs excludes crawl4ai-venv/ (Python venv)", () => {
 		const result = buildCtagsArgs(".", 0);
-		assert.ok(result.args.includes("--exclude=.pi/crawl4ai-venv"));
+		assert.ok(result.args.includes("--exclude=crawl4ai-venv"));
 	});
 
 	it("buildCtagsArgs excludes flask_blogs/ (unrelated submodule)", () => {
@@ -244,6 +244,68 @@ describe("Phase 2: Additional ctags exclude patterns", () => {
 		const mdCount = result.args.filter((a) => a === "--exclude=*.md").length;
 		assert.equal(nodeModulesCount, 1, "node_modules should not be duplicated");
 		assert.equal(mdCount, 1, "*.md should not be duplicated");
+	});
+
+	it("basename-only convention: no default exclude arg contains a '/' path separator", () => {
+		const result = buildCtagsArgs(".", 0);
+		const excludeArgs = result.args.filter((a) => a.startsWith("--exclude="));
+		for (const arg of excludeArgs) {
+			const value = arg.slice("--exclude=".length);
+			// Glob patterns (containing *) are exempt — they match basename regardless
+			if (value.includes("*")) continue;
+			// Extra excludes (piignore-originated) may contain / — but we only check defaults here
+			// We're called without extraExcludes, so this tests only built-in defaults
+			assert.ok(
+				!value.includes("/"),
+				`Built-in exclude "${value}" contains "/" — ctags --exclude matches basename only, use just the basename`,
+			);
+		}
+	});
+
+	it("basename-only convention: all expected basenames have corresponding --exclude arg", () => {
+		const result = buildCtagsArgs(".", 0);
+		const basenames = [
+			"node_modules",
+			".git",
+			"static",
+			"context",
+			"sessions",
+			"npm",
+			"chromium-deps",
+			"crawl4ai-venv",
+			"flask_blogs",
+			"benchmarks",
+		];
+		for (const name of basenames) {
+			assert.ok(
+				result.args.includes(`--exclude=${name}`),
+				`Expected --exclude=${name} to be present in ctags args`,
+			);
+		}
+	});
+
+	it("glob excludes still present (globs match basename correctly, no change needed)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=*.json"), "*.json glob exclude");
+		assert.ok(result.args.includes("--exclude=*.jsonl"), "*.jsonl glob exclude");
+		assert.ok(result.args.includes("--exclude=*.md"), "*.md glob exclude");
+		assert.ok(result.args.includes("--exclude=*.css"), "*.css glob exclude");
+		assert.ok(result.args.includes("--exclude=*.min.js"), "*.min.js glob exclude");
+	});
+
+	it("extra excludes containing '/' are preserved (piignore-originated patterns are user choice)", () => {
+		const result = buildCtagsArgs(".", 0, [".pi/venv", "build/foo"]);
+		assert.ok(
+			result.args.includes("--exclude=.pi/venv"),
+			".pi/venv exclude with / should be preserved",
+		);
+		assert.ok(
+			result.args.includes("--exclude=build/foo"),
+			"build/foo exclude with / should be preserved",
+		);
+		// Verify dedup still works
+		const count = result.args.filter((a) => a === "--exclude=.pi/venv").length;
+		assert.equal(count, 1, "extra excludes with / should not be duplicated");
 	});
 });
 
@@ -584,10 +646,10 @@ describe("Phase 7: Engine integration", () => {
 			// Check ctags args include new excludes
 			assert.ok(ctagsCall!.args.includes("--exclude=*.jsonl"), "should exclude *.jsonl");
 			assert.ok(ctagsCall!.args.includes("--exclude=*.md"), "should exclude *.md");
-			assert.ok(ctagsCall!.args.includes("--exclude=.pi/context"), "should exclude .pi/context");
+			assert.ok(ctagsCall!.args.includes("--exclude=context"), "should exclude context");
 			assert.ok(
-				ctagsCall!.args.includes("--exclude=.pi/crawl4ai-venv"),
-				"should exclude .pi/crawl4ai-venv",
+				ctagsCall!.args.includes("--exclude=crawl4ai-venv"),
+				"should exclude crawl4ai-venv",
 			);
 
 			// Verify index was built


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #527

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 3m 22s | 79.3K | 33 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 5m 11s | 118.6K | 29 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 57s | 57.5K | 23 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 46s | 52.5K | 35 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 26s | 34.1K | 22 | deepseek-v4-flash |

**Total:** 5 agents · 14m 43s · 341.9K tokens · 142 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/527