### PR TITLE
feat(#677): ranked-map: add path-aware keyword boost for query-relevant directories

### DIFF
--- a/.pi/extensions/ranked-map/README.md
+++ b/.pi/extensions/ranked-map/README.md
@@ -11,6 +11,7 @@
   - Structural overview in recency-only mode — one file per top-level directory ensures broad repo awareness
 - **Configurable token budget** — Default 4096 tokens, adjustable per call
 - **Caching** — Symbol index cached to `.pi/cache/ranked-map-index.json` keyed by git HEAD, config hash, and target directory (config changes or different directory scope invalidate the cache)
+- **Path-aware keyword boost** — Files whose path contains any expanded query term (e.g. query `"extension"` boosts `.pi/extensions/` files) receive a 1.5x keyword score multiplier (capped at 1.0). This follows field-weighted search principles — path matches are weighted higher than content-only matches
 - **Configurable test-file penalty** — Test files (`.test.`, `.spec.`, `/test/`) default to 0.5x score penalty; per-directory overrides configurable via `testFilePenalties` in settings (e.g. `{ ".pi/": 0.7 }`). Query terms matching file paths automatically cap penalty at 0.7x
 - **.piignore integration** — Patterns from `.piignore` are automatically added as ctags excludes
 - **Improved previews** — Shows ctag definition lines (from pattern field) instead of first 5 comment/import lines
@@ -45,7 +46,7 @@ Each phase accepts `ExecFn` + config via constructor, making all methods testabl
 2. The index is cached to disk keyed by current git HEAD, config hash, and target directory scope
 3. When called, the extension selects mode:
    - **Full dump** — repo small enough, returns all files sorted by path up to token budget
-   - **Ranked** — runs `rg --files-with-matches` for keyword scoring, `git log --name-only` for recency scoring (includes submodule commits via `discoverSubmodules` + `runGitRecency`), then combines scores with configurable weights. Only files present in the ctags symbol index are eligible for ranking — files excluded by `--exclude` patterns (`.json`, `.md`, `node_modules`, etc.) are filtered out regardless of keyword or recency matches, preventing token waste on non-code files. Test files receive a 0.5x score penalty. In recency-only mode (no query), a structural overview injects one representative file per top-level directory
+   - **Ranked** — runs `rg --files-with-matches` for keyword scoring, applies path-aware keyword boost (1.5x multiplier for files whose path contains query terms), then `git log --name-only` for recency scoring (includes submodule commits via `discoverSubmodules` + `runGitRecency`), then combines scores with configurable weights. Only files present in the ctags symbol index are eligible for ranking — files excluded by `--exclude` patterns (`.json`, `.md`, `node_modules`, etc.) are filtered out regardless of keyword or recency matches, preventing token waste on non-code files. Test files receive a 0.5x score penalty. In recency-only mode (no query), a structural overview injects one representative file per top-level directory
 4. Results are formatted as JSON with file paths, symbols, token counts, and (in ranked mode) file previews showing definition lines
 
 ## Install

--- a/.pi/extensions/ranked-map/engine.ts
+++ b/.pi/extensions/ranked-map/engine.ts
@@ -31,6 +31,7 @@ import {
 	computeRecencyScores,
 	computeFileSizeScores,
 	computeCommitCountScores,
+	applyPathBoost,
 	rankFiles,
 } from "./scoring.ts";
 import { runFrequencySearch } from "./search.ts";
@@ -207,6 +208,10 @@ export class RankedMapEngine {
 				signal,
 			);
 			keywordScores = computeKeywordScores(fileCounts, this.config.frequencyScalingFactor ?? 0.2);
+
+			// Apply path-aware boost: 1.5x score boost for files whose path contains
+			// any expanded query term (e.g. query "extension" boosts .pi/extensions/ files)
+			keywordScores = applyPathBoost(keywordScores, expandedTerms);
 
 			// Compute git commit count scores (only when query present)
 			// Commit count is irrelevant in recency-only mode

--- a/.pi/extensions/ranked-map/scoring.ts
+++ b/.pi/extensions/ranked-map/scoring.ts
@@ -184,6 +184,60 @@ export function computeFileSizeScores(fileSizes: Record<string, number>): Record
 }
 
 /**
+ * Apply path-aware keyword score boost for files whose relative path contains
+ * any individual alternative from the expanded query terms.
+ *
+ * For each file, if its path contains any expanded term alternative (plain text,
+ * case-insensitive), its keyword score is boosted by 1.5x, capped at 1.0.
+ *
+ * This is the path-aware boost step between computeKeywordScores and rankFiles.
+ * It follows the same field-weighted search technique used in production search
+ * engines: matches in the file path field are weighted higher than content matches.
+ *
+ * @param keywordScores - Map of file path → keyword score (0 to 1) from computeKeywordScores
+ * @param expandedTerms - Array of expanded regex patterns from expandQuery, e.g. "(extension|extensions)"
+ * @returns New map with boosted scores (original object is not mutated)
+ */
+export function applyPathBoost(
+	keywordScores: Record<string, number>,
+	expandedTerms: string[],
+): Record<string, number> {
+	const boosted: Record<string, number> = { ...keywordScores };
+
+	if (expandedTerms.length === 0) return boosted;
+
+	// Pre-parse expanded terms: split each pattern on | and collect alternatives
+	const alternatives: string[] = [];
+	for (const term of expandedTerms) {
+		// Strip outer parens if present, then split on |
+		const inner = term.startsWith("(") && term.endsWith(")") ? term.slice(1, -1) : term;
+		const parts = inner.split("|");
+		for (const part of parts) {
+			const clean = part.toLowerCase();
+			if (clean.length > 0 && !alternatives.includes(clean)) {
+				alternatives.push(clean);
+			}
+		}
+	}
+
+	if (alternatives.length === 0) return boosted;
+
+	for (const [path, score] of Object.entries(boosted)) {
+		if (score <= 0) continue;
+		const pathLower = path.toLowerCase();
+		for (const alt of alternatives) {
+			if (pathLower.includes(alt)) {
+				const raw = Math.min(1.0, score * 1.5);
+				boosted[path] = Math.round(raw * 100) / 100;
+				break;
+			}
+		}
+	}
+
+	return boosted;
+}
+
+/**
  * Apply test-file penalty to a set of ranked file scores.
  *
  * Files matching test patterns (.test., .spec., /test/) get their score

--- a/.pi/extensions/ranked-map/test/engine.test.ts
+++ b/.pi/extensions/ranked-map/test/engine.test.ts
@@ -400,6 +400,66 @@ describe("RankedMapEngine — format", () => {
 });
 
 // ---------------------------------------------------------------------------
+// rank — path-aware keyword boost integration
+// ---------------------------------------------------------------------------
+
+describe("RankedMapEngine — rank with path-aware keyword boost", () => {
+	it("engine.rank() with query 'extension' boosts .pi/extensions/ files", async () => {
+		const exec = mockExec();
+		exec.mock.mockImplementation(async (cmd: string, args: string[], _opts?: any) => {
+			if (cmd === "git" && args[0] === "rev-parse") {
+				return { stdout: "abc123\n", stderr: "", code: 0, killed: false };
+			}
+			if (cmd === "git" && args[0] === "submodule") {
+				return { stdout: "", stderr: "", code: 0, killed: false };
+			}
+			if (cmd === "git" && (args[0] === "log" || args[0] === "-C")) {
+				return { stdout: "", stderr: "", code: 0, killed: false };
+			}
+			// rg --count-matches: extension file has 3 matches, non-extension has 3 matches too
+			if (cmd === "rg") {
+				return {
+					stdout: ".pi/extensions/check-extensions/test/pipeline.test.ts:3\n" + "src/views.ts:3\n",
+					stderr: "",
+					code: 0,
+					killed: false,
+				};
+			}
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		});
+
+		const config: RankedMapConfig = {
+			...defaultConfig,
+			autoThreshold: 0,
+		};
+		const engine = new RankedMapEngine(config, exec, "/tmp");
+		const index = makeIndex();
+		// Both files have same content-match count (3), but .pi path matches "extension" query
+		index.symbols[".pi/extensions/check-extensions/test/pipeline.test.ts"] = [
+			{ type: "function", name: "testPipe", line: 1 },
+		];
+		index.symbols["src/views.ts"] = [{ type: "function", name: "view", line: 1 }];
+
+		const result = await engine.rank(index, "extension", 50000, ".", undefined);
+
+		const piFile = result.files.find((f) => f.path.startsWith(".pi/"));
+		const viewFile = result.files.find((f) => f.path.startsWith("src/"));
+
+		assert.ok(piFile, ".pi file should be in results");
+		assert.ok(viewFile, "src file should be in results");
+
+		// Both files had same rg match count (3), same keyword score before boost:
+		// kw = min(1.0, 3 * 0.2) = 0.6
+		// After path boost for .pi file: 0.6 * 1.5 = 0.9 (capped at 1.0)
+		// src/views.ts has no path match → stays 0.6
+		// .pi file should rank higher
+		const piIdx = result.files.indexOf(piFile);
+		const viewIdx = result.files.indexOf(viewFile);
+		assert.ok(piIdx < viewIdx, ".pi file should rank higher than src file with same content count");
+	});
+});
+
+// ---------------------------------------------------------------------------
 // rank — config-driven testFilePenalties
 // ---------------------------------------------------------------------------
 
@@ -444,8 +504,9 @@ describe("RankedMapEngine — rank with testFilePenalties config", () => {
 
 		const piTest = result.files.find((f) => f.path.startsWith(".pi/"));
 		assert.ok(piTest, ".pi test file should be in results");
-		// .pi test: kw = min(1.0, 3 * 0.2) = 0.6, score = 0.6 * 0.5 (kw weight) = 0.3, after override 0.7 → 0.21
-		assert.strictEqual(piTest!.score, 0.21);
+		// .pi test: kw = min(1.0, 3 * 0.2) = 0.6, after path boost (1.5x) → 0.9.
+		// score = 0.9 * 0.5 (kw weight) = 0.45, after override 0.7 → 0.315 → 0.32
+		assert.strictEqual(piTest!.score, 0.32);
 	});
 
 	it("config without testFilePenalties uses default 0.5x penalty (backward compat)", async () => {

--- a/.pi/extensions/ranked-map/test/scoring.test.ts
+++ b/.pi/extensions/ranked-map/test/scoring.test.ts
@@ -22,6 +22,7 @@ import {
 	computeRecencyScores,
 	computeFileSizeScores,
 	computeCommitCountScores,
+	applyPathBoost,
 } from "../scoring.ts";
 import type { SymbolEntry } from "../types.ts";
 
@@ -894,9 +895,7 @@ describe("rankFiles with testFilePenalties and queryTerms", () => {
 		".pi/extensions/check-extensions/test/pipeline.test.ts": [
 			{ type: "function", name: "test", line: 1 },
 		],
-		"other/test/foo.test.ts": [
-			{ type: "function", name: "test_i18n", line: 1 },
-		],
+		"other/test/foo.test.ts": [{ type: "function", name: "test_i18n", line: 1 }],
 		"src/foo.test.ts": [{ type: "function", name: "testFoo", line: 1 }],
 		"src/bar.ts": [{ type: "function", name: "bar", line: 1 }],
 	};
@@ -1070,5 +1069,170 @@ describe("rankFiles with testFilePenalties and queryTerms", () => {
 		assert.ok(bar);
 		assert.strictEqual(fooTest!.score, 0.5); // default 0.5 penalty
 		assert.strictEqual(bar!.score, 1.0); // no penalty
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 11: applyPathBoost
+// ---------------------------------------------------------------------------
+
+describe("applyPathBoost", () => {
+	it("path match boosts score by 1.5x", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("score already at 1.0 stays 1.0 after boost (cap works)", () => {
+		const scores = { ".pi/extensions/foo.ts": 1.0 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 1.0);
+	});
+
+	it("score ≤ 0 skipped (unchanged)", () => {
+		const scores = { ".pi/extensions/foo.ts": 0 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0);
+	});
+
+	it("non-matching path unchanged", () => {
+		const scores = { "src/views.ts": 0.4 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result["src/views.ts"], 0.4);
+	});
+
+	it("case-insensitive path matching", () => {
+		const scores = { ".pi/Extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/Extensions/foo.ts"], 0.75);
+	});
+
+	it("multi-alternative expanded term splits on | and checks each alternative individually", () => {
+		// The bug from the issue: using term.replace(/[()|\\]/g, "") would produce
+		// "extensionextensions" which never matches. Must split on | and check each.
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("empty expandedTerms returns scores unchanged, no mutation", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, []);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.5);
+		// Verify original object is not mutated
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.5);
+	});
+
+	it("term with no | (single alternative) matches correctly", () => {
+		const scores = { "src/extension.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension)"]);
+		assert.strictEqual(result["src/extension.ts"], 0.75);
+	});
+
+	it("boost value rounded to 2 decimal places", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.33 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		// 0.33 * 1.5 = 0.495 → rounded to 0.5
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.5);
+	});
+
+	it("multiple files, only matching paths get boost", () => {
+		const scores = {
+			".pi/extensions/foo.ts": 0.5,
+			"src/views.ts": 0.4,
+			"lib/extension.ts": 0.3,
+		};
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.75);
+		assert.strictEqual(result["src/views.ts"], 0.4);
+		assert.strictEqual(result["lib/extension.ts"], 0.45);
+	});
+
+	it("term with regex special characters like . or + treated as plain text", () => {
+		const scores = { "src/file.plus.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(file.plus)"]);
+		// After splitting, "file.plus" should be checked as plain substring (not regex)
+		// pathLower.includes(clean) — plain text match
+		assert.strictEqual(result["src/file.plus.ts"], 0.75);
+	});
+
+	it("expanded term alternative is a substring of path component", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension)"]);
+		// "extension" is a substring of "extensions" → matches
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("empty string in expandedTerms skipped gracefully", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, [""]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.5);
+	});
+
+	it("score 0.67 * 1.5 = 1.005 capped at 1.0", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.67 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		// 0.67 * 1.5 = 1.005 → capped at 1.0
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 1.0);
+	});
+
+	it("score 0.01 * 1.5 = 0.015 rounded to 0.02", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.01 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		// 0.01 * 1.5 = 0.015 → Math.round(0.015 * 100) / 100 = Math.round(1.5) / 100 = 2/100 = 0.02
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.02);
+	});
+
+	it("input scores object is not mutated", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(scores[".pi/extensions/foo.ts"], 0.5, "original should not change");
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.75, "result should have boosted value");
+	});
+
+	it("multiple expanded terms, match on second term", () => {
+		const scores = { "src/config.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(auth|login)", "(config|configuration)"]);
+		// "config" matches path "src/config.ts"
+		assert.strictEqual(result["src/config.ts"], 0.75);
+	});
+
+	it("path match via shorthand variant from expansion", () => {
+		const scores = { ".pi/extensions/foo.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(extension|extensions|extens|ext)"]);
+		// All alternatives contain "ext" which is substring of "extensions" → matches
+		assert.strictEqual(result[".pi/extensions/foo.ts"], 0.75);
+	});
+
+	it("negative scores are skipped", () => {
+		const scores = { ".pi/extensions/foo.ts": -0.5 };
+		const result = applyPathBoost(scores, ["(extension|extensions)"]);
+		assert.strictEqual(result[".pi/extensions/foo.ts"], -0.5);
+	});
+
+	it("no expanded terms match any path → all scores unchanged", () => {
+		const scores = {
+			"src/views.ts": 0.4,
+			"lib/utils.ts": 0.6,
+		};
+		const result = applyPathBoost(scores, ["(auth|login)", "(db|database)"]);
+		assert.strictEqual(result["src/views.ts"], 0.4);
+		assert.strictEqual(result["lib/utils.ts"], 0.6);
+	});
+
+	it("expanded term with pipe-only alternative is handled", () => {
+		const scores = { "src/foo/bar.ts": 0.5 };
+		const result = applyPathBoost(scores, ["(|foo|)"]);
+		// After splitting on |: ["", "foo", ""], check each
+		// "" doesn't match anything (includes check on empty string is true for all paths)
+		// but empty alternatives should be skipped
+		assert.strictEqual(result["src/foo/bar.ts"], 0.75);
+	});
+
+	it("single alternative term (bare string not in parens) matches", () => {
+		const scores = { "src/extension.ts": 0.5 };
+		// Some expandedTerms might not be in parens if it's a single term
+		const result = applyPathBoost(scores, ["extension"]);
+		assert.strictEqual(result["src/extension.ts"], 0.75);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #677

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 3m 23s | 65.9K | 42 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 54s | 40.5K | 42 | deepseek-v4-flash |

**Total:** 2 agents · 5m 17s · 106.4K tokens · 84 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/677
Closes #677