### PR TITLE
feat(#631): [harness] SYSTEM OVERRIDE false positive — blocks grep/rg in string arguments, not just commands

### DIFF
--- a/.pi/extensions/agent-harness/lib/bash-command.test.ts
+++ b/.pi/extensions/agent-harness/lib/bash-command.test.ts
@@ -49,6 +49,26 @@ describe("BashCommand.isSearch", () => {
 		assert.equal(new BashCommand("cd src && echo 'testing `rg` in body'").isSearch(), false);
 	});
 
+	// ── Phase 1: standalone commands with backtick grep/rg in quoted string args ──
+
+	it("false for standalone gh issue with backtick grep in body", () => {
+		assert.equal(
+			new BashCommand("gh issue create --body 'uses `grep` for searching'").isSearch(),
+			false,
+		);
+	});
+
+	it("false for standalone echo with backtick rg in string", () => {
+		assert.equal(new BashCommand("echo 'testing `rg` in the code'").isSearch(), false);
+	});
+
+	it("false for standalone gh issue with backtick grep pattern in body", () => {
+		assert.equal(
+			new BashCommand("gh issue create --body 'found by `grep` pattern'").isSearch(),
+			false,
+		);
+	});
+
 	it("false for grep with redirect", () => {
 		assert.equal(new BashCommand("grep foo > out.txt").isSearch(), true);
 	});
@@ -382,6 +402,20 @@ describe("BashCommand.detectMismatch", () => {
 		assert.equal(result, null);
 	});
 
+	// ── Phase 2: standalone commands with backtick grep/rg in quoted string args ──
+
+	it("standalone gh issue with backtick grep in body → null", () => {
+		const result = new BashCommand(
+			"gh issue create --body 'uses `grep` for searching'",
+		).detectMismatch();
+		assert.equal(result, null);
+	});
+
+	it("standalone echo with backtick rg in body → null", () => {
+		const result = new BashCommand("echo 'testing `rg` in body'").detectMismatch();
+		assert.equal(result, null);
+	});
+
 	it("head inside quoted argument → null", () => {
 		const result = new BashCommand(`gh issue view 123 --title "head -5"`).detectMismatch();
 		assert.equal(result, null);
@@ -553,6 +587,15 @@ describe("BashCommand.suggestRedirection", () => {
 
 	it("rg in quoted argument → null", () => {
 		assert.equal(new BashCommand(`gh issue view 123 --title "rg"`).suggestRedirection(), null);
+	});
+
+	// ── Phase 2: standalone commands with backtick grep/rg in quoted string args ──
+
+	it("standalone gh issue with backtick grep in body → null", () => {
+		assert.equal(
+			new BashCommand("gh issue create --body 'uses `grep` for text'").suggestRedirection(),
+			null,
+		);
 	});
 });
 

--- a/.pi/extensions/agent-harness/lib/bash-command.ts
+++ b/.pi/extensions/agent-harness/lib/bash-command.ts
@@ -171,7 +171,8 @@ export class BashCommand {
 	 * Logic matches harness-rules.ts isSearchInBash():
 	 *  - Piped, && chained, ; chained → not search (pass through)
 	 *  - Standalone grep/rg as first token → search
-	 *  - Backtick grep/rg → search (standalone only)
+	 *  - Backtick grep/rg as first token → search (standalone only)
+	 *  - Backtick grep/rg inside quoted string args → NOT search
 	 */
 	isSearch(): boolean {
 		if (!this.raw) return false;
@@ -181,11 +182,6 @@ export class BashCommand {
 			return false;
 		}
 
-		// Backtick patterns: `grep`, `rg` — search for standalone commands
-		if (this.lower.includes("`grep") || this.lower.includes("`rg")) {
-			return true;
-		}
-
 		// For standalone commands, check first segment only
 		if (this.segments.length === 0) return false;
 
@@ -193,6 +189,13 @@ export class BashCommand {
 		if (!firstSeg || firstSeg.tokens.length === 0) return false;
 
 		const first = firstSeg.tokens[0];
+
+		// Backtick patterns: `grep`, `rg` — search when first token
+		// starts with backtick + grep/rg (actual command, not string arg)
+		if (first.startsWith("`grep") || first.startsWith("`rg")) {
+			return true;
+		}
+
 		return first === "grep" || first === "rg";
 	}
 
@@ -308,13 +311,14 @@ export class BashCommand {
 		// Search in bash (grep/rg as first token — standalone only, not piped)
 		// Redirect does NOT suppress search detection
 		if (this.isStandalone()) {
-			// Backtick patterns: `grep`, `rg` — search for standalone commands
-			if (this.lower.includes("`grep") || this.lower.includes("`rg")) {
-				return "search";
-			}
 			for (const seg of this.segments) {
 				if (seg.tokens.length >= 1) {
 					const first = seg.tokens[0];
+					// Backtick patterns: `grep`, `rg` — search when first token
+					// starts with backtick + grep/rg (actual command, not string arg)
+					if (first.startsWith("`grep") || first.startsWith("`rg")) {
+						return "search";
+					}
 					if (first === "grep" || first === "rg") {
 						return "search";
 					}

--- a/.pi/extensions/agent-harness/test/index.test.ts
+++ b/.pi/extensions/agent-harness/test/index.test.ts
@@ -147,6 +147,17 @@ describe("AgentHarness — bash tool mismatch", () => {
 			assert.equal(h.handleToolCall(makeEvent("bash", { command: cmd }), makeCtx()), null, cmd);
 		}
 	});
+
+	it("standalone gh issue with backtick grep in body passes through", () => {
+		const h = new AgentHarness();
+		assert.equal(
+			h.handleToolCall(
+				makeEvent("bash", { command: "gh issue create --body 'uses `grep` for search'" }),
+				makeCtx(),
+			),
+			null,
+		);
+	});
 });
 
 // ── Error accumulation and retry blocking ──


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #631

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 3m 12s | 85.9K | 57 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 5s | 163.1K | 32 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 20s | 39.6K | 17 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 44s | 61.9K | 35 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 44s | 50.7K | 31 | deepseek-v4-flash |

**Total:** 5 agents · 12m 5s · 401.1K tokens · 172 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/631
Closes #631