### PR TITLE
feat(#577): ranked-map: config weights sum to 0.8 instead of 1.0, missing fileSize weight

### DIFF
--- a/.pi/extensions/ranked-map/PRD.md
+++ b/.pi/extensions/ranked-map/PRD.md
@@ -43,7 +43,7 @@ Refactor the `ranked-map` extension from a single 877-line monolith file at `.pi
 | Parameters: `query`, `tokenBudget`, `directory`                                                                           | Tool params       | ✅ No change                       |
 | Output: `files`, `total_tokens`, `budget`, `truncated`, `mode`                                                            | Tool output shape | ✅ No change                       |
 | Config key `rankedMap` in `.pi/settings.json`                                                                             | Config            | ✅ No change                       |
-| Config fields: `tokenBudget`, `recencyWindowDays`, `cacheTtlHours`, `autoThreshold`, `weights.keyword`, `weights.recency` | Config            | ✅ No change                       |
+| Config fields: `tokenBudget`, `recencyWindowDays`, `cacheTtlHours`, `autoThreshold`, `weights.keyword`, `weights.recency`, `weights.fileSize` | Config            | ✅ No change                       |
 | Cache file `.pi/cache/ranked-map-index.json`                                                                              | Cache format      | ✅ No change                       |
 | Exported pure functions for testing                                                                                       | Test imports      | ✅ All re-exported from `index.ts` |
 
@@ -154,7 +154,7 @@ export interface RankedMapConfig {
 	recencyWindowDays: number;
 	cacheTtlHours: number;
 	autoThreshold: number;
-	weights: { keyword: number; recency: number };
+	weights: { keyword: number; recency: number; fileSize?: number };
 }
 
 export interface CachedIndex {

--- a/.pi/extensions/ranked-map/cache.ts
+++ b/.pi/extensions/ranked-map/cache.ts
@@ -22,6 +22,7 @@ export function computeConfigHash(config: RankedMapConfig): string {
 		autoThreshold: config.autoThreshold,
 		wKw: config.weights.keyword,
 		wRec: config.weights.recency,
+		wFs: config.weights.fileSize ?? 0,
 	};
 	const str = JSON.stringify(fields, Object.keys(fields).sort());
 	// Simple djb2 hash

--- a/.pi/extensions/ranked-map/config.ts
+++ b/.pi/extensions/ranked-map/config.ts
@@ -15,7 +15,7 @@ export const DEFAULT_CONFIG: RankedMapConfig = {
 	recencyWindowDays: 30,
 	cacheTtlHours: 24,
 	autoThreshold: 20000,
-	weights: { keyword: 0.5, recency: 0.3 },
+	weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 };
 
 /** Maximum allowed recency window in days. */
@@ -75,6 +75,7 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 
 		let kwWeight = DEFAULT_CONFIG.weights.keyword;
 		let recWeight = DEFAULT_CONFIG.weights.recency;
+		let fsWeight: number = DEFAULT_CONFIG.weights.fileSize ?? 0;
 
 		if (rm.weights && typeof rm.weights === "object") {
 			const w = rm.weights;
@@ -97,10 +98,31 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 				recWeight = w.recency;
 			}
 
-			const sum = kwWeight + recWeight;
+			// When fileSize is explicitly present, validate it.
+			// When absent from the weights object, default to 0 to avoid
+			// surprising normalization of user-provided keyword+recency weights.
+			if ("fileSize" in w) {
+				if (
+					typeof w.fileSize === "number" &&
+					Number.isFinite(w.fileSize) &&
+					w.fileSize >= 0 &&
+					w.fileSize <= 1
+				) {
+					fsWeight = w.fileSize;
+				} else {
+					// Present but invalid — fall back to default
+					fsWeight = DEFAULT_CONFIG.weights.fileSize ?? 0.2;
+				}
+			} else {
+				// Not present in weights object — default to 0
+				fsWeight = 0;
+			}
+
+			const sum = kwWeight + recWeight + fsWeight;
 			if (sum > 1) {
 				kwWeight = kwWeight / sum;
 				recWeight = recWeight / sum;
+				fsWeight = fsWeight / sum;
 			}
 		}
 
@@ -109,7 +131,7 @@ export function loadRankedMapConfig(cwd: string): RankedMapConfig {
 			recencyWindowDays,
 			cacheTtlHours,
 			autoThreshold,
-			weights: { keyword: kwWeight, recency: recWeight },
+			weights: { keyword: kwWeight, recency: recWeight, fileSize: fsWeight },
 		};
 	} catch {
 		return { ...DEFAULT_CONFIG };

--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -15,7 +15,7 @@ import {
 	type RankedFileScore,
 	type RankedMapResult,
 } from "./types.ts";
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, statSync } from "node:fs";
 import { resolve, join } from "node:path";
 import { buildCtagsArgs, buildSymbolIndex } from "./ctags.ts";
 import { loadCachedIndex, computeConfigHash } from "./cache.ts";
@@ -26,7 +26,12 @@ import {
 	getStructuralOverview,
 	formatSymbols,
 } from "./format.ts";
-import { computeKeywordScores, computeRecencyScores, rankFiles } from "./scoring.ts";
+import {
+	computeKeywordScores,
+	computeRecencyScores,
+	computeFileSizeScores,
+	rankFiles,
+} from "./scoring.ts";
 import { runKeywordSearch } from "./search.ts";
 import { runGitRecency, getGitHead } from "./git.ts";
 import { buildPiignoreExcludes, buildIgnoreExcludes, discoverIgnoreFiles } from "./piignore.ts";
@@ -181,12 +186,27 @@ export class RankedMapEngine {
 		);
 		const recencyScores = computeRecencyScores(fileDates, this.config.recencyWindowDays);
 
+		// Compute file size scores for file size penalty
+		const fileSizes: Record<string, number> = {};
+		for (const filePath of Object.keys(index.symbols)) {
+			try {
+				const fullPath = resolve(this.cwd, targetDir, filePath);
+				if (existsSync(fullPath)) {
+					fileSizes[filePath] = statSync(fullPath).size;
+				}
+			} catch {
+				// ignore files that can't be read
+			}
+		}
+		const fileSizeScores = computeFileSizeScores(fileSizes);
+
 		const ranked = rankFiles(
 			keywordScores,
 			recencyScores,
 			this.config.weights,
 			budget,
 			index.symbols,
+			fileSizeScores,
 		);
 
 		// In recency-only mode (no query), inject structural overview files

--- a/.pi/extensions/ranked-map/scoring.ts
+++ b/.pi/extensions/ranked-map/scoring.ts
@@ -68,6 +68,43 @@ export function computeRecencyScores(
 }
 
 /**
+ * Compute file size penalty scores.
+ *
+ * Smaller files get higher scores (closer to 1.0), larger files get lower
+ * scores (closer to 0.0). This encourages smaller, more focused files to
+ * rank higher than large monolithic files with similar keyword/recency scores.
+ *
+ * Score formula: score = 1 - (fileSize - minSize) / (maxSize - minSize)
+ * - Smallest file → score 1.0
+ * - Largest file → score 0.0
+ * - All files same size → all get 0 (no penalty distinction)
+ * - Single file → score 0
+ */
+export function computeFileSizeScores(fileSizes: Record<string, number>): Record<string, number> {
+	const scores: Record<string, number> = {};
+	const sizes = Object.values(fileSizes);
+
+	if (sizes.length === 0) return scores;
+
+	const minSize = Math.min(...sizes);
+	const maxSize = Math.max(...sizes);
+
+	// All same size (including single file) → all get 0
+	if (maxSize === minSize) {
+		for (const file of Object.keys(fileSizes)) {
+			scores[file] = 0;
+		}
+		return scores;
+	}
+
+	for (const [file, size] of Object.entries(fileSizes)) {
+		scores[file] = Math.round((1 - (size - minSize) / (maxSize - minSize)) * 100) / 100;
+	}
+
+	return scores;
+}
+
+/**
  * Apply test-file penalty to a set of ranked file scores.
  *
  * Files matching test patterns (.test., .spec., /test/) get their score
@@ -103,18 +140,22 @@ export function applyTestFilePenalty(files: { path: string; score: number }[]): 
 }
 
 /**
- * Rank files by combined score (weighted sum of keyword + recency),
+ * Rank files by combined score (weighted sum of keyword + recency + fileSize),
  * sort descending, and fill within token budget (greedy).
  *
  * Test files (.test., .spec., /test/) receive a 0.5x score penalty
  * so source files rank higher than their corresponding tests.
+ *
+ * @param fileSizeScores - Optional file size scores from computeFileSizeScores.
+ *                         When omitted, fileSize weight contributes 0 to the score.
  */
 export function rankFiles(
 	keywordScores: Record<string, number>,
 	recencyScores: Record<string, number>,
-	weights: { keyword: number; recency: number },
+	weights: { keyword: number; recency: number; fileSize?: number },
 	tokenBudget: number,
 	symbolEntries: Record<string, SymbolEntry[]>,
+	fileSizeScores?: Record<string, number>,
 ): { files: RankedFileScore[]; totalTokens: number; truncated: boolean } {
 	const allFiles = new Set([
 		...Object.keys(keywordScores),
@@ -128,8 +169,10 @@ export function rankFiles(
 	for (const file of allFiles) {
 		const kw = keywordScores[file] ?? 0;
 		const rec = recencyScores[file] ?? 0;
+		const fs = fileSizeScores?.[file] ?? 0;
+		const fsWeight = weights.fileSize ?? 0;
 		const syms = symbolEntries[file] ?? [];
-		const score = kw * weights.keyword + rec * weights.recency;
+		const score = kw * weights.keyword + rec * weights.recency + fs * fsWeight;
 		scored.push({ path: file, score: Math.round(score * 100) / 100, symbols: syms });
 	}
 

--- a/.pi/extensions/ranked-map/test/engine.test.ts
+++ b/.pi/extensions/ranked-map/test/engine.test.ts
@@ -31,7 +31,7 @@ const defaultConfig: RankedMapConfig = {
 	recencyWindowDays: 30,
 	cacheTtlHours: 24,
 	autoThreshold: 20000,
-	weights: { keyword: 0.5, recency: 0.3 },
+	weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 };
 
 function mockExec(): ReturnType<typeof mock.fn<ExecFn>> {

--- a/.pi/extensions/ranked-map/test/features.test.ts
+++ b/.pi/extensions/ranked-map/test/features.test.ts
@@ -65,7 +65,7 @@ function makeConfig(overrides?: Partial<RankedMapConfig>): RankedMapConfig {
 		recencyWindowDays: 30,
 		cacheTtlHours: 24,
 		autoThreshold: 20000,
-		weights: { keyword: 0.5, recency: 0.3 },
+		weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 		...overrides,
 	};
 }

--- a/.pi/extensions/ranked-map/test/ranked-map.test.mts
+++ b/.pi/extensions/ranked-map/test/ranked-map.test.mts
@@ -188,9 +188,55 @@ describe("types module exports", () => {
 			recencyWindowDays: 30,
 			cacheTtlHours: 24,
 			autoThreshold: 20000,
-			weights: { keyword: 0.5, recency: 0.3 },
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 		};
 		assert.strictEqual(config.tokenBudget, 2048);
+	});
+
+	it("RankedMapConfig accepts weights with fileSize field", () => {
+		const config: RankedMapConfig = {
+			tokenBudget: 2048,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.6, recency: 0.3, fileSize: 0.1 },
+		};
+		assert.strictEqual(config.weights.fileSize, 0.1);
+	});
+
+	it("RankedMapConfig accepts fileSize=0 (lower bound)", () => {
+		const config: RankedMapConfig = {
+			tokenBudget: 2048,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.7, recency: 0.3, fileSize: 0 },
+		};
+		assert.strictEqual(config.weights.fileSize, 0);
+	});
+
+	it("RankedMapConfig accepts fileSize=1 (upper bound)", () => {
+		const config: RankedMapConfig = {
+			tokenBudget: 2048,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0, recency: 0, fileSize: 1 },
+		};
+		assert.strictEqual(config.weights.fileSize, 1);
+	});
+
+	it("RankedMapConfig requires fileSize in weights", () => {
+		const config: RankedMapConfig = {
+			tokenBudget: 2048,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
+		};
+		assert.strictEqual(config.weights.keyword, 0.5);
+		assert.strictEqual(config.weights.recency, 0.3);
+		assert.strictEqual(config.weights.fileSize, 0.2);
 	});
 
 	it("CachedIndex is a valid type interface", () => {
@@ -296,6 +342,7 @@ describe("loadRankedMapConfig", () => {
 			assert.strictEqual(result.cacheTtlHours, 24);
 			assert.strictEqual(result.weights.keyword, 0.5);
 			assert.strictEqual(result.weights.recency, 0.3);
+			assert.strictEqual(result.weights.fileSize, 0.2);
 		} finally {
 			cleanupDir(dir);
 		}
@@ -307,6 +354,7 @@ describe("loadRankedMapConfig", () => {
 			writeFileSync(join(dir, ".pi", "settings.json"), JSON.stringify({ theme: "dark" }));
 			const result = loadRankedMapConfig(dir);
 			assert.strictEqual(result.tokenBudget, 4096);
+			assert.strictEqual(result.weights.fileSize, 0.2);
 		} finally {
 			cleanupDir(dir);
 		}
@@ -468,6 +516,7 @@ describe("loadRankedMapConfig", () => {
 			assert.strictEqual(result.autoThreshold, 20000); // default
 			assert.strictEqual(result.weights.keyword, 0.5); // default
 			assert.strictEqual(result.weights.recency, 0.3); // default
+			assert.strictEqual(result.weights.fileSize, 0.2); // default
 		} finally {
 			cleanupDir(dir);
 		}
@@ -542,6 +591,131 @@ describe("loadRankedMapConfig", () => {
 			cleanupDir(dir);
 		}
 	});
+
+	it("parses custom fileSize weight from settings.json", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.6, recency: 0.3, fileSize: 0.1 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.keyword, 0.6);
+			assert.strictEqual(result.weights.recency, 0.3);
+			assert.strictEqual(result.weights.fileSize, 0.1);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("rejects fileSize < 0, falls back to default", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.5, recency: 0.3, fileSize: -0.1 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.keyword, 0.5);
+			assert.strictEqual(result.weights.recency, 0.3);
+			assert.strictEqual(result.weights.fileSize, 0.2);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("rejects fileSize > 1, falls back to default", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.5, recency: 0.3, fileSize: 1.5 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.fileSize, 0.2);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("rejects non-numeric fileSize, falls back to default", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.5, recency: 0.3, fileSize: "abc" } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.fileSize, 0.2);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("normalizes sum of keyword+recency+fileSize when sum > 1", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.8, recency: 0.6, fileSize: 0.6 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			// 0.8 + 0.6 + 0.6 = 2.0, normalize: 0.8/2.0 = 0.4, 0.6/2.0 = 0.3, 0.6/2.0 = 0.3
+			assert.ok(Math.abs(result.weights.keyword - 0.4) < 0.01);
+			assert.ok(Math.abs(result.weights.recency - 0.3) < 0.01);
+			assert.ok(Math.abs(result.weights.fileSize! - 0.3) < 0.01);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("partial config with only fileSize sets defaults for keyword and recency", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { fileSize: 0.1 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.keyword, 0.5);
+			assert.strictEqual(result.weights.recency, 0.3);
+			assert.strictEqual(result.weights.fileSize, 0.1);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("fileSize: 0 does not trigger normalization when keyword+recency+fileSize <= 1", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.5, recency: 0.3, fileSize: 0 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.keyword, 0.5);
+			assert.strictEqual(result.weights.recency, 0.3);
+			assert.strictEqual(result.weights.fileSize, 0);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("fileSize: 0.2 with keyword 0.5 and recency 0.3 sums to 1.0 exactly, no normalization", () => {
+		const dir = setupTmpDir();
+		try {
+			writeFileSync(
+				join(dir, ".pi", "settings.json"),
+				JSON.stringify({ rankedMap: { weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 } } }),
+			);
+			const result = loadRankedMapConfig(dir);
+			assert.strictEqual(result.weights.keyword, 0.5);
+			assert.strictEqual(result.weights.recency, 0.3);
+			assert.strictEqual(result.weights.fileSize, 0.2);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
 });
 
 describe("DEFAULT_CONFIG", () => {
@@ -552,6 +726,12 @@ describe("DEFAULT_CONFIG", () => {
 		assert.strictEqual(DEFAULT_CONFIG.autoThreshold, 20000);
 		assert.strictEqual(DEFAULT_CONFIG.weights.keyword, 0.5);
 		assert.strictEqual(DEFAULT_CONFIG.weights.recency, 0.3);
+		assert.strictEqual(DEFAULT_CONFIG.weights.fileSize, 0.2);
+	});
+
+	it("default weights sum to exactly 1.0", () => {
+		const { keyword, recency, fileSize } = DEFAULT_CONFIG.weights;
+		assert.strictEqual(keyword + recency + (fileSize ?? 0), 1.0);
 	});
 
 	it("MAX_RECENCY_WINDOW_DAYS is 365", () => {
@@ -1078,7 +1258,7 @@ describe("computeConfigHash", () => {
 			recencyWindowDays: 30,
 			cacheTtlHours: 24,
 			autoThreshold: 20000,
-			weights: { keyword: 0.5, recency: 0.3 },
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 		};
 		const hash1 = computeConfigHash(config);
 		const hash2 = computeConfigHash(config);
@@ -1091,14 +1271,14 @@ describe("computeConfigHash", () => {
 			recencyWindowDays: 30,
 			cacheTtlHours: 24,
 			autoThreshold: 20000,
-			weights: { keyword: 0.5, recency: 0.3 },
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 		};
 		const configB: RankedMapConfig = {
 			tokenBudget: 8192,
 			recencyWindowDays: 30,
 			cacheTtlHours: 24,
 			autoThreshold: 20000,
-			weights: { keyword: 0.5, recency: 0.3 },
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 		};
 		assert.notEqual(computeConfigHash(configA), computeConfigHash(configB));
 	});
@@ -1109,10 +1289,46 @@ describe("computeConfigHash", () => {
 			recencyWindowDays: 30,
 			cacheTtlHours: 24,
 			autoThreshold: 20000,
-			weights: { keyword: 0.5, recency: 0.3 },
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
 		};
 		const hash = computeConfigHash(config);
 		assert.ok(/^[0-9a-f]+$/.test(hash), "hash should be hex string, got: " + hash);
+	});
+
+	it("returns different hash when fileSize weight changes (cache invalidation)", () => {
+		const baseConfig: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
+		};
+		const changedConfig: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.1 },
+		};
+		assert.notEqual(computeConfigHash(baseConfig), computeConfigHash(changedConfig));
+	});
+
+	it("different fileSize values produce different hash", () => {
+		const configA: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0.2 },
+		};
+		const configB: RankedMapConfig = {
+			tokenBudget: 4096,
+			recencyWindowDays: 30,
+			cacheTtlHours: 24,
+			autoThreshold: 20000,
+			weights: { keyword: 0.5, recency: 0.3, fileSize: 0 },
+		};
+		assert.notEqual(computeConfigHash(configA), computeConfigHash(configB));
 	});
 });
 

--- a/.pi/extensions/ranked-map/test/scoring.test.ts
+++ b/.pi/extensions/ranked-map/test/scoring.test.ts
@@ -10,7 +10,12 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { rankFiles, computeKeywordScores, computeRecencyScores } from "../scoring.ts";
+import {
+	rankFiles,
+	computeKeywordScores,
+	computeRecencyScores,
+	computeFileSizeScores,
+} from "../scoring.ts";
 import type { SymbolEntry } from "../types.ts";
 
 // ---------------------------------------------------------------------------
@@ -230,5 +235,148 @@ describe("rankFiles — Phase 2: consistent key behavior", () => {
 		const scores = computeRecencyScores(fileDates, 30, now);
 		assert.equal(scores["src/new.ts"], 1.0);
 		assert.equal(scores["src/old.ts"], 0.0);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 3: computeFileSizeScores
+// ---------------------------------------------------------------------------
+
+describe("computeFileSizeScores", () => {
+	it("empty input returns empty object", () => {
+		const scores = computeFileSizeScores({});
+		assert.deepEqual(scores, {});
+	});
+
+	it("single file gets score 0 (no penalty)", () => {
+		const scores = computeFileSizeScores({ "a.ts": 1000 });
+		assert.strictEqual(scores["a.ts"], 0);
+	});
+
+	it("same-size files all get score 0", () => {
+		const scores = computeFileSizeScores({ "a.ts": 500, "b.ts": 500, "c.ts": 500 });
+		assert.strictEqual(scores["a.ts"], 0);
+		assert.strictEqual(scores["b.ts"], 0);
+		assert.strictEqual(scores["c.ts"], 0);
+	});
+
+	it("largest file gets 0, smallest gets 1", () => {
+		const scores = computeFileSizeScores({ "small.ts": 100, "medium.ts": 500, "large.ts": 1000 });
+		assert.strictEqual(scores["large.ts"], 0);
+		assert.strictEqual(scores["small.ts"], 1);
+	});
+
+	it("interpolated sizes get proportional scores between 0 and 1", () => {
+		const scores = computeFileSizeScores({ "a.ts": 200, "b.ts": 600 });
+		// a: 1 - (200-200)/(600-200) = 1 - 0 = 1.0
+		// b: 1 - (600-200)/(600-200) = 1 - 1 = 0.0
+		assert.strictEqual(scores["a.ts"], 1);
+		assert.strictEqual(scores["b.ts"], 0);
+	});
+
+	it("handles 0-size files without division by zero (all get 0)", () => {
+		const scores = computeFileSizeScores({ "a.ts": 0, "b.ts": 0 });
+		assert.strictEqual(scores["a.ts"], 0);
+		assert.strictEqual(scores["b.ts"], 0);
+	});
+
+	it("score is 0 if all files are 0 bytes", () => {
+		const scores = computeFileSizeScores({ "a.ts": 0 });
+		assert.strictEqual(scores["a.ts"], 0);
+	});
+
+	it("mid-size file gets interpolated score", () => {
+		// min=100, max=1000, mid=550: 1 - (550-100)/(1000-100) = 1 - 450/900 = 1 - 0.5 = 0.5
+		const scores = computeFileSizeScores({ "small.ts": 100, "mid.ts": 550, "large.ts": 1000 });
+		assert.strictEqual(scores["mid.ts"], 0.5);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 4: rankFiles with fileSize weight
+// ---------------------------------------------------------------------------
+
+describe("rankFiles with fileSize weight", () => {
+	const symEntries: Record<string, SymbolEntry[]> = {
+		"small.ts": [{ type: "function", name: "foo", line: 1 }],
+		"large.ts": [{ type: "function", name: "bar", line: 1 }],
+	};
+
+	it("uses fileSize weight when fileSizeScores provided", () => {
+		const kw = { "small.ts": 1.0, "large.ts": 1.0 };
+		const rec = { "small.ts": 0, "large.ts": 0 };
+		const fs = { "small.ts": 1.0, "large.ts": 0.0 };
+		const weights = { keyword: 0.5, recency: 0.3, fileSize: 0.2 };
+
+		const result = rankFiles(kw, rec, weights, 10_000, symEntries, fs);
+		const small = result.files.find((f) => f.path === "small.ts")!;
+		const large = result.files.find((f) => f.path === "large.ts")!;
+
+		// small: 1.0*0.5 + 0*0.3 + 1.0*0.2 = 0.7
+		// large: 1.0*0.5 + 0*0.3 + 0.0*0.2 = 0.5
+		assert.strictEqual(small.score, 0.7);
+		assert.strictEqual(large.score, 0.5);
+		// small should rank higher
+		assert.ok(result.files.indexOf(small) < result.files.indexOf(large));
+	});
+
+	it("large file with same keyword+recency gets lower total score", () => {
+		const kw = { "small.ts": 0.8, "large.ts": 0.8 };
+		const rec = { "small.ts": 0.5, "large.ts": 0.5 };
+		const fs = { "small.ts": 1.0, "large.ts": 0.0 };
+		const weights = { keyword: 0.5, recency: 0.3, fileSize: 0.2 };
+
+		const result = rankFiles(kw, rec, weights, 10_000, symEntries, fs);
+		const small = result.files.find((f) => f.path === "small.ts")!;
+		const large = result.files.find((f) => f.path === "large.ts")!;
+
+		// small: 0.8*0.5 + 0.5*0.3 + 1.0*0.2 = 0.4 + 0.15 + 0.2 = 0.75
+		// large: 0.8*0.5 + 0.5*0.3 + 0.0*0.2 = 0.4 + 0.15 + 0 = 0.55
+		assert.ok(small.score > large.score, "smaller file should rank higher");
+	});
+
+	it("works without fileSizeScores (backward compat, fileSize score defaults to 0)", () => {
+		const kw = { "small.ts": 1.0, "large.ts": 1.0 };
+		const rec = { "small.ts": 0.5, "large.ts": 0.5 };
+		const weights = { keyword: 0.5, recency: 0.3, fileSize: 0.2 };
+
+		// No fileSizeScores passed — fileSize weight contributes 0
+		const result = rankFiles(kw, rec, weights, 10_000, symEntries);
+		const small = result.files.find((f) => f.path === "small.ts")!;
+		// small: 1.0*0.5 + 0.5*0.3 + 0*0.2 = 0.5 + 0.15 + 0 = 0.65
+		assert.strictEqual(small.score, 0.65);
+	});
+
+	it("works without fileSize in weights (backward compat)", () => {
+		const kw = { "small.ts": 1.0, "large.ts": 0.5 };
+		const rec = { "small.ts": 0.5, "large.ts": 0.5 };
+		const fs = { "small.ts": 1.0, "large.ts": 0.0 };
+		const weights = { keyword: 0.6, recency: 0.4 }; // no fileSize
+
+		// fileSize weight defaults to 0, even when fileSizeScores provided
+		const result = rankFiles(kw, rec, weights, 10_000, symEntries, fs);
+		const small = result.files.find((f) => f.path === "small.ts")!;
+		// small: 1.0*0.6 + 0.5*0.4 + 1.0*0 = 0.6 + 0.2 + 0 = 0.8
+		assert.strictEqual(small.score, 0.8);
+	});
+
+	it("fileSizeScores entries default to 0 for files not in the map", () => {
+		const syms: Record<string, SymbolEntry[]> = {
+			"with_fs.ts": [{ type: "function", name: "foo", line: 1 }],
+			"no_fs.ts": [{ type: "function", name: "bar", line: 1 }],
+		};
+		const kw = { "with_fs.ts": 1.0, "no_fs.ts": 1.0 };
+		const rec = { "with_fs.ts": 0, "no_fs.ts": 0 };
+		const fs = { "with_fs.ts": 1.0 }; // no_fs.ts not in fileSizeScores
+		const weights = { keyword: 0.5, recency: 0.3, fileSize: 0.2 };
+
+		const result = rankFiles(kw, rec, weights, 10_000, syms, fs);
+		const withFs = result.files.find((f) => f.path === "with_fs.ts")!;
+		const noFs = result.files.find((f) => f.path === "no_fs.ts")!;
+
+		// with_fs: 1.0*0.5 + 0*0.3 + 1.0*0.2 = 0.7
+		// no_fs: 1.0*0.5 + 0*0.3 + 0*0.2 = 0.5
+		assert.strictEqual(withFs.score, 0.7);
+		assert.strictEqual(noFs.score, 0.5);
 	});
 });

--- a/.pi/extensions/ranked-map/types.ts
+++ b/.pi/extensions/ranked-map/types.ts
@@ -11,7 +11,7 @@ export interface RankedMapConfig {
 	recencyWindowDays: number;
 	cacheTtlHours: number;
 	autoThreshold: number;
-	weights: { keyword: number; recency: number };
+	weights: { keyword: number; recency: number; fileSize?: number };
 }
 
 /** On-disk cache format for symbol index. */

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,46 +1,51 @@
 {
-	"quietStartup": true,
-	"theme": "agentcastle",
-	"sessionDir": ".pi/sessions",
-	"contextStatusBar": {
-		"showTps": true
-	},
-	"rankedMap": {
-		"tokenBudget": 2048,
-		"recencyWindowDays": 30,
-		"cacheTtlHours": 24,
-		"autoThreshold": 20000,
-		"weights": {
-			"keyword": 0.5,
-			"recency": 0.3
-		}
-	},
-	"docker": {
-		"memory": "4G",
-		"cpus": "2.0"
-	},
-	"skills": [".pi/skills"],
-	"prompts": [
-		"prompts",
-		"prompts/operations",
-		"prompts/development",
-		"prompts/requirement",
-		"prompts/misc"
-	],
-	"supervisor": {
-		"repo": "SchneiderDaniel/agentcastle",
-		"projectNumber": 3,
-		"statusField": "Status",
-		"statusMapping": {
-			"Research": "researcher",
-			"Architecture": "architect",
-			"TestDesign": "test-designer",
-			"Implementation": "developer",
-			"Audit": "auditor"
-		},
-		"maxRejections": 5,
-		"codeowners": ["SchneiderDaniel"],
-		"agentTimeoutsMin": {},
-		"bellOnComplete": false
-	}
+  "quietStartup": true,
+  "theme": "agentcastle",
+  "sessionDir": ".pi/sessions",
+  "contextStatusBar": {
+    "showTps": true
+  },
+  "rankedMap": {
+    "tokenBudget": 2048,
+    "recencyWindowDays": 30,
+    "cacheTtlHours": 24,
+    "autoThreshold": 20000,
+    "weights": {
+      "keyword": 0.5,
+      "recency": 0.3,
+      "fileSize": 0.2
+    }
+  },
+  "docker": {
+    "memory": "4G",
+    "cpus": "2.0"
+  },
+  "skills": [
+    ".pi/skills"
+  ],
+  "prompts": [
+    "prompts",
+    "prompts/operations",
+    "prompts/development",
+    "prompts/requirement",
+    "prompts/misc"
+  ],
+  "supervisor": {
+    "repo": "SchneiderDaniel/agentcastle",
+    "projectNumber": 3,
+    "statusField": "Status",
+    "statusMapping": {
+      "Research": "researcher",
+      "Architecture": "architect",
+      "TestDesign": "test-designer",
+      "Implementation": "developer",
+      "Audit": "auditor"
+    },
+    "maxRejections": 5,
+    "codeowners": [
+      "SchneiderDaniel"
+    ],
+    "agentTimeoutsMin": {},
+    "bellOnComplete": false
+  }
 }


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #577

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 23s | 33.2K | 27 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 3m 3s | 73.3K | 22 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 20s | 59.4K | 21 | deepseek-v4-flash |
| developer | ✗ FAILED | 2s | 0 | 0 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 17s | 82.8K | 79 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 2s | 52.3K | 40 | deepseek-v4-flash |

**Total:** 6 agents · 13m 7s · 300.9K tokens · 189 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/577