### PR TITLE
feat(#622): [efficiency] Auto-prompt structural_search when agent reads code files without using it

### DIFF
--- a/.pi/extensions/session-advice/advisor.ts
+++ b/.pi/extensions/session-advice/advisor.ts
@@ -530,6 +530,91 @@ function detectTurnInefficiency(data: SessionData): WasteSignal[] {
 	return results;
 }
 
+// ── Code file extension helpers ──
+
+/** Code file extensions that trigger structural-search-underuse detection. */
+const CODE_FILE_EXTS = new Set([
+	".ts",
+	".js",
+	".py",
+	".tsx",
+	".jsx",
+	".mts",
+	".go",
+	".rs",
+	".java",
+	".c",
+	".cpp",
+	".swift",
+	".kt",
+]);
+
+/** True if the file path ends with a known code file extension. */
+function isCodeFilePath(filePath: string): boolean {
+	const extIdx = filePath.lastIndexOf(".");
+	if (extIdx < 0) return false;
+	const ext = filePath.slice(extIdx).toLowerCase();
+	return CODE_FILE_EXTS.has(ext);
+}
+
+/** Entry tool names that indicate a code file touch. */
+const CODE_TOUCH_TOOLS = new Set(["read", "edit", "write", "writeIfEmpty", "editExisting"]);
+
+/** Check if a session entry is a code file touch (read/edit/write on a code file). */
+function isCodeFileTouch(e: SessionEntry): boolean {
+	if (!CODE_TOUCH_TOOLS.has(e.toolName ?? "")) return false;
+	const p = getEntryPath(e);
+	return p.length > 0 && isCodeFilePath(p);
+}
+
+/** Check if a session entry has a given tool name. */
+function hasToolName(e: SessionEntry, name: string): boolean {
+	return e.toolName === name;
+}
+
+/**
+ * D8: Structural search underuse — 3+ code file touches with zero structural_search calls.
+ */
+function detectStructuralSearchUnderuse(data: SessionData): WasteSignal[] {
+	const results: WasteSignal[] = [];
+
+	// Check if any structural_search call exists
+	const hasStructuralSearch = data.entries.some((e) => hasToolName(e, "structural_search"));
+	if (hasStructuralSearch) return results;
+
+	// Collect code file touches
+	const codeTouches = data.entries.filter(isCodeFileTouch);
+	if (codeTouches.length < 3) return results;
+
+	// Check if all code touches are on the same file path (redundant-read territory, not ours)
+	const uniquePaths = new Set(codeTouches.map((e) => getEntryPath(e)));
+	if (uniquePaths.size === 1) return results;
+
+	// Calculate waste: sumTokenCost of offending calls minus structural_search overhead
+	const waste = sumTokenCost(codeTouches);
+	// Estimate 1 structural_search call would have been sufficient
+	const estimatedSearchCost = 50;
+	const actualWaste = Math.max(0, waste - estimatedSearchCost);
+
+	const details = codeTouches.map(
+		(e) => `${e.toolName} ${getEntryPath(e)} (turn ${e.turnIndex}) instead of structural_search`,
+	);
+
+	results.push({
+		signal: "structural-search-underuse",
+		label: "structural_search underused — read/edit on code files without AST query",
+		wastedTokens: actualWaste,
+		wastedCost: sumDollarCost(codeTouches),
+		occurrences: codeTouches.length,
+		details,
+		context: {
+			files: [...uniquePaths],
+		},
+	});
+
+	return results;
+}
+
 // ── Main analysis ──
 
 /**
@@ -545,6 +630,7 @@ export function analyzeSession(data: SessionData): WasteSignal[] {
 		...detectErrorLoop(data),
 		...detectNoBatch(data),
 		...detectTurnInefficiency(data),
+		...detectStructuralSearchUnderuse(data),
 	];
 
 	// Dedup by signal+context (same key = same underlying issue, merge)

--- a/.pi/extensions/session-advice/fixes.ts
+++ b/.pi/extensions/session-advice/fixes.ts
@@ -40,6 +40,10 @@ export const FIXES: Record<string, FixEntry> = {
 		idea: "Combine multiple read-only tool calls into discovery turns, or skip turns that produce no file changes.",
 		effort: "High",
 	},
+	"structural-search-underuse": {
+		idea: "Use `structural_search` (AST-aware query) when working with code files instead of reading/editing multiple files blindly. Reduces token waste from excessive file reads.",
+		effort: "Low",
+	},
 };
 
 /** Fallback fix when signal key is not in FIXES. */

--- a/.pi/extensions/session-advice/test/session-advice-advisor.test.mts
+++ b/.pi/extensions/session-advice/test/session-advice-advisor.test.mts
@@ -368,6 +368,181 @@ describe("return type is WasteSignal[]", () => {
 	});
 });
 
