### PR TITLE
feat(#665): Bug: structural-analyzer - YAML quoted keys in sgconfig.yml include quotes in auto-detected language

### DIFF
--- a/.pi/extensions/structural-analyzer/index.ts
+++ b/.pi/extensions/structural-analyzer/index.ts
@@ -191,7 +191,16 @@ export function parseLanguageGlobsFromYaml(yamlContent: string): string | null {
 			// Match "  lang: ..." pattern
 			const match = trimmed.match(/^(\S+):/);
 			if (match) {
-				return match[1];
+				let lang = match[1];
+				// Strip surrounding single or double quotes (YAML spec §3.2.3.1)
+				// Quotes are presentation detail, not content
+				if (
+					(lang.startsWith('"') && lang.endsWith('"')) ||
+					(lang.startsWith("'") && lang.endsWith("'"))
+				) {
+					lang = lang.slice(1, -1);
+				}
+				return lang;
 			}
 		}
 	}

--- a/.pi/extensions/structural-analyzer/test/structural-analyzer.test.mts
+++ b/.pi/extensions/structural-analyzer/test/structural-analyzer.test.mts
@@ -576,6 +576,34 @@ suppressError: false`;
 		const result = await detectLanguage(mockExec as any, "/p");
 		assert.strictEqual(result, "typescript");
 	});
+
+	it("detectLanguage with double-quoted key in sgconfig.yml", async () => {
+		const sgconfigYaml = `languageGlobs:
+  "ts": "**/*.ts"`;
+
+		const mockExec = async (cmd: string, args: string[]) => {
+			if (cmd === "test" && args[1] === "sgconfig.yml") return { code: 0 };
+			if (cmd === "test") return { code: 1 };
+			if (cmd === "cat" && args[0] === "sgconfig.yml") return { code: 0, stdout: sgconfigYaml };
+			return { code: 0, stdout: "" };
+		};
+		const result = await detectLanguage(mockExec as any, "/p");
+		assert.strictEqual(result, "ts");
+	});
+
+	it("detectLanguage with single-quoted key in sgconfig.yml", async () => {
+		const sgconfigYaml = `languageGlobs:
+  'ts': "**/*.ts"`;
+
+		const mockExec = async (cmd: string, args: string[]) => {
+			if (cmd === "test" && args[1] === "sgconfig.yml") return { code: 0 };
+			if (cmd === "test") return { code: 1 };
+			if (cmd === "cat" && args[0] === "sgconfig.yml") return { code: 0, stdout: sgconfigYaml };
+			return { code: 0, stdout: "" };
+		};
+		const result = await detectLanguage(mockExec as any, "/p");
+		assert.strictEqual(result, "ts");
+	});
 });
 
 describe("parseLanguageGlobsFromYaml", () => {
@@ -595,6 +623,59 @@ languageGlobs:
 
 	it("returns null for empty yaml", () => {
 		assert.strictEqual(parseLanguageGlobsFromYaml(""), null);
+	});
+
+	// ═══════════════════════════════════════════════════════════════════
+	// Quoted YAML key handling (issue #665)
+	// ═══════════════════════════════════════════════════════════════════
+
+	it('unquotes double-quoted key: "ts" → ts', () => {
+		const yaml = `languageGlobs:
+  "ts": "**/*.ts"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), "ts");
+	});
+
+	it("unquotes single-quoted key: 'py' → py", () => {
+		const yaml = `languageGlobs:
+  'py': "**/*.py"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), "py");
+	});
+
+	it("mixed quoted first key / unquoted second key → returns first key unquoted", () => {
+		const yaml = `languageGlobs:
+  "ts": "**/*.ts"
+  js: "**/*.js"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), "ts");
+	});
+
+	it("unquoted key still works (regression guard)", () => {
+		const yaml = `languageGlobs:
+  ts: "**/*.ts"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), "ts");
+	});
+
+	it("key with only leading quote (malformed) returns unchanged", () => {
+		const yaml = `languageGlobs:
+  "ts: "**/*.ts"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), '"ts');
+	});
+
+	it("key with only trailing quote (malformed) returns unchanged", () => {
+		const yaml = `languageGlobs:
+  ts": "**/*.ts"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), 'ts"');
+	});
+
+	it("empty double-quoted key returns empty string", () => {
+		const yaml = `languageGlobs:
+  "": "**/*.ts"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), "");
+	});
+
+	it("quoted key with special chars and spaces returns unquoted", () => {
+		const yaml = `languageGlobs:
+  "my-lang": "**/*.my"`;
+		assert.strictEqual(parseLanguageGlobsFromYaml(yaml), "my-lang");
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #665

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 39s | 28.1K | 14 | deepseek-v4-flash |
| researcher | ✓ SUCCESS | 2m 4s | 102.8K | 26 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 30s | 14.6K | 11 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 39s | 61.5K | 22 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 19s | 19.9K | 21 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 12s | 18.6K | 20 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 0s | 23.0K | 32 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 27s | 32.7K | 41 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 53s | 23.3K | 35 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 20s | 37.5K | 57 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 22s | 44.4K | 36 | deepseek-v4-flash |

**Total:** 11 agents · 21m 24s · 406.5K tokens · 315 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/665
Closes #665