### PR TITLE
feat(#545): Dead Code: tsc-checkpoint - unused pi param in runTscCheckpoint

### DIFF
--- a/.pi/extensions/supervisor/checks/tsc-decisions.ts
+++ b/.pi/extensions/supervisor/checks/tsc-decisions.ts
@@ -68,7 +68,7 @@ export function determineTscCheckpointDecision(
  * Throws if the tsc-checkpoint module is not available.
  */
 export async function getRunTscCheckpoint(): Promise<
-	(pi: ExtensionAPI, worktreePath: string) => Promise<TscCheckpointResult>
+	(worktreePath: string) => Promise<TscCheckpointResult>
 > {
 	const mod = await import("../../tsc-checkpoint");
 	return mod.runTscCheckpoint;

--- a/.pi/extensions/supervisor/pipeline/audit.ts
+++ b/.pi/extensions/supervisor/pipeline/audit.ts
@@ -89,7 +89,7 @@ export async function runTscAndLspAudit(
 		if (runTscCheckpointFn) {
 			ctx.ui.setStatus("supervisor", "Running TSC checkpoint...");
 			getDebugLogger().info("pipeline-audit", "Running TSC checkpoint", { worktreePath });
-			const tscResult = await runTscCheckpointFn(pi, worktreePath);
+			const tscResult = await runTscCheckpointFn(worktreePath);
 			const tscDecision = determineTscCheckpointDecision(tscResult, "Audit");
 
 			getDebugLogger().info("pipeline-audit", "TSC result", {

--- a/.pi/extensions/supervisor/test/pipeline-audit.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline-audit.test.mts
@@ -2,8 +2,9 @@
  * Tests for pipeline-audit.ts — worktreePath plumbing fix (Issue #284)
  *
  * Phase 1: `worktreePath` parameter plumbing in `pipeline-audit.ts`
- * Phase 2: `worktreePath` passed from `pipeline.ts` call site
- * Phase 3: Path construction consistency (resolvePath not string concat)
+ * Phase 2: `getRunTscCheckpoint` returns function with only worktreePath param
+ * Phase 3: `worktreePath` passed from `pipeline.ts` call site
+ * Phase 4: Path construction consistency (resolvePath not string concat)
  * Phase 6: Non-standard `worktreeBase` config compatibility
  *
  * Run with:
@@ -19,8 +20,10 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
-const AUDIT_TS = resolve(__dirname, "../pipeline-audit.ts");
+const AUDIT_TS = resolve(__dirname, "../pipeline/audit.ts");
 const PIPELINE_TS = resolve(__dirname, "../pipeline/handler.ts");
+const TSC_DECISIONS_TS = resolve(__dirname, "../checks/tsc-decisions.ts");
+const TSC_CHECKPOINT_INDEX_TS = resolve(__dirname, "../../tsc-checkpoint/index.ts");
 
 function readAuditSource(): string {
 	return readFileSync(AUDIT_TS, "utf-8");
@@ -56,21 +59,21 @@ describe("pipeline-audit.ts — worktreePath param plumbing (Phase 1)", () => {
 		);
 	});
 
-	it("runTscCheckpointFn called with worktreePath not ctx.cwd", () => {
+	it("runTscCheckpointFn called with worktreePath not pi", () => {
 		const src = readAuditSource();
-		// Check that runTscCheckpointFn is called with worktreePath
-		const tscCallIdx = src.indexOf("runTscCheckpointFn(pi, ");
-		assert.ok(tscCallIdx >= 0, "runTscCheckpointFn call exists");
+		// Check that runTscCheckpointFn is called with worktreePath only
+		const tscCallIdx = src.indexOf("runTscCheckpointFn(worktreePath");
+		assert.ok(tscCallIdx >= 0, "runTscCheckpointFn(worktreePath) call exists");
 		// Extract arguments after call
 		const callSection = src.substring(tscCallIdx, tscCallIdx + 80);
-		// Should reference worktreePath, not ctx.cwd
+		// Should reference worktreePath, not pi
 		assert.ok(
 			callSection.includes("worktreePath"),
-			"runTscCheckpointFn should receive worktreePath as 2nd arg",
+			"runTscCheckpointFn should receive worktreePath",
 		);
 		assert.ok(
-			!callSection.includes("ctx.cwd"),
-			"runTscCheckpointFn should NOT receive ctx.cwd as 2nd arg",
+			!callSection.includes("runTscCheckpointFn(pi,"),
+			"runTscCheckpointFn should NOT receive pi as first arg",
 		);
 	});
 
@@ -148,10 +151,58 @@ describe("pipeline-audit.ts — worktreePath param plumbing (Phase 1)", () => {
 });
 
 // ===========================================================================
-// Phase 2: `worktreePath` passed from `pipeline.ts` call site
+// Phase 2: `getRunTscCheckpoint` returns function with only worktreePath param
 // ===========================================================================
 
-describe("pipeline.ts — worktreePath passed to runTscAndLspAudit (Phase 2)", () => {
+describe("getRunTscCheckpoint — pi param removed (Phase 2)", () => {
+	it("getRunTscCheckpoint returns function with .length === 1 (no pi param)", async () => {
+		const { runTscCheckpoint } = await import("../../tsc-checkpoint/index.ts");
+		assert.strictEqual(
+			runTscCheckpoint.length,
+			1,
+			"runTscCheckpoint should accept only worktreePath",
+		);
+	});
+
+	it("getRunTscCheckpoint source shows (worktreePath: string) signature with no pi", () => {
+		const src = readFileSync(TSC_DECISIONS_TS, "utf-8");
+		const getRunIdx = src.indexOf("export async function getRunTscCheckpoint");
+		assert.ok(getRunIdx >= 0, "getRunTscCheckpoint function exists in tsc-decisions.ts");
+		// Verify the return type shows only worktreePath param (no pi)
+		const returnTypeSection = src.substring(getRunIdx, src.indexOf("> {", getRunIdx) + 3);
+		assert.ok(
+			returnTypeSection.includes("worktreePath: string"),
+			"getRunTscCheckpoint return type should have worktreePath: string",
+		);
+		assert.ok(
+			!returnTypeSection.includes("pi:"),
+			"getRunTscCheckpoint return type should NOT have pi param",
+		);
+	});
+
+	it("calling resolved function with single string argument does not throw", async () => {
+		const { runTscCheckpoint } = await import("../../tsc-checkpoint/index.ts");
+		// Should not throw — returns empty diagnostics for nonexistent path
+		await assert.doesNotReject(async () => {
+			await runTscCheckpoint("/nonexistent/tsconfig-path");
+		});
+	});
+
+	it("calling resolved function with zero args throws (worktreePath is required)", async () => {
+		const { runTscCheckpoint } = await import("../../tsc-checkpoint/index.ts");
+		// Since the function uses resolve() on worktreePath, calling without args should throw
+		await assert.rejects(async () => {
+			// @ts-expect-error testing runtime behavior with missing required param
+			await runTscCheckpoint();
+		});
+	});
+});
+
+// ===========================================================================
+// Phase 3: `worktreePath` passed from `pipeline.ts` call site
+// ===========================================================================
+
+describe("pipeline.ts — worktreePath passed to runTscAndLspAudit (Phase 3)", () => {
 	it("runTscAndLspAudit call includes worktreePath as 8th arg", () => {
 		const src = readPipelineSource();
 		// Find the runTscAndLspAudit call
@@ -183,10 +234,10 @@ describe("pipeline.ts — worktreePath passed to runTscAndLspAudit (Phase 2)", (
 });
 
 // ===========================================================================
-// Phase 3: Path construction consistency (resolvePath not string concat)
+// Phase 4: Path construction consistency (resolvePath not string concat)
 // ===========================================================================
 
-describe("pipeline-audit.ts — resolvePath used in runLspPreAudit (Phase 3)", () => {
+describe("pipeline-audit.ts — resolvePath used in runLspPreAudit (Phase 4)", () => {
 	it("resolvePath imported in pipeline-audit.ts", () => {
 		const src = readAuditSource();
 		const importSection = src.substring(0, src.indexOf("export async function"));

--- a/.pi/extensions/tsc-checkpoint/index.ts
+++ b/.pi/extensions/tsc-checkpoint/index.ts
@@ -336,10 +336,7 @@ export function formatTscDiagnostics(diagnostics: TscDiagnostic[]): string {
  * Kept for backward compatibility with supervisor pipeline.
  * Runs a one-shot tsc check using the TypeScript compiler API.
  */
-export async function runTscCheckpoint(
-	pi: ExtensionAPI,
-	worktreePath: string,
-): Promise<TscCheckpointResult> {
+export async function runTscCheckpoint(worktreePath: string): Promise<TscCheckpointResult> {
 	const configPath = resolve(worktreePath, "tsconfig.json");
 
 	if (!existsSync(configPath)) {

--- a/.pi/extensions/tsc-checkpoint/test/tsc-checkpoint.test.mts
+++ b/.pi/extensions/tsc-checkpoint/test/tsc-checkpoint.test.mts
@@ -21,9 +21,10 @@ import {
 	resolveDiagnosticFilePath,
 	formatDiagnostics,
 	formatTrend,
+	runTscCheckpoint,
 } from "../index.ts";
 
-import type { TscDiagnostic, TscWatchAdapter } from "../index.ts";
+import type { TscDiagnostic, TscWatchAdapter, TscCheckpointResult } from "../index.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
 // Mock Adapter for Testing
@@ -487,7 +488,36 @@ describe("formatTrend", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════
-// Phase 5: Integration — Extension Entry Point
+// Phase 5: runTscCheckpoint (deprecated one-shot adapter)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("runTscCheckpoint (deprecated one-shot)", () => {
+	it("is exported and callable with single worktreePath argument", async () => {
+		const result = await runTscCheckpoint("/nonexistent/path");
+		assert.ok(typeof result === "object");
+		assert.ok("diagnostics" in result);
+		assert.ok("hasErrors" in result);
+	});
+
+	it("has .length === 1 (only worktreePath param)", () => {
+		assert.strictEqual(runTscCheckpoint.length, 1);
+	});
+
+	it("calling with nonexistent path returns empty diagnostics", async () => {
+		const result = await runTscCheckpoint("/nonexistent/path");
+		assert.deepStrictEqual(result, { diagnostics: [], hasErrors: false });
+	});
+
+	it("ExtensionAPI type import still present in source (used by tscCheckpoint entry)", async () => {
+		// Verify by checking that the module still exports the entry function
+		// which depends on ExtensionAPI
+		const mod = await import("../index.ts");
+		assert.ok(typeof mod.default === "function", "default export (tscCheckpoint) still present");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 6: Integration — Extension Entry Point
 // ═══════════════════════════════════════════════════════════════════════
 
 interface MockSendUserMessage {


### PR DESCRIPTION
## Problem

`ranked_map` does not read or respect `.gitignore` files — neither the top-level one nor `.gitignore` files inside git submodules. Files and directories that are gitignored still get indexed by ctags and can appear in ranked results, polluting the symbol index with irrelevant entries.

## Evidence

Top-level `.gitignore` contains these unexcluded patterns:
- `ignore/` — temp files, ad-hoc outputs
- `custom/` — user data
- `cache/` — generated artifacts
- `.env` / `.agent_env` — secrets
- `.pi/web-search-venv/` — Python venv
- `tmp/` — temporary files

Hardcoded ctags excludes in `ctags.ts` cover: node_modules, .git, *.json, *.min.js, *.css, static, *.jsonl, *.md, context, sessions, npm, chromium-deps, crawl4ai-venv, benchmarks.

Git submodules (e.g. `flask_blogs/`) have their own `.gitignore` with entries like `__pycache__/`, `*.pyc`, `.venv/`, `venv/`, `*.so`, `dist/`, `build/`, `.eggs/`, `*.egg-info/`. These are not excluded either.

`rg --files-with-matches` (used for keyword search in ranked mode) already respects `.gitignore` natively, but ctags indexing does not.

## Proposed Solution

Add a `.gitignore` parser (similar to existing `piignore.ts`):

1. **New file**: `.pi/extensions/ranked-map/gitignore.ts`
   - `parseGitignoreLine(line: string): string | null` — same semantics as `parsePiignoreLine`
   - `buildGitignoreExcludes(gitignorePath: string): string[]`
   - `discoverGitignoreFiles(rootDir: string): string[]` — recursively find all `.gitignore` files including submodules

2. **Integrate in `engine.ts` — `buildOrLoadIndex()`**:
   - Call `discoverGitignoreFiles()` to find all `.gitignore` files
   - Merge all patterns into ctags `--exclude` args alongside hardcoded + `.piignore` patterns

### Approach

Recursively discover all `.gitignore` files (excluding `.git/`), parse each, add all patterns as top-level ctags `--exclude` args. ctags `--exclude` matches against basename, so global patterns like `__pycache__` or `*.pyc` work regardless of directory depth.

### Expected change

Current: excludes = hardcoded + piignore
Desired: excludes = hardcoded + piignore + all `.gitignore` patterns (recursive)

## Impact
- Smaller symbol index (fewer irrelevant files)
- Faster ctags execution
- Cleaner ranked results (no temp/data/venv/files appearing)
- Consistent with `ripgrep_search` behavior (which respects `.gitignore`)
- Submodule artifacts stop polluting top results

## Files
- New: `.pi/extensions/ranked-map/gitignore.ts` — parser + recursive discovery
- Modified: `.pi/extensions/ranked-map/engine.ts` — integrate into `buildOrLoadIndex()`
- Modified: `.pi/extensions/ranked-map/ctags.ts` — accept merged exclude list