+// ---------------------------------------------------------------------------
+// detectStructuralSearchUnderuse tests
+// ---------------------------------------------------------------------------
+
+describe("detectStructuralSearchUnderuse", () => {
+	it("3 distinct code file reads, 0 structural_search → signal fires", () => {
+		const data = makeSession([
+			readEntry("/repo/src/components/app.ts", 0),
+			readEntry("/repo/src/utils/helpers.ts", 1),
+			readEntry("/repo/src/main/entry.ts", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 1, "3 code file reads with no structural_search should fire");
+		assert.ok(ss[0].wastedTokens >= 0, "wastedTokens should be >= 0");
+	});
+
+	it("3 code file reads + 1 structural_search → NO signal", () => {
+		const data = makeSession([
+			readEntry("/repo/src/app.ts", 0),
+			readEntry("/repo/src/utils.ts", 1),
+			readEntry("/repo/src/main.ts", 2),
+			structuralSearchEntry(3),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "at least 1 structural_search call should prevent signal");
+	});
+
+	it("2 code file reads → NO signal (below threshold)", () => {
+		const data = makeSession([
+			readEntry("/repo/src/app.ts", 0),
+			readEntry("/repo/src/utils.ts", 1),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "2 code reads should not fire");
+	});
+
+	it("3 reads on non-code files (.json, .yaml) → NO signal", () => {
+		const data = makeSession([
+			readEntry("/repo/config.json", 0),
+			readEntry("/repo/tsconfig.json", 1),
+			readEntry("/repo/deploy.yaml", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "non-code file reads should not fire");
+	});
+
+	it("3 code file edits (edit/write) → signal fires", () => {
+		const data = makeSession([
+			editEntry("/repo/src/app.ts", 0),
+			writeEntry("/repo/src/utils.ts", 1),
+			editEntry("/repo/src/main.ts", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 1, "3 code file edits should fire");
+	});
+
+	it("mixed: 2 code reads + 3 non-code reads → NO signal (code < 3)", () => {
+		const data = makeSession([
+			readEntry("/repo/src/app.ts", 0),
+			readEntry("/repo/src/utils.ts", 1),
+			readEntry("/repo/config.json", 2),
+			readEntry("/repo/deploy.yaml", 3),
+			readEntry("/repo/.env", 4),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "2 code + 3 non-code should not fire");
+	});
+
+	it("3 reads all on same file → NO signal (redundant-read territory)", () => {
+		const data = makeSession([
+			readEntry("/repo/src/app.ts", 0),
+			readEntry("/repo/src/app.ts", 1),
+			readEntry("/repo/src/app.ts", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(
+			ss.length,
+			0,
+			"3 reads on same file should not fire structural-search-underuse",
+		);
+	});
+
+	it("empty session → no crash, no signal", () => {
+		const data = makeSession([]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "empty session should not crash");
+	});
+
+	it("session with only structural_search calls → no crash, no signal", () => {
+		const data = makeSession([
+			structuralSearchEntry(0),
+			structuralSearchEntry(1),
+			structuralSearchEntry(2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "only structural_search calls should not fire");
+	});
+
+	it("wastedTokens estimate includes sumTokenCost of offending reads", () => {
+		const data = makeSession([
+			readEntry("/repo/src/app.ts", 0),
+			readEntry("/repo/src/utils.ts", 1),
+			readEntry("/repo/src/main.ts", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 1);
+		// Each read entry has text=path, charsToTokens for "/repo/src/app.ts" = ceil(17/4) = 5
+		// 3 entries * 5 = 15. Minus 50 overhead = 0 with floor. At minimum > 0 for longer paths.
+		assert.ok(ss[0].wastedTokens >= 0, "wastedTokens should be non-negative");
+	});
+
+	it("writeIfEmpty and editExisting count as code file touches", () => {
+		const data = makeSession([
+			{
+				type: "tool_use",
+				toolName: "writeIfEmpty",
+				args: { path: "/repo/src/new.ts" },
+				text: "/repo/src/new.ts",
+				turnIndex: 0,
+			},
+			{
+				type: "tool_use",
+				toolName: "editExisting",
+				args: { path: "/repo/src/existing.ts" },
+				text: "/repo/src/existing.ts",
+				turnIndex: 1,
+			},
+			{
+				type: "tool_use",
+				toolName: "edit",
+				args: { path: "/repo/src/another.ts" },
+				text: "/repo/src/another.ts",
+				turnIndex: 2,
+			},
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 1, "writeIfEmpty/editExisting/edit should count as code touches");
+	});
+
+	it("0 code file reads, 3 non-code reads → NO signal", () => {
+		const data = makeSession([
+			readEntry("/repo/README.md", 0),
+			readEntry("/repo/.gitignore", 1),
+			readEntry("/repo/package.json", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 0, "only non-code reads should not fire");
+	});
+
+	it("signal context includes files list", () => {
+		const data = makeSession([
+			readEntry("/repo/src/app.ts", 0),
+			readEntry("/repo/src/utils.ts", 1),
+			readEntry("/repo/src/main.ts", 2),
+		]);
+		const signals = analyzeSession(data);
+		const ss = signals.filter((s) => s.signal === "structural-search-underuse");
+		assert.strictEqual(ss.length, 1);
+		assert.ok(ss[0].context.files, "should have files context");
+		assert.ok(ss[0].context.files!.length >= 3, "should list affected files");
+	});
+});
+
 describe("analyzeSessionFile removed (dead code)", () => {
 	it("should NOT be exported from advisor.ts", async () => {
 		const advisor = await import("../advisor.ts");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ Core philosophies:
 - Correct: `structural_search`
 - Wrong: `ripgrep_search`, `bash | grep`
 
+  Use `structural_search` when reading code files to find function definitions, class declarations, method calls, try/catch blocks — avoids text-match noise from comments/strings. Prefer this over reading entire files when you need to locate specific code structures.
+
 **Read** file contents
 
 - Correct: `read(path, offset?, limit?)`


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #622

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 5s | 37.7K | 18 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 1m 40s | 71.1K | 27 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 53s | 39.7K | 20 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 56s | 60.0K | 56 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 42s | 33.4K | 29 | deepseek-v4-flash |

**Total:** 5 agents · 9m 15s · 241.9K tokens · 150 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/622
Closes #622