### PR TITLE
feat(#677): ranked-map: add path-aware keyword boost for query-relevant directories

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -11,6 +11,7 @@
   - Structural overview in recency-only mode — one file per top-level directory ensures broad repo awareness
 - **Configurable token budget** — Default 4096 tokens, adjustable per call
 - **Caching** — Symbol index cached to `.pi/cache/ranked-map-index.json` keyed by git HEAD, config hash, and target directory (config changes or different directory scope invalidate the cache)
+- **Path-aware keyword boost** — Files whose relative path contains any expanded query term receive a 1.5x multiplier on their keyword score (capped at 1.0). A query for "extension" automatically boosts `.pi/extensions/` files, elevating semantically relevant results regardless of content-match density
 - **Configurable test-file penalty** — Test files (`.test.`, `.spec.`, `/test/`) default to 0.5x score penalty; per-directory overrides configurable via `testFilePenalties` in settings (e.g. `{ ".pi/": 0.7 }`). Query terms matching file paths automatically cap penalty at 0.7x
 - **.piignore integration** — Patterns from `.piignore` are automatically added as ctags excludes
 - **Improved previews** — Shows ctag definition lines (from pattern field) instead of first 5 comment/import lines
@@ -26,7 +27,7 @@
 The extension is orchestrated by a **`RankedMapEngine`** class (`engine.ts`) that separates the pipeline into independently testable phases:
 
 - **`buildOrLoadIndex()`** — Look up git HEAD, try cache, fall back to ctags + parsing. Integrates `.piignore` patterns as additional ctags excludes
-- **`rank()`** — Select mode (full-dump vs ranked), compute keyword + recency scores (including submodule git history via `discoverSubmodules()` and `runGitRecency()`), apply test-file penalty, combine and truncate by token budget
+- **`rank()`** — Select mode (full-dump vs ranked), compute keyword scores with path-aware boost (files whose path matches query terms receive a 1.5x multiplier), compute recency scores (including submodule git history via `discoverSubmodules()` and `runGitRecency()`), apply test-file penalty, combine and truncate by token budget
 - **`addPreviews()`** — Show ctag pattern-based previews (definition lines) when available, fall back to reading first 5 file lines
 - **`format()`** — Shape results into the final `RankedMapResult` output. Includes `getStructuralOverview()` for recency-only mode
 
@@ -45,7 +46,7 @@ Each phase accepts `ExecFn` + config via constructor, making all methods testabl
 2. The index is cached to disk keyed by current git HEAD, config hash, and target directory scope
 3. When called, the extension selects mode:
    - **Full dump** — repo small enough, returns all files sorted by path up to token budget
-   - **Ranked** — runs `rg --files-with-matches` for keyword scoring, `git log --name-only` for recency scoring (includes submodule commits via `discoverSubmodules` + `runGitRecency`), then combines scores with configurable weights. Only files present in the ctags symbol index are eligible for ranking — files excluded by `--exclude` patterns (`.json`, `.md`, `node_modules`, etc.) are filtered out regardless of keyword or recency matches, preventing token waste on non-code files. Test files receive a 0.5x score penalty. In recency-only mode (no query), a structural overview injects one representative file per top-level directory
+   - **Ranked** — runs `rg --files-with-matches` for keyword scoring, `git log --name-only` for recency scoring (includes submodule commits via `discoverSubmodules` + `runGitRecency`), then combines scores with configurable weights. Files whose relative path contains any expanded query term receive a 1.5x keyword score boost (capped at 1.0), elevating results whose directory structure makes them semantically relevant. Only files present in the ctags symbol index are eligible for ranking — files excluded by `--exclude` patterns (`.json`, `.md`, `node_modules`, etc.) are filtered out regardless of keyword or recency matches, preventing token waste on non-code files. Test files receive a 0.5x score penalty. In recency-only mode (no query), a structural overview injects one representative file per top-level directory
 4. Results are formatted as JSON with file paths, symbols, token counts, and (in ranked mode) file previews showing definition lines
 
 ## Install

--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -31,6 +31,7 @@ import {
 	computeRecencyScores,
 	computeFileSizeScores,
 	computeCommitCountScores,
+	applyPathBoost,
 	rankFiles,
 } from "./scoring.ts";
 import { runFrequencySearch } from "./search.ts";
@@ -207,6 +208,9 @@ export class RankedMapEngine {
 				signal,
 			);
 			keywordScores = computeKeywordScores(fileCounts, this.config.frequencyScalingFactor ?? 0.2);
+
+			// Apply path-aware boost: files whose path matches query terms get 1.5x
+			keywordScores = applyPathBoost(keywordScores, expandedTerms);
 
 			// Compute git commit count scores (only when query present)
 			// Commit count is irrelevant in recency-only mode

--- a/.pi/extensions/ranked-map/scoring.ts
+++ b/.pi/extensions/ranked-map/scoring.ts
@@ -184,6 +184,65 @@ export function computeFileSizeScores(fileSizes: Record<string, number>): Record
 }
 
 /**
+ * Apply path-aware keyword score boost.
+ *
+ * Files whose relative path contains any of the expanded query terms
+ * get their keyword score boosted by 1.5x (capped at 1.0).
+ * This elevates files that are semantically relevant by directory path.
+ *
+ * Expanded terms are regex alternation groups like "(extension|extensions|extens)".
+ * Each alternative is checked individually against the file path (case-insensitive).
+ * Files with score ≤ 0 are skipped (no boost for zero or negative scores).
+ *
+ * @param keywordScores - Map of file path → keyword score (0 to 1)
+ * @param expandedTerms - Array of expanded regex patterns, one per query term
+ * @returns New map with boosted scores, original input not mutated
+ */
+export function applyPathBoost(
+	keywordScores: Record<string, number>,
+	expandedTerms: string[],
+): Record<string, number> {
+	const boosted: Record<string, number> = {};
+
+	for (const [path, score] of Object.entries(keywordScores)) {
+		if (score <= 0) {
+			boosted[path] = score;
+			continue;
+		}
+
+		const pathLower = path.toLowerCase();
+		let matched = false;
+
+		for (const term of expandedTerms) {
+			if (!term) continue;
+
+			// Strip outer parens and split on | to get individual alternatives
+			const inner = term.startsWith("(") && term.endsWith(")") ? term.slice(1, -1) : term;
+			const alternatives = inner.split("|");
+
+			for (const alt of alternatives) {
+				const clean = alt.replace(/[()|\\]/g, "").toLowerCase();
+				if (!clean) continue;
+				if (pathLower.includes(clean)) {
+					matched = true;
+					break;
+				}
+			}
+			if (matched) break;
+		}
+
+		if (matched) {
+			const raw = Math.min(1.0, score * 1.5);
+			boosted[path] = Math.round(raw * 100) / 100;
+		} else {
+			boosted[path] = score;
+		}
+	}
+
+	return boosted;
+}
+
+/**
  * Apply test-file penalty to a set of ranked file scores.
  *
  * Files matching test patterns (.test., .spec., /test/) get their score

--- a/.pi/extensions/ranked-map/test/engine.test.ts
+++ b/.pi/extensions/ranked-map/test/engine.test.ts
@@ -331,6 +331,64 @@ describe("RankedMapEngine — rank", () => {
 		const result = await engine.rank(index, "", 1, ".", undefined);
 		assert.ok(result.truncated || result.files.length < 2, "should truncate with tiny budget");
 	});
+
+	it("applies applyPathBoost when query matches file path", async () => {
+		const exec = mockExec();
+		exec.mock.mockImplementation(async (cmd: string, args: string[], _opts?: any) => {
+			if (cmd === "git" && args[0] === "rev-parse") {
+				return { stdout: "abc123\n", stderr: "", code: 0, killed: false };
+			}
+			if (cmd === "git" && args[0] === "submodule") {
+				return { stdout: "", stderr: "", code: 0, killed: false };
+			}
+			if (cmd === "git" && (args[0] === "log" || args[0] === "-C")) {
+				return { stdout: "", stderr: "", code: 0, killed: false };
+			}
+			// rg --count-matches returns file with 1 match
+			if (cmd === "rg") {
+				return {
+					stdout: ".pi/extensions/foo.ts:1\n",
+					stderr: "",
+					code: 0,
+					killed: false,
+				};
+			}
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		});
+
+		const config: RankedMapConfig = {
+			...defaultConfig,
+			autoThreshold: 0,
+		};
+		const engine = new RankedMapEngine(config, exec, "/tmp");
+		const index: CachedIndex = {
+			head: "abc123",
+			builtAt: Date.now(),
+			symbols: {
+				".pi/extensions/foo.ts": [{ type: "function", name: "foo", line: 1 }],
+				"src/views.ts": [{ type: "function", name: "view", line: 1 }],
+			},
+		};
+
+		const result = await engine.rank(index, "extension", 50000, ".", undefined);
+
+		const extFile = result.files.find((f) => f.path === ".pi/extensions/foo.ts");
+		const viewFile = result.files.find((f) => f.path === "src/views.ts");
+
+		assert.ok(extFile, ".pi/extensions/foo.ts should be in results");
+		assert.ok(viewFile, "src/views.ts should be in results");
+
+		// extension keyword score = min(1.0, 1 * 0.2) = 0.2
+		// After applyPathBoost: path contains "extension" → 0.2 * 1.5 = 0.3
+		// After keyword weight (0.5): 0.3 * 0.5 = 0.15
+		assert.strictEqual(extFile!.score, 0.15);
+
+		// src/views.ts doesn't contain "extension" in path → no boost
+		// Keyword score stays 0.0 (no match from rg) or 0 if not in rg output
+		// Actually views.ts wasn't in rg output, so kw = 0
+		// Score = 0 * 0.5 = 0
+		assert.strictEqual(viewFile!.score, 0);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -444,8 +502,9 @@ describe("RankedMapEngine — rank with testFilePenalties config", () => {
 
 		const piTest = result.files.find((f) => f.path.startsWith(".pi/"));
 		assert.ok(piTest, ".pi test file should be in results");
-		// .pi test: kw = min(1.0, 3 * 0.2) = 0.6, score = 0.6 * 0.5 (kw weight) = 0.3, after override 0.7 → 0.21
-		assert.strictEqual(piTest!.score, 0.21);
+		// .pi test: kw = min(1.0, 3 * 0.2) = 0.6, after path boost (path matches "extension") = 0.9,
+		// score = 0.9 * 0.5 (kw weight) = 0.45, after override 0.7 → 0.315 → 0.32
+		assert.strictEqual(piTest!.score, 0.32);
 	});
 
 	it("config without testFilePenalties uses default 0.5x penalty (backward compat)", async () => {

--- a/.pi/extensions/ranked-map/test/scoring.test.ts
+++ b/.pi/extensions/ranked-map/test/scoring.test.ts
@@ -22,6 +22,7 @@ import {
 	computeRecencyScores,
 	computeFileSizeScores,
 	computeCommitCountScores,
+	applyPathBoost,
 } from "../scoring.ts";
 import type { SymbolEntry } from "../types.ts";
 
@@ -894,9 +895,7 @@ describe("rankFiles with testFilePenalties and queryTerms", () => {
 		".pi/extensions/check-extensions/test/pipeline.test.ts": [
 			{ type: "function", name: "test", line: 1 },
 		],
-		"other/test/foo.test.ts": [
-			{ type: "function", name: "test_i18n", line: 1 },
-		],
+		"other/test/foo.test.ts": [{ type: "function", name: "test_i18n", line: 1 }],
 		"src/foo.test.ts": [{ type: "function", name: "testFoo", line: 1 }],
 		"src/bar.ts": [{ type: "function", name: "bar", line: 1 }],
 	};
@@ -1070,5 +1069,114 @@ describe("rankFiles with testFilePenalties and queryTerms", () => {
 		assert.ok(bar);
 		assert.strictEqual(fooTest!.score, 0.5); // default 0.5 penalty
 		assert.strictEqual(bar!.score, 1.0); // no penalty
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 11: applyPathBoost — path-aware keyword score boosting
+// ---------------------------------------------------------------------------
+
+describe("applyPathBoost", () => {
+	it("path match boosts score by 1.5x", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.5 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("score already at 1.0 stays 1.0 after boost (cap works)", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 1.0 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 1.0);
+	});
+
+	it("score ≤ 0 skipped (unchanged at 0)", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0);
+	});
+
+	it("non-matching path (no query term in path) unchanged", () => {
+		const scores = applyPathBoost({ "src/views.ts": 0.4 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores["src/views.ts"], 0.4);
+	});
+
+	it("case-insensitive path matching: path with capitalized dir matches term", () => {
+		const scores = applyPathBoost({ ".pi/Extensions/foo.ts": 0.5 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/Extensions/foo.ts"], 0.75);
+	});
+
+	it("multi-alternative expanded term splits on | and checks each alternative individually", () => {
+		// Term like "(extension|extensions)" should check both alternatives separately,
+		// not as concatenated "extensionextensions"
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.5 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("empty expandedTerms array returns scores unchanged, no mutation", () => {
+		const input = { ".pi/extensions/foo.ts": 0.5 };
+		const original = { ...input };
+		const scores = applyPathBoost(input, []);
+		assert.deepEqual(scores, original);
+	});
+
+	it("term with no | (single alternative) still matches correctly", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.5 }, ["(extension)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("boost value rounded to 2 decimal places: 0.33 * 1.5 = 0.495 → 0.5", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.33 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.5);
+	});
+
+	it("multiple files in map, only matching paths get boost, non-matching paths unchanged", () => {
+		const scores = applyPathBoost(
+			{
+				".pi/extensions/foo.ts": 0.5,
+				"src/views.ts": 0.4,
+				"docs/readme.md": 0.3,
+			},
+			["(extension|extensions)"],
+		);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.75);
+		assert.strictEqual(scores["src/views.ts"], 0.4);
+		assert.strictEqual(scores["docs/readme.md"], 0.3);
+	});
+
+	it("term with regex special characters like . or + treated as plain text", () => {
+		const scores = applyPathBoost({ "src/foo+bar.ts": 0.5 }, ["(foo+bar)"]);
+		assert.strictEqual(scores["src/foo+bar.ts"], 0.75);
+	});
+
+	it("expanded term alternative is a substring of path component", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.5 }, ["(extension)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("empty string in expandedTerms array is skipped gracefully", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.5 }, ["", "(extension)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("score 0.67 * 1.5 = 1.005 → capped at 1.0", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.67 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 1.0);
+	});
+
+	it("score 0.01 * 1.5 = 0.015 → rounded to 0.02", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.01 }, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.02);
+	});
+
+	it("original input object is not mutated", () => {
+		const input = { ".pi/extensions/foo.ts": 0.5, "src/views.ts": 0.4 };
+		const inputCopy = { ...input };
+		applyPathBoost(input, ["(extension|extensions)"]);
+		assert.deepEqual(input, inputCopy);
+	});
+
+	it("no matching terms in expandedTerms returns unchanged scores", () => {
+		const scores = applyPathBoost({ ".pi/extensions/foo.ts": 0.5, "src/views.ts": 0.4 }, [
+			"(database|sql)",
+		]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.5);
+		assert.strictEqual(scores["src/views.ts"], 0.4);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #677

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 1m 1s | 42.1K | 10 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 1s | 97.8K | 24 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 40s | 34.8K | 12 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 1s | 71.5K | 41 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 6m 31s | 61.2K | 65 | deepseek-v4-flash |

**Total:** 5 agents · 13m 14s · 307.5K tokens · 152 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/677
Closes #677