### PR TITLE
feat(#623): detectErrorLoop — arg comparison, proportional cost split, waste filtering

### DIFF
--- a/.pi/extensions/session-advice/advisor.ts
+++ b/.pi/extensions/session-advice/advisor.ts
@@ -372,7 +372,12 @@ function detectBashCat(data: SessionData): WasteSignal[] {
 }
 
 /**
- * D5: Error loop — tool error followed by retrying same tool (no strategy change).
+ * D5: Error loop — tool error followed by retrying same tool with same args (no strategy change).
+ *
+ * Fixes for #623 / #617:
+ * - Arg comparison: flags only when retries share same args (different args = strategy change)
+ * - Proportional cost split: wastes only retries beyond the first (first retry is reasonable)
+ * - False-positive filtering: skips single errors, different-args retries
  */
 function detectErrorLoop(data: SessionData): WasteSignal[] {
 	const results: WasteSignal[] = [];
@@ -385,30 +390,71 @@ function detectErrorLoop(data: SessionData): WasteSignal[] {
 		const window = data.entries.slice(errIdx + 1, errIdx + 9);
 		const sameToolRetries = window.filter((e) => e.toolName === err.toolName);
 
-		if (sameToolRetries.length >= 2) {
-			const waste = sumTokenCost(sameToolRetries);
-			const details = [
-				`\`${err.toolName}\` errored turn ${err.turnIndex}, retried ${sameToolRetries.length}x without changing approach`,
-			];
-			results.push({
-				signal: "error-loop",
-				label: "Error retry loop",
-				wastedTokens: waste,
-				wastedCost: sumDollarCost(sameToolRetries),
-				occurrences: sameToolRetries.length,
-				details,
-				context: {
-					toolName: err.toolName,
-					turnRange: [
-						err.turnIndex,
-						sameToolRetries[sameToolRetries.length - 1]?.turnIndex ?? err.turnIndex,
-					],
-				},
-			});
+		if (sameToolRetries.length < 2) continue;
+
+		// Compare args among retries — if args differ, it's strategy change not loop
+		// Group retries by args key; pick the largest group
+		const groups = groupBy(sameToolRetries, (e) => stableJsonKey(e.args));
+		let largest: { key: string; entries: SessionEntry[] } | undefined;
+		for (const g of groups) {
+			if (!largest || g.entries.length > largest.entries.length) {
+				largest = g;
+			}
 		}
+
+		if (!largest || largest.entries.length < 2) continue;
+
+		// Proportional waste: only retries beyond the first are wasteful
+		const wastefulRetries = largest.entries.slice(1);
+		const waste = sumTokenCost(wastefulRetries);
+		const cost = sumDollarCost(wastefulRetries);
+		const details = [
+			`\`${err.toolName}\` errored turn ${err.turnIndex}, retried ${largest.entries.length}x with same args — first retry is reasonable, ${wastefulRetries.length} subsequent retries wasted`,
+		];
+		results.push({
+			signal: "error-loop",
+			label: "Error retry loop",
+			wastedTokens: waste,
+			wastedCost: cost,
+			occurrences: wastefulRetries.length,
+			details,
+			context: {
+				toolName: err.toolName,
+				turnRange: [
+					err.turnIndex,
+					largest.entries[largest.entries.length - 1]?.turnIndex ?? err.turnIndex,
+				],
+			},
+		});
 	}
 
 	return results;
+}
+
+/** Stable JSON key for args comparison. */
+function stableJsonKey(args: Record<string, unknown> | undefined): string {
+	if (!args) return "__no_args__";
+	try {
+		const keys = Object.keys(args).sort();
+		return JSON.stringify(args, keys);
+	} catch {
+		return "__no_args__";
+	}
+}
+
+/** Group entries by a string key. */
+function groupBy<T>(items: T[], keyFn: (item: T) => string): Array<{ key: string; entries: T[] }> {
+	const map = new Map<string, T[]>();
+	for (const item of items) {
+		const key = keyFn(item);
+		const group = map.get(key);
+		if (group) {
+			group.push(item);
+		} else {
+			map.set(key, [item]);
+		}
+	}
+	return Array.from(map.entries()).map(([key, entries]) => ({ key, entries }));
 }
 
 /**

--- a/.pi/extensions/session-advice/test/session-advice-advisor.test.mts
+++ b/.pi/extensions/session-advice/test/session-advice-advisor.test.mts
@@ -126,7 +126,7 @@ describe("detectBashGrep", () => {
 });
 
 describe("detectErrorLoop", () => {
-	it("flags when same tool errors and retried 2+ times", () => {
+	it("flags when same tool errors and retried 2+ times with same args", () => {
 		const data = makeSession([
 			readToolError(0),
 			readEntry("/repo/src/missing.ts", 1),
@@ -134,7 +134,30 @@ describe("detectErrorLoop", () => {
 		]);
 		const signals = analyzeSession(data);
 		const errs = signals.filter((s) => s.signal === "error-loop");
-		assert.ok(errs.length >= 1, "should flag retries after error");
+		assert.ok(errs.length >= 1, "should flag retries after error with same args");
+	});
+
+	it("does NOT flag when retries have different args (strategy change)", () => {
+		const data = makeSession([
+			readToolError(0),
+			readEntry("/repo/src/file-a.ts", 1),
+			readEntry("/repo/src/file-b.ts", 2),
+		]);
+		const signals = analyzeSession(data);
+		const errs = signals.filter((s) => s.signal === "error-loop");
+		assert.strictEqual(errs.length, 0, "different args = strategy change, not loop");
+	});
+
+	it("flags 2+ retries with same args even with different-args retries in window", () => {
+		const data = makeSession([
+			readToolError(0),
+			readEntry("/repo/src/target.ts", 1),
+			readEntry("/repo/src/other.ts", 2),
+			readEntry("/repo/src/target.ts", 3),
+		]);
+		const signals = analyzeSession(data);
+		const errs = signals.filter((s) => s.signal === "error-loop");
+		assert.ok(errs.length >= 1, "should flag same-args retries despite different-args in between");
 	});
 
 	it("does NOT flag single error without retry", () => {
@@ -142,6 +165,21 @@ describe("detectErrorLoop", () => {
 		const signals = analyzeSession(data);
 		const errs = signals.filter((s) => s.signal === "error-loop");
 		assert.strictEqual(errs.length, 0);
+	});
+
+	it("proportional waste: counts only retries beyond first", () => {
+		// 1 error + 3 retries with same args → 2 wasteful (first retry excluded)
+		const data = makeSession([
+			readToolError(0),
+			readEntry("/repo/src/missing.ts", 1),
+			readEntry("/repo/src/missing.ts", 2),
+			readEntry("/repo/src/missing.ts", 3),
+		]);
+		const signals = analyzeSession(data);
+		const errs = signals.filter((s) => s.signal === "error-loop");
+		assert.ok(errs.length >= 1, "should flag");
+		// 3 retries - 1 = 2 wasteful
+		assert.strictEqual(errs[0].occurrences, 2, "should have 2 wasteful occurrences");
 	});
 });
 


### PR DESCRIPTION
## Summary

Fixes 3 bugs in D5 detectErrorLoop false-positive detection (issue #623).

### Changes

**1. Arg comparison** — `detectErrorLoop` now groups retries by a stable JSON args key. Only flags when 2+ retries with the same args appear in the 8-entry window after an error. Different args = strategy change, not a loop. This eliminates false positives when the agent tries different files/commands after an error.

**2. Proportional cost split** — Only retries beyond the first are counted as waste. The first retry after an error is reasonable (the agent doesn't know yet it will fail again). Subsequent same-args retries without strategy change are wasteful.

**3. Waste filtering** — Groups same-tool retries by args key, picks the largest group. Single retries with same args no longer trigger. Uses stable JSON serialization for deterministic comparison.

### Files changed

- `.pi/extensions/session-advice/advisor.ts` — `detectErrorLoop` rewritten with `stableJsonKey` and `groupBy` helpers
- `.pi/extensions/session-advice/test/session-advice-advisor.test.mts` — 3 new tests (different-args skip, mixed-args window, proportional cost), 2 updated

### Tests

41 passing, 0 failing. All 5 `detectErrorLoop` tests pass:
- Same-args retries flagged ✓
- Different-args retries skipped (new) ✓
- Same-args in mixed window flagged (new) ✓
- Single error no retry skipped ✓
- Proportional occurrences count (new) ✓

Closes #623