### PR TITLE
feat(#566): Bug: check-extensions — 'config option' keyword doesn't map to scan patterns (CHANGELOG_API_TO_PATTERN)

### DIFF
--- a/.pi/extensions/check-extensions/changelog-parser.ts
+++ b/.pi/extensions/check-extensions/changelog-parser.ts
@@ -13,7 +13,7 @@ export interface ChangeEntry {
 }
 
 // Keywords that flag an entry as API-visible
-const API_KEYWORDS = [
+export const API_KEYWORDS = [
 	"extension",
 	"tool",
 	"command",
@@ -163,7 +163,7 @@ function isInternalEntry(description: string): boolean {
 /**
  * Extract API names from a changelog entry description.
  */
-function extractApiNames(description: string): string[] {
+export function extractApiNames(description: string): string[] {
 	const names: string[] = [];
 	const lower = description.toLowerCase();
 
@@ -181,7 +181,6 @@ function extractApiNames(description: string): string[] {
 			else if (kw === "pi.setActiveTools") names.push("setActiveTools");
 			else if (kw === "registerCommand") names.push("registerCommand");
 			else if (kw === "registerTool") names.push("registerTool");
-			else if (kw === "config option") names.push("config");
 			else if (kw === "export") names.push("export");
 			else if (kw === "tool") names.push("tool");
 			else if (kw === "command") names.push("command");

--- a/.pi/extensions/check-extensions/constants.ts
+++ b/.pi/extensions/check-extensions/constants.ts
@@ -61,6 +61,7 @@ const _CHANGELOG_API_TO_PATTERN: Record<string, string[]> = {
 	extension: ["pi.on", "pi.registerCommand"],
 	SDK: ["pi.exec", "pi.sendUserMessage"],
 	config: ["pi.registerFlag", "pi.getFlag"],
+	"config option": ["pi.registerFlag", "pi.getFlag"],
 	export: ["pi.sendUserMessage", "pi.sendMessage"],
 };
 

--- a/.pi/extensions/check-extensions/test/check-extensions.test.mts
+++ b/.pi/extensions/check-extensions/test/check-extensions.test.mts
@@ -2648,3 +2648,144 @@ describe("types", () => {
 		assert.ok(hasReExport, "issue-builder.ts must re-export ExecFn from types.ts");
 	});
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 15: extractApiNames — "config option" keyword mapping (Issue #566)
+// ═══════════════════════════════════════════════════════════════════════
+
+import { extractApiNames, API_KEYWORDS } from "../changelog-parser.ts";
+
+describe("extractApiNames — config option (Phase 1: characterization)", () => {
+	it('returns "config option" for "Added config option for extension flag support"', () => {
+		const names = extractApiNames("Added config option for extension flag support");
+		assert.ok(names.includes("config option"), "Should include 'config option'");
+	});
+
+	it('returns "config option" for "Added config option only"', () => {
+		const names = extractApiNames("Added config option only");
+		assert.ok(names.includes("config option"), "Should include 'config option'");
+	});
+
+	it('returns "config option" for "New config option"', () => {
+		const names = extractApiNames("New config option");
+		assert.ok(names.includes("config option"), "Should include 'config option' on substring match");
+	});
+
+	it('does NOT return "config" for "Added configuration option"', () => {
+		const names = extractApiNames("Added configuration option");
+		// "configuration" contains "config" substring but not "config option"
+		assert.ok(!names.includes("config"), "Should NOT include 'config' for 'configuration'");
+	});
+
+	it('returns empty array for ""', () => {
+		assert.deepStrictEqual(extractApiNames(""), []);
+	});
+
+	it('returns empty array for "No API keywords here"', () => {
+		assert.deepStrictEqual(extractApiNames("No API keywords here"), []);
+	});
+});
+
+describe("CHANGELOG_API_TO_PATTERN — config option (Phase 2: fix mapping)", () => {
+	it('CHANGELOG_API_TO_PATTERN["config option"] equals ["pi.registerFlag", "pi.getFlag"]', () => {
+		assert.deepStrictEqual(CHANGELOG_API_TO_PATTERN["config option"], [
+			"pi.registerFlag",
+			"pi.getFlag",
+		]);
+	});
+
+	it("CHANGELOG_API_TO_PATTERN remains frozen", () => {
+		assert.ok(Object.isFrozen(CHANGELOG_API_TO_PATTERN));
+	});
+
+	it("All API_KEYWORDS map to existing CHANGELOG_API_TO_PATTERN keys (SSOT invariant)", () => {
+		// For each keyword, determine what name extractApiNames pushes (excluding regex additions)
+		// The if-else chain or else-fallthrough pushes the canonical name
+		const ifElseMapping: Record<string, string> = {
+			"pi.on": "on",
+			"pi.exec": "exec",
+			"pi.sendUserMessage": "sendUserMessage",
+			"ctx.ui": "ctx.ui",
+			"ctx.sessionManager": "sessionManager",
+			"ctx.abort": "abort",
+			"pi.registerFlag": "registerFlag",
+			"pi.registerShortcut": "registerShortcut",
+			"pi.getFlag": "getFlag",
+			"pi.setActiveTools": "setActiveTools",
+			registerCommand: "registerCommand",
+			registerTool: "registerTool",
+			"config option": "config option", // after if-else removal, falls through to else
+			export: "export",
+			tool: "tool",
+			command: "command",
+			event: "event",
+			SDK: "SDK",
+			sdk: "SDK",
+		};
+		for (const kw of API_KEYWORDS) {
+			const name = ifElseMapping[kw] ?? kw;
+			const patterns = CHANGELOG_API_TO_PATTERN[name];
+			assert.ok(
+				Array.isArray(patterns) && patterns.length > 0,
+				`Keyword "${kw}" maps to name "${name}" which has no entry in CHANGELOG_API_TO_PATTERN`,
+			);
+		}
+	});
+
+	it("parsePhase round-trip: 'Added config option for extension flags' affects pi.registerFlag and pi.getFlag", () => {
+		const pi = { sendUserMessage: () => {} } as any;
+		const ctx: PipelineContext = { cwd: "/tmp", ui: { notify: () => {} } };
+		const pipeline = new ChangelogPipeline(pi, ctx);
+
+		const md = `## [0.76.0] - 2026-06-01\n\n### Added\n\n- Added config option for extension flags\n`;
+		const result = pipeline.parsePhase(md);
+
+		assert.ok(result.affectedApiPatterns.has("pi.registerFlag"), "Should include pi.registerFlag");
+		assert.ok(result.affectedApiPatterns.has("pi.getFlag"), "Should include pi.getFlag");
+	});
+});
+
+describe("extractApiNames — config option (Phase 3: remove if-else coupling)", () => {
+	it('returns "config option" instead of "config" for "Added config option for extension flag support"', () => {
+		const names = extractApiNames("Added config option for extension flag support");
+		// After removing the if-else, "config option" keyword falls through to else and pushes kw as-is
+		assert.ok(
+			names.includes("config option"),
+			"Should include 'config option' (pushed via else fallback, not if-else translation)",
+		);
+	});
+
+	it('returns "config option" not "config" for "Added config option only"', () => {
+		const names = extractApiNames("Added config option only");
+		assert.ok(names.includes("config option"), "Should include 'config option'");
+		// After if-else removal, "config" should NOT be in the result
+		// (unless another keyword happens to push "config")
+	});
+
+	it("SSOT invariant still holds: CHANGELOG_API_TO_PATTERN has 'config option' key", () => {
+		assert.ok(
+			Array.isArray(CHANGELOG_API_TO_PATTERN["config option"]),
+			"CHANGELOG_API_TO_PATTERN should have 'config option' key",
+		);
+		assert.deepStrictEqual(
+			CHANGELOG_API_TO_PATTERN["config option"],
+			["pi.registerFlag", "pi.getFlag"],
+			"Should map to same patterns as 'config'",
+		);
+	});
+
+	it("parsePhase round-trip still produces correct patterns", () => {
+		const pi = { sendUserMessage: () => {} } as any;
+		const ctx: PipelineContext = { cwd: "/tmp", ui: { notify: () => {} } };
+		const pipeline = new ChangelogPipeline(pi, ctx);
+
+		const md = `## [0.76.0] - 2026-06-01\n\n### Added\n\n- Added config option for extension flags\n`;
+		const result = pipeline.parsePhase(md);
+
+		assert.ok(
+			result.affectedApiPatterns.has("pi.registerFlag"),
+			"pi.registerFlag should still be affected",
+		);
+		assert.ok(result.affectedApiPatterns.has("pi.getFlag"), "pi.getFlag should still be affected");
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #566

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 2m 41s | 56.0K | 20 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 5m 47s | 40.6K | 42 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 34s | 49.6K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 49s | 90.2K | 47 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 49s | 45.2K | 34 | deepseek-v4-flash |

**Total:** 5 agents · 16m 40s · 281.6K tokens · 161 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/566