### PR TITLE
fix(#600): case-insensitive CHANGELOG_API_TO_PATTERN lookup

### DIFF
--- a/.pi/extensions/check-extensions/constants.ts
+++ b/.pi/extensions/check-extensions/constants.ts
@@ -67,3 +67,11 @@ const _CHANGELOG_API_TO_PATTERN: Record<string, string[]> = {
 
 export const CHANGELOG_API_TO_PATTERN: Readonly<Record<string, readonly string[]>> =
 	Object.freeze(_CHANGELOG_API_TO_PATTERN);
+
+/** Lowercase-key map for case-insensitive lookup (fixes #600) */
+const _LOWER_CHANGELOG_API_TO_PATTERN: Record<string, readonly string[]> = {};
+for (const [key, val] of Object.entries(_CHANGELOG_API_TO_PATTERN)) {
+	_LOWER_CHANGELOG_API_TO_PATTERN[key.toLowerCase()] = val;
+}
+export const CHANGELOG_API_TO_PATTERN_LOWER: Readonly<Record<string, readonly string[]>> =
+	Object.freeze(_LOWER_CHANGELOG_API_TO_PATTERN);

--- a/.pi/extensions/check-extensions/pipeline.ts
+++ b/.pi/extensions/check-extensions/pipeline.ts
@@ -10,7 +10,7 @@ import { join } from "node:path";
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 
-import { PI_CHANGELOG_PATH, API_PATTERNS, CHANGELOG_API_TO_PATTERN } from "./constants.ts";
+import { PI_CHANGELOG_PATH, API_PATTERNS, CHANGELOG_API_TO_PATTERN_LOWER } from "./constants.ts";
 import { parseChangelog, parseStructuredChange, type ChangeEntry } from "./changelog-parser.ts";
 import { scanExtensionsAST, type ASTFinding, type ExecFn as AstExecFn } from "./ast-scanner.ts";
 import { resolveRelevance } from "./change-resolver.ts";
@@ -179,7 +179,7 @@ export class ChangelogPipeline {
 		const affectedApiPatterns = new Set<string>();
 		for (const entry of entries) {
 			for (const apiName of entry.apiNames) {
-				const patterns = CHANGELOG_API_TO_PATTERN[apiName.toLowerCase()];
+				const patterns = CHANGELOG_API_TO_PATTERN_LOWER[apiName.toLowerCase()];
 				if (patterns) {
 					for (const p of patterns) affectedApiPatterns.add(p);
 				}

--- a/.pi/extensions/check-extensions/test/check-extensions.test.mts
+++ b/.pi/extensions/check-extensions/test/check-extensions.test.mts
@@ -2435,11 +2435,11 @@ describe("consumer-contract — pipeline.ts", () => {
 		);
 	});
 
-	it("imports CHANGELOG_API_TO_PATTERN from ./constants.ts", () => {
+	it("imports CHANGELOG_API_TO_PATTERN_LOWER from ./constants.ts", () => {
 		assert.ok(
-			pipelineSrc.includes("CHANGELOG_API_TO_PATTERN") &&
+			pipelineSrc.includes("CHANGELOG_API_TO_PATTERN_LOWER") &&
 				pipelineSrc.includes('from "./constants.ts"'),
-			"pipeline.ts must import CHANGELOG_API_TO_PATTERN from ./constants.ts",
+			"pipeline.ts must import CHANGELOG_API_TO_PATTERN_LOWER from ./constants.ts",
 		);
 	});
 
@@ -2457,10 +2457,10 @@ describe("consumer-contract — pipeline.ts", () => {
 		);
 	});
 
-	it("does NOT re-define const CHANGELOG_API_TO_PATTERN locally", () => {
+	it("does NOT re-define const CHANGELOG_API_TO_PATTERN_LOWER locally", () => {
 		assert.ok(
-			!pipelineSrc.includes("const CHANGELOG_API_TO_PATTERN"),
-			"pipeline.ts must not define CHANGELOG_API_TO_PATTERN locally",
+			!pipelineSrc.includes("const CHANGELOG_API_TO_PATTERN_LOWER"),
+			"pipeline.ts must not define CHANGELOG_API_TO_PATTERN_LOWER locally",
 		);
 	});
 });


### PR DESCRIPTION
## Bug

`CHANGELOG_API_TO_PATTERN[apiName.toLowerCase()]` in pipeline.ts `parsePhase` performed case-sensitive lookup against camelCase map keys. Most API names with uppercase letters failed to map, causing scan patterns to be silently omitted.

### Affected APIs
`registerCommand`, `registerTool`, `sendUserMessage`, `sessionManager`, `registerFlag`, `registerShortcut`, `getFlag`, `setActiveTools`, `sendMessage`, `appendEntry`, `setSessionName`, `SDK`

## Fix (Option C)

Build lowercase-key map alongside original in `constants.ts`, export as `CHANGELOG_API_TO_PATTERN_LOWER`, use in `pipeline.ts` `parsePhase`. Original map preserved for tests.

```typescript
// constants.ts
const _LOWER_CHANGELOG_API_TO_PATTERN: Record<string, readonly string[]> = {};
for (const [key, val] of Object.entries(_CHANGELOG_API_TO_PATTERN)) {
    _LOWER_CHANGELOG_API_TO_PATTERN[key.toLowerCase()] = val;
}
export const CHANGELOG_API_TO_PATTERN_LOWER = Object.freeze(_LOWER_CHANGELOG_API_TO_PATTERN);

// pipeline.ts
const patterns = CHANGELOG_API_TO_PATTERN_LOWER[apiName.toLowerCase()];
```

## Validation

- Original `CHANGELOG_API_TO_PATTERN` unchanged — all existing tests pass
- Updated pipeline.ts import/lookup tests to reference `CHANGELOG_API_TO_PATTERN_LOWER`
- O(1) lookup, no performance regression

Closes #600