### PR TITLE
feat(#568): Duplicate Code: check-extensions - manifest-reader.ts extension.json and package.json try/catch blocks near-identical

### DIFF
--- a/.pi/extensions/check-extensions/manifest-reader.ts
+++ b/.pi/extensions/check-extensions/manifest-reader.ts
@@ -19,6 +19,31 @@ export interface ExtensionManifest {
 }
 
 /**
+ * Try to read manifest fields from a JSON file.
+ *
+ * Checks if the file exists, reads it, parses JSON, and extracts
+ * piVersion and testedWithVersion into the provided manifest object.
+ * Returns true if the file was successfully read and parsed,
+ * false if the file doesn't exist or contains invalid JSON.
+ *
+ * @param filePath - Path to the JSON file to read
+ * @param manifest - Manifest object to populate
+ * @returns true if file was read and parsed successfully, false otherwise
+ */
+export function tryReadManifestFile(filePath: string, manifest: ExtensionManifest): boolean {
+	if (!existsSync(filePath)) return false;
+	try {
+		const content = readFileSync(filePath, "utf-8");
+		const data = JSON.parse(content);
+		if (data.piVersion) manifest.piVersion = String(data.piVersion);
+		if (data.testedWithVersion) manifest.testedWithVersion = String(data.testedWithVersion);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Read extension manifest from a directory.
  * Checks extension.json first, then package.json as fallback.
  *
@@ -33,31 +58,13 @@ export function readManifest(extensionDir: string): ExtensionManifest {
 	};
 
 	// Try extension.json first
-	const extJsonPath = join(extensionDir, "extension.json");
-	if (existsSync(extJsonPath)) {
-		try {
-			const content = readFileSync(extJsonPath, "utf-8");
-			const data = JSON.parse(content);
-			if (data.piVersion) manifest.piVersion = String(data.piVersion);
-			if (data.testedWithVersion) manifest.testedWithVersion = String(data.testedWithVersion);
-			return manifest;
-		} catch {
-			// Invalid JSON — fall through to package.json
-		}
+	if (tryReadManifestFile(join(extensionDir, "extension.json"), manifest)) {
+		return manifest;
 	}
 
 	// Try package.json as fallback
-	const pkgJsonPath = join(extensionDir, "package.json");
-	if (existsSync(pkgJsonPath)) {
-		try {
-			const content = readFileSync(pkgJsonPath, "utf-8");
-			const data = JSON.parse(content);
-			if (data.piVersion) manifest.piVersion = String(data.piVersion);
-			if (data.testedWithVersion) manifest.testedWithVersion = String(data.testedWithVersion);
-			return manifest;
-		} catch {
-			// Invalid JSON — return defaults
-		}
+	if (tryReadManifestFile(join(extensionDir, "package.json"), manifest)) {
+		return manifest;
 	}
 
 	return manifest;

--- a/.pi/extensions/check-extensions/test/check-extensions.test.mts
+++ b/.pi/extensions/check-extensions/test/check-extensions.test.mts
@@ -2007,7 +2007,7 @@ describe("impact-scorer", () => {
 // Phase 8: manifest-reader.ts — Extension manifest parsing
 // ═══════════════════════════════════════════════════════════════════════
 
-import { readManifest, type ExtensionManifest } from "../manifest-reader.ts";
+import { readManifest, tryReadManifestFile, type ExtensionManifest } from "../manifest-reader.ts";
 
 describe("manifest-reader", () => {
 	let tmpDir: string;
@@ -2646,5 +2646,116 @@ describe("types", () => {
 			(source.includes('from "./types.ts"') &&
 				(source.includes("ExecFn") || source.includes("type ExecFn")));
 		assert.ok(hasReExport, "issue-builder.ts must re-export ExecFn from types.ts");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 15: manifest-reader.ts — tryReadManifestFile helper
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("tryReadManifestFile", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), "tryread-test-"));
+	});
+
+	afterEach(() => {
+		if (tmpDir) {
+			try {
+				rmSync(tmpDir, { recursive: true, force: true });
+			} catch {
+				/* ok */
+			}
+		}
+	});
+
+	it("returns true and populates manifest from valid JSON with piVersion and testedWithVersion", () => {
+		const filePath = join(tmpDir, "test.json");
+		writeFileSync(filePath, JSON.stringify({ piVersion: "1.0.0", testedWithVersion: "2.0.0" }));
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(filePath, manifest);
+		assert.strictEqual(result, true);
+		assert.strictEqual(manifest.piVersion, "1.0.0");
+		assert.strictEqual(manifest.testedWithVersion, "2.0.0");
+	});
+
+	it("returns false for non-existent path, manifest unchanged", () => {
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(join(tmpDir, "nonexistent.json"), manifest);
+		assert.strictEqual(result, false);
+		assert.strictEqual(manifest.piVersion, "UNKNOWN");
+		assert.strictEqual(manifest.testedWithVersion, "UNKNOWN");
+	});
+
+	it("returns false for malformed JSON, manifest unchanged", () => {
+		const filePath = join(tmpDir, "bad.json");
+		writeFileSync(filePath, "not valid json");
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(filePath, manifest);
+		assert.strictEqual(result, false);
+		assert.strictEqual(manifest.piVersion, "UNKNOWN");
+		assert.strictEqual(manifest.testedWithVersion, "UNKNOWN");
+	});
+
+	it("returns true with no field changes when JSON has no piVersion or testedWithVersion", () => {
+		const filePath = join(tmpDir, "no-field.json");
+		writeFileSync(filePath, JSON.stringify({ otherField: "value" }));
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(filePath, manifest);
+		assert.strictEqual(result, true);
+		assert.strictEqual(manifest.piVersion, "UNKNOWN");
+		assert.strictEqual(manifest.testedWithVersion, "UNKNOWN");
+	});
+
+	it("returns true and populates only piVersion when testedWithVersion missing", () => {
+		const filePath = join(tmpDir, "partial.json");
+		writeFileSync(filePath, JSON.stringify({ piVersion: "3.0.0" }));
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(filePath, manifest);
+		assert.strictEqual(result, true);
+		assert.strictEqual(manifest.piVersion, "3.0.0");
+		assert.strictEqual(manifest.testedWithVersion, "UNKNOWN");
+	});
+
+	it("coerces numeric piVersion to string", () => {
+		const filePath = join(tmpDir, "numeric.json");
+		writeFileSync(filePath, JSON.stringify({ piVersion: 42, testedWithVersion: 99 }));
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(filePath, manifest);
+		assert.strictEqual(result, true);
+		assert.strictEqual(manifest.piVersion, "42");
+		assert.strictEqual(manifest.testedWithVersion, "99");
+	});
+
+	it("does not set piVersion when value is null (falsy check)", () => {
+		const filePath = join(tmpDir, "null.json");
+		writeFileSync(filePath, JSON.stringify({ piVersion: null, testedWithVersion: "1.0.0" }));
+		const manifest: ExtensionManifest = {
+			piVersion: "UNKNOWN",
+			testedWithVersion: "UNKNOWN",
+		};
+		const result = tryReadManifestFile(filePath, manifest);
+		assert.strictEqual(result, true);
+		assert.strictEqual(manifest.piVersion, "UNKNOWN");
+		assert.strictEqual(manifest.testedWithVersion, "1.0.0");
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #568

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 25s | 11.8K | 7 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 1m 1s | 139.4K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 49s | 36.8K | 13 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 48s | 52.7K | 46 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 17s | 38.1K | 40 | deepseek-v4-flash |

**Total:** 5 agents · 9m 21s · 278.8K tokens · 118 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/568