### PR TITLE
feat(#574): ranked-map: add web-search-venv to built-in ctags excludes

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -33,7 +33,7 @@ Each phase accepts `ExecFn` + config via constructor, making all methods testabl
 ## How it works
 
 1. On first call, the extension builds a symbol index via `ctags --output-format=json -R` over the target directory
-   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `context`, `sessions`, `npm`, `chromium-deps`, `crawl4ai-venv`, `benchmarks`
+   - Automatically excludes: `node_modules`, `.git`, `*.json`, `*.jsonl`, `*.md`, `*.min.js`, `*.css`, `static`, `context`, `sessions`, `npm`, `chromium-deps`, `crawl4ai-venv`, `web-search-venv`, `benchmarks`
      - Basename-only patterns — `ctags --exclude` matches against the basename of each file/directory, so path prefixes like `.pi/` are omitted
    - Also reads `.piignore` for additional exclusion patterns
 2. The index is cached to disk keyed by current git HEAD, config hash, and target directory scope

--- a/.pi/extensions/ranked-map/ctags.ts
+++ b/.pi/extensions/ranked-map/ctags.ts
@@ -93,6 +93,7 @@ export function buildCtagsArgs(
 		"npm",
 		"chromium-deps",
 		"crawl4ai-venv",
+		"web-search-venv",
 		// Submodules scanned like any other directory
 		// Benchmarks — not source
 		"benchmarks",

--- a/.pi/extensions/ranked-map/test/features.test.ts
+++ b/.pi/extensions/ranked-map/test/features.test.ts
@@ -191,6 +191,11 @@ describe("Phase 2: Additional ctags exclude patterns", () => {
 		assert.ok(result.args.includes("--exclude=crawl4ai-venv"));
 	});
 
+	it("buildCtagsArgs excludes web-search-venv/ (Python venv for web search)", () => {
+		const result = buildCtagsArgs(".", 0);
+		assert.ok(result.args.includes("--exclude=web-search-venv"));
+	});
+
 	it("buildCtagsArgs no longer excludes flask_blogs/ (submodule scanned like any other directory)", () => {
 		const result = buildCtagsArgs(".", 0);
 		assert.ok(!result.args.includes("--exclude=flask_blogs"));
@@ -279,6 +284,7 @@ describe("Phase 2: Additional ctags exclude patterns", () => {
 			"npm",
 			"chromium-deps",
 			"crawl4ai-venv",
+			"web-search-venv",
 			"benchmarks",
 		];
 		for (const name of basenames) {
@@ -1149,6 +1155,7 @@ describe("Phase 9: Git submodule indexing (flask_blogs)", () => {
 			"npm",
 			"chromium-deps",
 			"crawl4ai-venv",
+			"web-search-venv",
 			"benchmarks",
 		];
 		for (const ex of standardExcludes) {

--- a/.pi/extensions/ranked-map/test/mts-support.test.ts
+++ b/.pi/extensions/ranked-map/test/mts-support.test.ts
@@ -93,6 +93,7 @@ describe("Phase 2: Regression — existing args unchanged", () => {
 			"npm",
 			"chromium-deps",
 			"crawl4ai-venv",
+			"web-search-venv",
 			"benchmarks",
 		];
 		for (const ex of standardExcludes) {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #574

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 27s | 28.9K | 10 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 18s | 108.6K | 21 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 27s | 33.7K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 33s | 36.2K | 27 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 50s | 37.0K | 39 | deepseek-v4-flash |

**Total:** 5 agents · 6m 36s · 244.4K tokens · 111 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/574