### PR TITLE
fix(check-extensions): resolveRelevance no longer marks variable-arg findings as not-applicable

### DIFF
--- a/.pi/extensions/check-extensions/ast-scanner.ts
+++ b/.pi/extensions/check-extensions/ast-scanner.ts
@@ -154,9 +154,11 @@ function extractFirstArg(match: Record<string, unknown>): string[] {
  * Extract a simple argument value from the first arg string.
  * Strips surrounding quotes for clean comparison.
  */
-function cleanArg(arg: string): string {
-	return arg.replace(/^["'`]|["'`]$/g, "");
-}
+// No longer used — callArgs now stores raw (quoted) args
+// to let downstream code distinguish string literals from variable references
+// function cleanArg(arg: string): string {
+// 	return arg.replace(/^["'`]|["'`]$/g, "");
+// }
 
 /**
  * Run ast-grep for a pattern and parse JSON results.
@@ -441,7 +443,7 @@ export async function scanExtensionsAST(
 					column: colNum,
 					lineContent: firstLine.trim(),
 					matchContext: "runtime-call",
-					callArgs: args.map(cleanArg),
+					callArgs: args.map((a) => a.trim()),
 					changelogVersion: "",
 					isBreaking: false,
 					category: "",
@@ -480,7 +482,7 @@ export async function scanExtensionsAST(
 					column: colNum,
 					lineContent: firstLine.trim(),
 					matchContext: "runtime-call",
-					callArgs: args.map(cleanArg),
+					callArgs: args.map((a) => a.trim()),
 					changelogVersion: "",
 					isBreaking: false,
 					category: "",

--- a/.pi/extensions/check-extensions/change-resolver.ts
+++ b/.pi/extensions/check-extensions/change-resolver.ts
@@ -59,6 +59,14 @@ export function resolveRelevance(
 				: finding.callArgs[0];
 
 		if (targetArg) {
+			// Detect variable/expression arg (no surrounding quotes)
+			// Variables can hold any value at runtime so we can't determine
+			// relevance from static analysis alone — return undefined (falls through)
+			const firstChar = targetArg.trim()[0];
+			if (firstChar !== '"' && firstChar !== "'" && firstChar !== "`") {
+				return undefined;
+			}
+
 			// Strip quotes for comparison
 			const cleanFindingArg = targetArg.replace(/^["'`]|["'`]$/g, "");
 			const cleanEventType = structured.affectedEventType.replace(/^["'`]|["'`]$/g, "");

--- a/.pi/extensions/check-extensions/test/check-extensions.test.mts
+++ b/.pi/extensions/check-extensions/test/check-extensions.test.mts
@@ -1041,7 +1041,7 @@ describe("change-resolver", () => {
 			changelogVersion: "",
 			isBreaking: false,
 			category: "",
-			callArgs: ["tool_call"],
+			callArgs: ['"tool_call"'],
 			matchContext: "runtime-call" as const,
 		};
 		const structured: StructuredChange = {
@@ -1052,6 +1052,39 @@ describe("change-resolver", () => {
 
 		const result = resolveRelevance(entry, finding, structured);
 		assert.strictEqual(result, true);
+	});
+
+	it("returns undefined when finding uses variable arg (can't determine relevance)", () => {
+		const entry = {
+			version: "1.0.0",
+			category: "Changed" as const,
+			description: "Deprecated `pi.on(tool_call)` in favor of `pi.on(tool_before_call)`",
+			apiNames: ["on"],
+			isBreaking: true,
+		};
+		// Variable arg (eventName) — no quotes → can't statically determine relevance
+		const finding = {
+			extensionName: "caveman",
+			file: "index.ts",
+			apiName: "pi.on",
+			line: 1,
+			column: 1,
+			lineContent: "pi.on(eventName, handler)",
+			changelogVersion: "",
+			isBreaking: false,
+			category: "",
+			callArgs: ["eventName"],
+			matchContext: "runtime-call" as const,
+		};
+		const structured: StructuredChange = {
+			deprecatedSignature: 'pi.on("tool_call")',
+			newSignature: 'pi.on("tool_before_call")',
+			affectedEventType: "tool_call",
+		};
+
+		const result = resolveRelevance(entry, finding, structured);
+		// Variable arg → can't determine → undefined (falls through, no false negative)
+		assert.strictEqual(result, undefined);
 	});
 
 	it("returns false when changelog event doesn't match finding args", () => {
@@ -1072,7 +1105,7 @@ describe("change-resolver", () => {
 			changelogVersion: "",
 			isBreaking: false,
 			category: "",
-			callArgs: ["session_start"],
+			callArgs: ['"session_start"'],
 			matchContext: "runtime-call" as const,
 		};
 		const structured: StructuredChange = {
@@ -1103,7 +1136,7 @@ describe("change-resolver", () => {
 			changelogVersion: "",
 			isBreaking: false,
 			category: "",
-			callArgs: ["session_start"],
+			callArgs: ['"session_start"'],
 			matchContext: "runtime-call" as const,
 		};
 
@@ -1112,7 +1145,7 @@ describe("change-resolver", () => {
 		assert.strictEqual(result, undefined);
 	});
 
-	it("returns false when finding has no callArgs", () => {
+	it("returns undefined when finding has no callArgs", () => {
 		const entry = {
 			version: "1.0.0",
 			category: "Changed" as const,
@@ -1161,7 +1194,7 @@ describe("change-resolver", () => {
 			changelogVersion: "",
 			isBreaking: false,
 			category: "",
-			callArgs: ["my-cmd"],
+			callArgs: ['"my-cmd"'],
 			matchContext: "runtime-call" as const,
 		};
 


### PR DESCRIPTION
## Summary

Fixes #546

`resolveRelevance` compared dequoted `callArgs` with changelog's `affectedEventType`. When extensions used **variable arguments** (e.g., `pi.on(eventName)` instead of `pi.on("tool_call")`), the arg name `eventName` didn't match literal `tool_call`, causing `resolveRelevance` to return `false` → category set to `not-applicable` → **audit false negative**.

## Root Cause

`ast-scanner.ts` stored `callArgs` with `cleanArg()` which stripped surrounding quotes, losing the information about whether the original argument was a string literal or a variable reference.

## Changes

### 1. `ast-scanner.ts` — Store raw (quoted) args
- `callArgs: args.map(cleanArg)` → `callArgs: args.map((a) => a.trim())`
- String literals now preserve quotes: `"tool_call"` stays as `"tool_call"`
- Variables remain unquoted: `eventName` stays as `eventName`
- `cleanArg` function removed (commented out with explanation)

### 2. `change-resolver.ts` — Detect variable args
- Before comparing, check if `targetArg` starts with a quote character
- If unquoted → variable/expression → return `undefined` (can't determine relevance from static analysis) instead of `false` (definitely not applicable)
- String literals still correctly compared and filtered

### 3. `check-extensions.test.mts` — Updated tests
- All `resolveRelevance` test fixtures: `callArgs` now use quoted format (matching raw-arg storage)
- **New test**: `"returns undefined when finding uses variable arg"` — verifies variable args return `undefined` (no false negative)
- Fixed misleading test name: `"returns false when finding has no callArgs"` → `"returns undefined when finding has no callArgs"`

## Testing

- ✅ All 117 tests pass (`check-extensions.test.mts`)
- ✅ All 22 pipeline tests pass (`pipeline.test.ts`)
- No breaking changes to public API