### PR TITLE
feat(#579): ranked-map: .gitignore integration skips many patterns and applies submodule ignores globally

### DIFF
--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -16,7 +16,7 @@ import {
 	type RankedMapResult,
 } from "./types.ts";
 import { existsSync, mkdirSync, writeFileSync, readFileSync, statSync } from "node:fs";
-import { resolve, join } from "node:path";
+import { resolve, join, dirname, relative } from "node:path";
 import { buildCtagsArgs, buildSymbolIndex } from "./ctags.ts";
 import { loadCachedIndex, computeConfigHash } from "./cache.ts";
 import {
@@ -102,10 +102,36 @@ export class RankedMapEngine {
 		const piignorePath = join(this.cwd, ".piignore");
 		const piignoreExcludes = buildIgnoreExcludes(piignorePath);
 
-		// Incorporate .gitignore patterns from root and submodules
+		// Incorporate .gitignore patterns — scope submodule patterns to their directory
 		const targetAbs = resolve(this.cwd, targetDir);
-		const gitignorePaths = discoverIgnoreFiles(targetAbs);
-		const gitignoreExcludes = gitignorePaths.flatMap((p) => buildIgnoreExcludes(p));
+
+		// First, read root .gitignore to determine which dirs to skip during discovery
+		const rootGitignore = join(targetAbs, ".gitignore");
+		const rootExcludes = buildIgnoreExcludes(rootGitignore);
+		// Compute skipDirs from root .gitignore patterns that are simple directory
+		// names (no globs, no path separators — only basename-level dir ignores).
+		// This prevents traversal into directories already gitignored at root level,
+		// which is especially important for large ignored dirs like node_modules.
+		const skipDirs = rootExcludes.filter((e) => !e.includes("*") && !e.includes("/"));
+
+		// Discover .gitignore files, skipping directories matched by root .gitignore
+		const gitignorePaths = discoverIgnoreFiles(targetAbs, skipDirs);
+
+		// Build excludes — scope submodule .gitignore patterns to their directory
+		const gitignoreExcludes: string[] = [];
+		for (const p of gitignorePaths) {
+			const parentDir = dirname(p);
+			const relPath = relative(targetAbs, parentDir);
+			if (relPath === "." || relPath === "" || relPath === targetAbs) {
+				// Root .gitignore — use patterns as-is (ctags basename matching)
+				gitignoreExcludes.push(...buildIgnoreExcludes(p));
+			} else {
+				// Submodule .gitignore — scope patterns with relative path prefix.
+				// ctags --exclude matches against full path when pattern contains '/',
+				// so flask_blogs/__pycache__ only matches within flask_blogs/.
+				gitignoreExcludes.push(...buildIgnoreExcludes(p, relPath));
+			}
+		}
 
 		const allExcludes = [...piignoreExcludes, ...gitignoreExcludes];
 

--- a/.pi/extensions/ranked-map/piignore.ts
+++ b/.pi/extensions/ranked-map/piignore.ts
@@ -13,12 +13,15 @@
  *
  * Not supported (silently skipped):
  * - Negation (!)
- * - Double-star glob patterns (**)
+ * - Double-star in middle of glob patterns
  * - Leading slash patterns (absolute paths)
+ *
+ * Supported:
+ * - Leading double-star slash prefix (strip prefix, process remainder)
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 /**
  * Parse a single ignore-file line into a ctags --exclude pattern.
@@ -48,8 +51,16 @@ export function parseIgnoreLine(line: string): string | null {
 		if (pattern.endsWith("/")) pattern = pattern.slice(0, -1);
 	}
 
-	// Ctags --exclude supports globs but not ** (double-star)
-	// Skip patterns containing ** that aren't just trailing /**
+	// Strip leading **/ prefix (gitignore "at any depth" indicator)
+	// e.g. **/venv/ → venv, **/credentials.* → credentials.*
+	// Strip repeatedly to handle patterns like **/**/dir/
+	while (pattern.startsWith("**/")) {
+		pattern = pattern.slice(3);
+	}
+
+	// Ctags --exclude supports globs but not ** in middle of pattern
+	// After stripping leading **/, remaining ** means a/**/b or similar — reject.
+	// Also reject bare ** (just the globstar).
 	// NOTE: check before basename extraction — a/**/b must be rejected
 	// even though basename alone ("b") wouldn't contain **.
 	if (pattern.includes("**")) return null;
@@ -72,8 +83,16 @@ export function parseIgnoreLine(line: string): string | null {
  * Read an ignore file (.piignore or .gitignore) and return list of
  * ctags --exclude argument values. Returns empty array if file
  * doesn't exist or can't be read.
+ *
+ * When scopePrefix is provided, each pattern is prefixed with the scope path
+ * to scope the exclude to that subdirectory. This is used for submodule
+ * .gitignore files so patterns like __pycache__/ are applied only within
+ * the submodule (e.g. flask_blogs/__pycache__) rather than globally.
+ *
+ * ctags --exclude matches against full path when pattern contains '/',
+ * otherwise matches against basename only.
  */
-export function buildIgnoreExcludes(ignoreFilePath: string): string[] {
+export function buildIgnoreExcludes(ignoreFilePath: string, scopePrefix?: string): string[] {
 	try {
 		if (!existsSync(ignoreFilePath)) return [];
 
@@ -84,7 +103,11 @@ export function buildIgnoreExcludes(ignoreFilePath: string): string[] {
 		for (const line of lines) {
 			const pattern = parseIgnoreLine(line);
 			if (pattern) {
-				excludes.push(pattern);
+				if (scopePrefix) {
+					excludes.push(`${scopePrefix}/${pattern}`);
+				} else {
+					excludes.push(pattern);
+				}
 			}
 		}
 
@@ -98,10 +121,16 @@ export function buildIgnoreExcludes(ignoreFilePath: string): string[] {
  * Recursively discover all .gitignore files under rootDir.
  * Excludes .git/ directories to avoid indexing git internals.
  *
+ * Optional skipDirs parameter specifies directory basenames to skip
+ * during traversal (e.g. ["node_modules", ".venv", "dist"]).
+ * These are typically derived from the root .gitignore file and prevent
+ * traversal into directories that are already gitignored.
+ *
  * Returns absolute paths to each .gitignore file found.
  */
-export function discoverIgnoreFiles(rootDir: string): string[] {
+export function discoverIgnoreFiles(rootDir: string, skipDirs?: string[]): string[] {
 	const results: string[] = [];
+	const skipSet = new Set(skipDirs ?? []);
 
 	try {
 		if (!existsSync(rootDir)) return [];
@@ -109,8 +138,9 @@ export function discoverIgnoreFiles(rootDir: string): string[] {
 		const entries = readdirSync(rootDir);
 
 		for (const entry of entries) {
-			// Skip .git directory
+			// Skip .git directory and any directories matching skipDirs
 			if (entry === ".git") continue;
+			if (skipSet.has(entry)) continue;
 
 			const fullPath = join(rootDir, entry);
 
@@ -118,8 +148,8 @@ export function discoverIgnoreFiles(rootDir: string): string[] {
 				const stat = statSync(fullPath);
 
 				if (stat.isDirectory()) {
-					// Recurse into subdirectories
-					const nested = discoverIgnoreFiles(fullPath);
+					// Recurse into subdirectories, passing skipDirs through
+					const nested = discoverIgnoreFiles(fullPath, skipDirs);
 					results.push(...nested);
 				} else if (entry === ".gitignore") {
 					results.push(fullPath);

--- a/.pi/extensions/ranked-map/test/features.test.ts
+++ b/.pi/extensions/ranked-map/test/features.test.ts
@@ -818,7 +818,7 @@ describe("Phase 10: .gitignore integration", () => {
 		assert.equal(parseIgnoreLine(".eggs/"), ".eggs");
 		assert.equal(parseIgnoreLine("*.egg-info"), "*.egg-info");
 		assert.equal(parseIgnoreLine("*.so"), "*.so");
-		assert.equal(parseIgnoreLine("**/venv/"), null);
+		assert.equal(parseIgnoreLine("**/venv/"), "venv");
 	});
 
 	it("buildIgnoreExcludes reads .gitignore content", () => {
@@ -923,7 +923,7 @@ describe("Phase 10: .gitignore integration", () => {
 		}
 	});
 
-	it("buildOrLoadIndex with .gitignore in target subdirectory", async () => {
+	it("buildOrLoadIndex scopes submodule .gitignore patterns", async () => {
 		const dir = tmpDir();
 		try {
 			// Create .gitignore in a subdirectory (simulating submodule)
@@ -961,10 +961,15 @@ describe("Phase 10: .gitignore integration", () => {
 				ctagsCall!.args.includes("--exclude=pi_ignored"),
 				"should include piignore exclude",
 			);
-			// Should include gitignore exclude from subdirectory
+			// Submodule .gitignore exclude should be SCOPED with submod/ prefix
 			assert.ok(
-				ctagsCall!.args.includes("--exclude=sub_ignored"),
-				"should include gitignore exclude from submodule",
+				ctagsCall!.args.includes("--exclude=submod/sub_ignored"),
+				"submodule gitignore exclude should be scoped with submod/ prefix",
+			);
+			// The un-scoped version should NOT be present
+			assert.ok(
+				!ctagsCall!.args.includes("--exclude=sub_ignored"),
+				"submodule gitignore exclude should NOT appear unscoped",
 			);
 		} finally {
 			cleanup(dir);

--- a/.pi/extensions/ranked-map/test/piignore.test.ts
+++ b/.pi/extensions/ranked-map/test/piignore.test.ts
@@ -80,8 +80,8 @@ describe("parsePiignoreLine", () => {
 		assert.equal(parsePiignoreLine("*.pem"), "*.pem");
 	});
 
-	it("returns pattern for nested glob", () => {
-		assert.equal(parsePiignoreLine("**/credentials.*"), null); // contains **
+	it("strips **/ prefix from glob pattern", () => {
+		assert.equal(parsePiignoreLine("**/credentials.*"), "credentials.*");
 	});
 
 	it("returns pattern for directory glob", () => {
@@ -291,8 +291,8 @@ describe("parseIgnoreLine", () => {
 		assert.equal(parseIgnoreLine("*.pem"), "*.pem");
 	});
 
-	it("returns null for double-star prefix glob", () => {
-		assert.equal(parseIgnoreLine("**/credentials.*"), null);
+	it("strips **/ prefix from credentials.*", () => {
+		assert.equal(parseIgnoreLine("**/credentials.*"), "credentials.*");
 	});
 
 	it("returns pattern for directory glob", () => {
@@ -316,8 +316,28 @@ describe("parseIgnoreLine", () => {
 		assert.equal(parseIgnoreLine("*.zip"), "*.zip");
 	});
 
-	it("returns null for **/venv/ double-star prefix", () => {
-		assert.equal(parseIgnoreLine("**/venv/"), null);
+	it("strips **/ prefix from directory pattern", () => {
+		assert.equal(parseIgnoreLine("**/venv/"), "venv");
+	});
+
+	it("strips **/ before trailing /**", () => {
+		assert.equal(parseIgnoreLine("**/node_modules/**"), "node_modules");
+	});
+
+	it("strips repeated **/ prefixes", () => {
+		assert.equal(parseIgnoreLine("**/**/dir/"), "dir");
+	});
+
+	it("strips **/ from glob pattern", () => {
+		assert.equal(parseIgnoreLine("**/*.pyc"), "*.pyc");
+	});
+
+	it("still rejects ** in middle of pattern", () => {
+		assert.equal(parseIgnoreLine("a/**/b"), null);
+	});
+
+	it("still rejects bare ** pattern", () => {
+		assert.equal(parseIgnoreLine("**"), null);
 	});
 
 	it("parses .venv/ directory pattern (python venv)", () => {
@@ -465,6 +485,61 @@ describe("buildIgnoreExcludes", () => {
 			cleanupDir(dir);
 		}
 	});
+
+	it("scopePrefix prefixes patterns with submodule path", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), ["__pycache__/", "*.pyc"].join("\n"));
+			const result = buildIgnoreExcludes(join(dir, ".gitignore"), "flask_blogs");
+			assert.deepEqual(result, ["flask_blogs/__pycache__", "flask_blogs/*.pyc"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("scopePrefix with deeper submodule path", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), ["venv/", "*.log", "build/"].join("\n"));
+			const result = buildIgnoreExcludes(join(dir, ".gitignore"), "sub/deep");
+			assert.deepEqual(result, ["sub/deep/venv", "sub/deep/*.log", "sub/deep/build"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("scopePrefix with no scope (empty) behaves like normal", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), ["__pycache__/", "*.pyc"].join("\n"));
+			const result = buildIgnoreExcludes(join(dir, ".gitignore"), "");
+			assert.deepEqual(result, ["__pycache__", "*.pyc"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("scopePrefix with null (no arg) behaves like normal", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), ["__pycache__/", "*.pyc"].join("\n"));
+			const result = buildIgnoreExcludes(join(dir, ".gitignore"));
+			assert.deepEqual(result, ["__pycache__", "*.pyc"]);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("scopePrefix with empty .gitignore produces empty result", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), "");
+			const result = buildIgnoreExcludes(join(dir, ".gitignore"), "submod");
+			assert.deepEqual(result, []);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -549,6 +624,61 @@ describe("discoverIgnoreFiles", () => {
 			writeFileSync(join(dir, "a", "b", ".gitignore"), "b_ignored\n");
 
 			const result = discoverIgnoreFiles(dir);
+			assert.equal(result.length, 3);
+			assert.ok(result.includes(join(dir, ".gitignore")));
+			assert.ok(result.includes(join(dir, "a", ".gitignore")));
+			assert.ok(result.includes(join(dir, "a", "b", ".gitignore")));
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("skipDirs skips matching directories during traversal", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), "root\n");
+			mkdirSync(join(dir, "node_modules"), { recursive: true });
+			// .gitignore inside node_modules should NOT be discovered
+			writeFileSync(join(dir, "node_modules", ".gitignore"), "ignored\n");
+			mkdirSync(join(dir, "src"), { recursive: true });
+			writeFileSync(join(dir, "src", ".gitignore"), "src_ignored\n");
+
+			const result = discoverIgnoreFiles(dir, ["node_modules", "dist"]);
+			assert.equal(result.length, 2, "should skip node_modules");
+			assert.ok(result.includes(join(dir, ".gitignore")));
+			assert.ok(result.includes(join(dir, "src", ".gitignore")));
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("skipDirs empty array skips nothing (same as no arg)", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), "root\n");
+			mkdirSync(join(dir, "sub"), { recursive: true });
+			writeFileSync(join(dir, "sub", ".gitignore"), "sub\n");
+
+			const result = discoverIgnoreFiles(dir, []);
+			assert.equal(result.length, 2);
+		} finally {
+			cleanupDir(dir);
+		}
+	});
+
+	it("skipDirs passes through to recursive calls", () => {
+		const dir = setupDir();
+		try {
+			writeFileSync(join(dir, ".gitignore"), "root\n");
+			mkdirSync(join(dir, "a"), { recursive: true });
+			writeFileSync(join(dir, "a", ".gitignore"), "a\n");
+			mkdirSync(join(dir, "a", "node_modules"), { recursive: true });
+			// This .gitignore inside a/node_modules should be skipped
+			writeFileSync(join(dir, "a", "node_modules", ".gitignore"), "should_be_skipped\n");
+			mkdirSync(join(dir, "a", "b"), { recursive: true });
+			writeFileSync(join(dir, "a", "b", ".gitignore"), "b\n");
+
+			const result = discoverIgnoreFiles(dir, ["node_modules"]);
 			assert.equal(result.length, 3);
 			assert.ok(result.includes(join(dir, ".gitignore")));
 			assert.ok(result.includes(join(dir, "a", ".gitignore")));


### PR DESCRIPTION
## Description

Three fixes for .gitignore integration in ranked-map:

### 1. `**/` prefix patterns silently skipped
Patterns like `**/venv/` returned null from `parseIgnoreLine`, meaning they were silently dropped. Now the leading `**/` prefix is stripped before processing, so `**/venv/` correctly produces `--exclude=venv`.

### 2. discoverIgnoreFiles traverses ignored directories
`discoverIgnoreFiles` traversed into every subdirectory including large gitignored dirs like `node_modules`, `.venv`, `dist`, wasting I/O and potentially missing legitimate .gitignore files. Now accepts optional `skipDirs` parameter — engine computes skipDirs from root .gitignore patterns.

### 3. Submodule .gitignore patterns applied globally
Submodule .gitignore patterns (e.g. `flask_blogs/.gitignore` with `__pycache__/`) were applied globally via `--exclude=__pycache__`, ignoring every `__pycache__` in the repo. Now scoped to their submodule path (e.g. `--exclude=flask_blogs/__pycache__`) using ctags' full-path matching when pattern contains '/').

## Changes

| File | Change |
|------|--------|
| `piignore.ts` | `parseIgnoreLine` strips `**/` prefix; `buildIgnoreExcludes` accepts `scopePrefix`; `discoverIgnoreFiles` accepts `skipDirs` |
| `engine.ts` | `buildOrLoadIndex` computes skipDirs from root .gitignore, scopes submodule patterns via `scopePrefix` |
| `test/piignore.test.ts` | Updated **/ tests, added scopePrefix + skipDirs tests |
| `test/features.test.ts` | Updated **/venv/ and submodule scoping tests |

## Tests
```
# tests 234
# pass 234
# fail 0
```

Closes #579