### PR TITLE
feat(#603): wrap format-on-save tool_result handler in try/catch to prevent unhandled promise rejection

### DIFF
--- a/.pi/extensions/format-on-save/index.ts
+++ b/.pi/extensions/format-on-save/index.ts
@@ -20,58 +20,62 @@ import { runEslintOnFile } from "./eslint.mts";
 
 export default function (pi: ExtensionAPI) {
 	pi.on("tool_result", async (event, ctx) => {
-		// Only handle write and edit tools
-		if (event.toolName !== "write" && event.toolName !== "edit") return;
-
-		// Skip errors
-		if (event.isError) return;
-
-		// Extract the file path from input
-		const filePath = (event.input as { path?: string }).path;
-		if (!looksLikeFilePath(filePath)) return;
-
-		// Resolve relative paths against cwd
-		const absolutePath = resolve(ctx.cwd, filePath);
-
-		// Skip non-formatable files
-		if (!shouldFormat(absolutePath)) return;
-
-		// Skip files that don't exist (shouldn't happen after write, but safe)
-		if (!existsSync(absolutePath)) return;
-
-		// Skip files that are too large
 		try {
-			const stats = statSync(absolutePath);
-			if (stats.size > MAX_FILE_SIZE_BYTES) return;
-		} catch {
-			return;
-		}
+			// Only handle write and edit tools
+			if (event.toolName !== "write" && event.toolName !== "edit") return;
 
-		// Step 1: Format the file in-place with --write
-		const { command, args } = buildPrettierArgs(ctx.cwd, absolutePath);
-		const result = await pi.exec.bind(pi)(command, args, { cwd: ctx.cwd, timeout: 15_000 });
-		const ok = result.code === 0;
-		if (ok && ctx.hasUI) {
-			ctx.ui.notify(`Formatted: ${filePath}`, "info");
-		}
+			// Skip errors
+			if (event.isError) return;
 
-		// Step 2: ESLint on saved file (Tier 1 diagnostics, advisory only)
-		if (shouldLint(absolutePath)) {
-			const lintMsg = await runEslintOnFile(pi.exec.bind(pi), absolutePath, ctx.cwd);
-			if (lintMsg && ctx.hasUI) {
-				ctx.ui.notify(`ESLint ran: ${filePath}`, "info");
+			// Extract the file path from input
+			const filePath = (event.input as { path?: string }).path;
+			if (!looksLikeFilePath(filePath)) return;
+
+			// Resolve relative paths against cwd
+			const absolutePath = resolve(ctx.cwd, filePath);
+
+			// Skip non-formatable files
+			if (!shouldFormat(absolutePath)) return;
+
+			// Skip files that don't exist (shouldn't happen after write, but safe)
+			if (!existsSync(absolutePath)) return;
+
+			// Skip files that are too large
+			try {
+				const stats = statSync(absolutePath);
+				if (stats.size > MAX_FILE_SIZE_BYTES) return;
+			} catch {
+				return;
 			}
-			if (lintMsg) {
-				// Non-blocking — deliver as followUp, Developer can proceed
-				const followUp = [
-					`## Lint Diagnostics — ${filePath}`,
-					``,
-					`ESLint found the following issues (advisory — not blocking):`,
-					``,
-					lintMsg,
-				].join("\n");
-				pi.sendUserMessage(followUp, { deliverAs: "followUp" });
+
+			// Step 1: Format the file in-place with --write
+			const { command, args } = buildPrettierArgs(ctx.cwd, absolutePath);
+			const result = await pi.exec.bind(pi)(command, args, { cwd: ctx.cwd, timeout: 15_000 });
+			const ok = result.code === 0;
+			if (ok && ctx.hasUI) {
+				ctx.ui.notify(`Formatted: ${filePath}`, "info");
 			}
+
+			// Step 2: ESLint on saved file (Tier 1 diagnostics, advisory only)
+			if (shouldLint(absolutePath)) {
+				const lintMsg = await runEslintOnFile(pi.exec.bind(pi), absolutePath, ctx.cwd);
+				if (lintMsg && ctx.hasUI) {
+					ctx.ui.notify(`ESLint ran: ${filePath}`, "info");
+				}
+				if (lintMsg) {
+					// Non-blocking — deliver as followUp, Developer can proceed
+					const followUp = [
+						`## Lint Diagnostics — ${filePath}`,
+						``,
+						`ESLint found the following issues (advisory — not blocking):`,
+						``,
+						lintMsg,
+					].join("\n");
+					pi.sendUserMessage(followUp, { deliverAs: "followUp" });
+				}
+			}
+		} catch (err) {
+			console.error("format-on-save: error in tool_result handler:", err);
 		}
 	});
 }

--- a/.pi/extensions/format-on-save/test/format-on-save.test.mts
+++ b/.pi/extensions/format-on-save/test/format-on-save.test.mts
@@ -467,3 +467,34 @@ describe("buildPrettierArgs config path", () => {
 		assert.ok(result.args.includes("--write"));
 	});
 });
+
+// ═══════════════════════════════════════════════════════════════════════
+// Tests: error boundary (handler-level try/catch)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("handler error boundary", () => {
+	it("runEslintOnFile does not throw on exec rejection (simulated via failing mock)", async () => {
+		let caught = false;
+		const failingExec: ExecFn = async () => {
+			throw new Error("ENOENT: npx not found");
+		};
+		try {
+			await runEslintOnFile(failingExec, "test.ts", "/tmp");
+		} catch {
+			caught = true;
+		}
+		// Without handler-level try/catch, this would propagate as unhandled rejection.
+		// runEslintOnFile itself should propagate the error for the handler to catch.
+		assert.strictEqual(caught, true, "exec rejection should propagate through runEslintOnFile");
+	});
+
+	it("tryRunEslint propagates exec rejection (no internal swallow)", async () => {
+		const failingExec: ExecFn = async () => {
+			throw new Error("exec failed");
+		};
+		await assert.rejects(async () => {
+			// Import tryRunEslint via dynamic hack — use runEslintOnFile which wraps it
+			await runEslintOnFile(failingExec, "test.ts", "/tmp");
+		}, /exec failed/);
+	});
+});


### PR DESCRIPTION
## Summary

Wrap the `pi.on("tool_result", ...)` async handler body in a try/catch block so that any rejection from `pi.exec` (e.g., ENOENT for `npx`, ESLint not found, Prettier binary missing) is caught instead of propagating as an unhandled promise rejection.

## Changes

- **index.ts**: Added outer try/catch around entire handler body. Errors logged to console.error with `format-on-save:` prefix — non-blocking, session not disrupted.
- **test/format-on-save.test.mts**: Added 2 tests confirming `runEslintOnFile` propagates exec rejection (proof that handler-level try/catch is necessary).

## Testing

```
# tests 36
# suites 7
# pass 36
# fail 0
```

All existing tests pass. New error-boundary tests pass.

## Related

Closes #603