### PR TITLE
feat(#573): Dead Code: check-extensions - unused manifestCache variable in run()

### DIFF
--- a/.pi/extensions/check-extensions/pipeline.ts
+++ b/.pi/extensions/check-extensions/pipeline.ts
@@ -16,7 +16,6 @@ import { scanExtensionsAST, type ASTFinding, type ExecFn as AstExecFn } from "./
 import { resolveRelevance } from "./change-resolver.ts";
 import { computeImpactScore, type ImpactScore } from "./impact-scorer.ts";
 import { generateMigrationSnippet, type MigrationSnippet } from "./migration-generator.ts";
-import { readManifest } from "./manifest-reader.ts";
 import {
 	buildIssueTitle,
 	buildIssueBodyWithSnippets,
@@ -93,7 +92,7 @@ export class ChangelogPipeline {
 		const { scanResult: scan, findingsByExtension } = scanResult;
 
 		// Phase 2.5: Cross-reference
-		const { relevantFindingsByExtension, snippetsByExtension, scoresByExtension, manifestCache } =
+		const { relevantFindingsByExtension, snippetsByExtension, scoresByExtension } =
 			this.crossRefPhase(entries, latestVersion, findingsByExtension, scan);
 
 		if (relevantFindingsByExtension.size === 0) {
@@ -261,19 +260,11 @@ export class ChangelogPipeline {
 		relevantFindingsByExtension: Map<string, ASTFinding[]>;
 		snippetsByExtension: Map<string, MigrationSnippet[]>;
 		scoresByExtension: Map<string, ImpactScore>;
-		manifestCache: Map<string, ReturnType<typeof readManifest>>;
 	} {
-		const extensionsDir = join(this.ctx.cwd, ".pi", "extensions");
-		const manifestCache = new Map<string, ReturnType<typeof readManifest>>();
 		const snippetsByExtension = new Map<string, MigrationSnippet[]>();
 		const scoresByExtension = new Map<string, ImpactScore>();
 
 		for (const [extName, extFindings] of findingsByExtension) {
-			// Read manifest for version info
-			const extDir = join(extensionsDir, extName);
-			const manifest = readManifest(extDir);
-			manifestCache.set(extName, manifest);
-
 			const extSnippets: MigrationSnippet[] = [];
 
 			for (const f of extFindings) {
@@ -332,7 +323,6 @@ export class ChangelogPipeline {
 			relevantFindingsByExtension,
 			snippetsByExtension,
 			scoresByExtension,
-			manifestCache,
 		};
 	}
 

--- a/.pi/extensions/check-extensions/test/pipeline.test.ts
+++ b/.pi/extensions/check-extensions/test/pipeline.test.ts
@@ -372,7 +372,70 @@ describe("ChangelogPipeline — Phase 2.5: crossRefPhase", () => {
 		assert.ok(result.relevantFindingsByExtension instanceof Map);
 		assert.ok(result.snippetsByExtension instanceof Map);
 		assert.ok(result.scoresByExtension instanceof Map);
-		assert.ok(result.manifestCache instanceof Map);
+	});
+
+	it("does not return manifestCache from crossRefPhase", () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		const pipeline = new ChangelogPipeline(pi, ctx);
+
+		const entries: ChangeEntry[] = [makeChangeEntry()];
+		const findingsByExtension = new Map<string, ASTFinding[]>();
+		findingsByExtension.set("test-ext", [makeASTFinding()]);
+
+		const scanResult: ASTScanningResult = {
+			findings: [makeASTFinding()],
+			skipCount: 0,
+		};
+
+		const result = pipeline.crossRefPhase(entries, "0.74.0", findingsByExtension, scanResult);
+
+		// manifestCache should have been removed from the return value
+		assert.equal((result as Record<string, unknown>).manifestCache, undefined);
+	});
+
+	it("crossRefPhase does not call readManifest", async () => {
+		// Register mock for readManifest before the module loads it
+		const mockReadManifest = mock.fn(() => ({}));
+		// Use mock.module to intercept in case pipeline.ts imports readManifest
+		// (it shouldn't since the dead code was removed, but this guards regressions)
+		try {
+			mock.module("../manifest-reader.ts", {
+				namedExports: { readManifest: mockReadManifest },
+			});
+		} catch {
+			// mock.module not available (needs --experimental-test-module-mocks)
+			// Fallback: dynamically import and verify no manifestCache property
+		}
+
+		// Dynamic import ensures we get the module after mock setup
+		const { ChangelogPipeline: CP } = await import("../pipeline.ts");
+
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		const pipeline = new CP(pi, ctx);
+
+		const entries: ChangeEntry[] = [makeChangeEntry()];
+		const findingsByExtension = new Map<string, ASTFinding[]>();
+		findingsByExtension.set("test-ext", [makeASTFinding()]);
+
+		const scanResult: ASTScanningResult = {
+			findings: [makeASTFinding()],
+			skipCount: 0,
+		};
+
+		const result = pipeline.crossRefPhase(entries, "0.74.0", findingsByExtension, scanResult);
+
+		// Verify readManifest was never called (0 calls even if the mock was registered)
+		if (mockReadManifest.mock.calls !== undefined) {
+			assert.equal(mockReadManifest.mock.calls.length, 0);
+		}
+
+		// And the pipeline still produces correct results for the three outputs
+		assert.ok(result.relevantFindingsByExtension instanceof Map);
+		assert.ok(result.snippetsByExtension instanceof Map);
+		assert.ok(result.scoresByExtension instanceof Map);
+		assert.equal((result as Record<string, unknown>).manifestCache, undefined);
 	});
 
 	it("preserves findings without matching changelog entry (not auto-filtered)", () => {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #573

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 40s | 15.0K | 11 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 28s | 92.6K | 22 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 55s | 40.6K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 4s | 52.0K | 51 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 36s | 36.4K | 31 | deepseek-v4-flash |

**Total:** 5 agents · 11m 43s · 236.6K tokens · 133 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/573