### PR TITLE
feat(#575): ranked-map: piignore path-prefixed ctags excludes are no-ops (basename matching)

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -90,7 +90,7 @@ The extension automatically reads `.piignore` from the project root and converts
 
 - Directory patterns (`dist/` → `--exclude=dist`)
 - Glob patterns (`*.log` → `--exclude=*.log`)
-- Path patterns (`.pi/cache` → `--exclude=.pi/cache`)
+- Path patterns (`.pi/cache` → `--exclude=cache` via basename extraction)
 
 Comments and negations are skipped. Patterns with double-star (`**`) or leading slash (`/`) are skipped.
 

--- a/.pi/extensions/ranked-map/piignore.ts
+++ b/.pi/extensions/ranked-map/piignore.ts
@@ -8,7 +8,7 @@
  * - Comment lines (#)
  * - Directory patterns (dir/ → --exclude=dir)
  * - Glob patterns (*.ext → --exclude=*.ext)
- * - Path patterns (path/to/dir/ → --exclude=path/to/dir)
+ * - Path patterns — extracts basename for ctags compat (path/to/dir/ → --exclude=dir)
  * - Negation patterns (!pattern → skipped, ctags can't negate)
  *
  * Not supported (silently skipped):
@@ -50,10 +50,20 @@ export function parseIgnoreLine(line: string): string | null {
 
 	// Ctags --exclude supports globs but not ** (double-star)
 	// Skip patterns containing ** that aren't just trailing /**
+	// NOTE: check before basename extraction — a/**/b must be rejected
+	// even though basename alone ("b") wouldn't contain **.
 	if (pattern.includes("**")) return null;
 
 	// Skip patterns with leading / (absolute-style paths)
+	// NOTE: check before basename extraction — /absolute/path must be
+	// rejected even though basename alone ("path") wouldn't start with /.
 	if (pattern.startsWith("/")) return null;
+
+	// Extract basename (last path component) for ctags --exclude compatibility.
+	// ctags --exclude matches against basename only, not full path.
+	if (pattern.includes("/")) {
+		pattern = pattern.split("/").pop()!;
+	}
 
 	return pattern || null;
 }

--- a/.pi/extensions/ranked-map/test/piignore.test.ts
+++ b/.pi/extensions/ranked-map/test/piignore.test.ts
@@ -32,20 +32,20 @@ describe("parsePiignoreLine", () => {
 		assert.equal(parsePiignoreLine("*.log"), "*.log");
 	});
 
-	it("returns pattern for path pattern without trailing slash", () => {
-		assert.equal(parsePiignoreLine(".pi/cache"), ".pi/cache");
+	it("extracts basename for path pattern without trailing slash", () => {
+		assert.equal(parsePiignoreLine(".pi/cache"), "cache");
 	});
 
-	it("returns pattern for path pattern with trailing slash", () => {
-		assert.equal(parsePiignoreLine(".pi/cache/"), ".pi/cache");
+	it("extracts basename for path pattern with trailing slash", () => {
+		assert.equal(parsePiignoreLine(".pi/cache/"), "cache");
 	});
 
 	it("strips trailing /**", () => {
 		assert.equal(parsePiignoreLine("dist/**"), "dist");
 	});
 
-	it("strips trailing /** with nested path", () => {
-		assert.equal(parsePiignoreLine("build/output/**"), "build/output");
+	it("extracts basename for nested path with trailing /**", () => {
+		assert.equal(parsePiignoreLine("build/output/**"), "output");
 	});
 
 	it("returns null for empty line", () => {
@@ -217,20 +217,46 @@ describe("parseIgnoreLine", () => {
 		assert.equal(parseIgnoreLine("*.log"), "*.log");
 	});
 
-	it("returns pattern for path pattern without trailing slash", () => {
-		assert.equal(parseIgnoreLine(".pi/cache"), ".pi/cache");
+	it("extracts basename for path pattern without trailing slash", () => {
+		assert.equal(parseIgnoreLine(".pi/cache"), "cache");
 	});
 
-	it("returns pattern for path pattern with trailing slash", () => {
-		assert.equal(parseIgnoreLine(".pi/cache/"), ".pi/cache");
+	it("extracts basename for path pattern with trailing slash", () => {
+		assert.equal(parseIgnoreLine(".pi/cache/"), "cache");
 	});
 
 	it("strips trailing /**", () => {
 		assert.equal(parseIgnoreLine("dist/**"), "dist");
 	});
 
-	it("strips trailing /** with nested path", () => {
-		assert.equal(parseIgnoreLine("build/output/**"), "build/output");
+	it("extracts basename for nested path with trailing /**", () => {
+		assert.equal(parseIgnoreLine("build/output/**"), "output");
+	});
+
+	// ── Path-prefixed patterns (real-world .piignore use) ──
+
+	it("extracts basename for .pi/npm (no trailing slash)", () => {
+		assert.equal(parseIgnoreLine(".pi/npm"), "npm");
+	});
+
+	it("extracts basename for .pi/npm/ (with trailing slash)", () => {
+		assert.equal(parseIgnoreLine(".pi/npm/"), "npm");
+	});
+
+	it("extracts basename for .pi/chromium-deps/", () => {
+		assert.equal(parseIgnoreLine(".pi/chromium-deps/"), "chromium-deps");
+	});
+
+	it("extracts basename for .pi/crawl4ai-venv/", () => {
+		assert.equal(parseIgnoreLine(".pi/crawl4ai-venv/"), "crawl4ai-venv");
+	});
+
+	it("extracts basename for deeply nested path a/b/c/d/", () => {
+		assert.equal(parseIgnoreLine("a/b/c/d/"), "d");
+	});
+
+	it("extracts filename for some/path/file.ts", () => {
+		assert.equal(parseIgnoreLine("some/path/file.ts"), "file.ts");
 	});
 
 	it("returns null for empty line", () => {
@@ -558,4 +584,3 @@ describe("backward compatibility — old names are aliases", () => {
 		}
 	});
 });
-


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #575

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 38s | 21.3K | 16 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 56s | 91.7K | 20 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 13s | 38.5K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 30s | 46.4K | 33 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 14s | 33.7K | 25 | deepseek-v4-flash |

**Total:** 5 agents · 8m 29s · 231.6K tokens · 109 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/575