### PR TITLE
feat(#718): Replace test-fail-first TDD gate with test-assertions + strengthened test-covers-symbols

### DIFF
--- a/.pi/extensions/supervisor/checks/tdd-gate.ts
+++ b/.pi/extensions/supervisor/checks/tdd-gate.ts
@@ -1,8 +1,8 @@
 // ─── TDD Gate ─────────────────────────────────────────────────────
 // Deterministic TDD verification gate for the supervisor pipeline.
 // Runs after developer commit, before auditor dispatch.
-// Verifies that tests were written, tests fail without implementation,
-// and tests reference new implementation code.
+// Verifies that tests were written, contain assertions, and that
+// exported symbols from implementation are exercised in tests.
 
 import { existsSync, readFileSync } from "node:fs";
 import { join, extname, basename } from "node:path";
@@ -26,7 +26,7 @@ export interface TddGateResult {
 /** A single TDD check within the gate. */
 export interface TddCheck {
 	/** Check name. */
-	name: "tests-written" | "test-fail-first" | "tests-reference-implementation";
+	name: "tests-written" | "test-assertions" | "test-covers-symbols";
 	/** Whether the check passed. */
 	passed: boolean;
 	/** Optional human-readable detail about the check result. */
@@ -159,6 +159,361 @@ export function buildTddGateResult(checks: TddCheck[]): TddGateResult {
 	};
 }
 
+// ─── Assertion Detection ───────────────────────────────────────────
+
+/**
+ * Built-in regex for detecting assertion lines.
+ * Matches common assertion patterns in test files.
+ */
+const DEFAULT_ASSERT_REGEX =
+	/(?:assert|expect|t\.\w+|ok\(|deepEqual|strictEqual|notStrictEqual|throws|rejects|doesNotThrow|doesNotReject|ifError|fail)/;
+
+/**
+ * Build a combined regex for assertion line detection.
+ * Custom patterns are treated as plain function names (escaped for regex safety).
+ * The built-in DEFAULT_ASSERT_REGEX is always included as a fallback.
+ */
+function buildAssertionRegex(customPatterns: string[]): RegExp {
+	if (customPatterns.length === 0) {
+		return DEFAULT_ASSERT_REGEX;
+	}
+	// Escape custom patterns (they are plain function names like "verify", "myAssert")
+	const escaped = customPatterns.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+	return new RegExp(`${escaped.join("|")}|${DEFAULT_ASSERT_REGEX.source}`);
+}
+
+/**
+ * Check if a line of code contains a placeholder assertion.
+ * A placeholder assertion is one where ALL arguments to every assertion
+ * call on the line are literal values (true/false/null/undefined/numbers/strings).
+ * Returns true only if assertion calls exist AND all their args are literals.
+ *
+ * Creates a fresh regex each call to avoid state issues with the `g` flag
+ * (important for parallel test execution).
+ */
+function isPlaceholderLine(line: string): boolean {
+	const assertCallRegex =
+		/(?:(?:assert|expect)\.\w+|expect|t\.\w+|ok|deepEqual|strictEqual|notStrictEqual|throws|rejects|doesNotThrow|doesNotReject|ifError|fail)\s*\(([^)]*)\)/g;
+
+	// Remove string literals to avoid false matches on content
+	const cleaned = line
+		.replace(/'(?:[^'\\]|\\.)*'/g, "")
+		.replace(/"(?:[^"\\]|\\.)*"/g, "")
+		.replace(/`(?:[^`\\]|\\.)*`/g, "");
+
+	// Match assertion function calls with their parenthesized arguments
+	let match: RegExpExecArray | null;
+	let hasAnyAssertionCall = false;
+
+	while ((match = assertCallRegex.exec(cleaned)) !== null) {
+		hasAnyAssertionCall = true;
+		const args = match[1].trim();
+		if (!args) continue;
+
+		// Split args by comma (simplistic — won't handle nested parens, but
+		// nested parens imply non-literal args so this is conservative)
+		const argList = args
+			.split(",")
+			.map((a) => a.trim())
+			.filter(Boolean);
+
+		for (const arg of argList) {
+			// Check if this arg is a literal
+			if (/^(true|false|null|undefined|-?\d+(?:\.\d+)?)$/i.test(arg)) continue;
+			if (/^["'`]/.test(arg)) continue; // String literal
+			// Non-literal found — this assertion has real arguments
+			return false;
+		}
+	}
+
+	return hasAnyAssertionCall;
+}
+
+/**
+ * Check that test files contain assertion statements.
+ *
+ * Scans each test file for assertion patterns (assert.*, expect.*, t.is, ok(, etc.)
+ * and rejects files with no assertions or only placeholder assertions
+ * (all-literal arguments like `expect(true).toBe(true)`).
+ *
+ * @param testFiles - List of test file paths (relative to worktreePath)
+ * @param worktreePath - Path to the worktree
+ * @param assertPatterns - Optional custom assertion function name patterns
+ * @returns TddCheck with pass/fail
+ */
+export function checkTestAssertions(
+	testFiles: string[],
+	worktreePath: string,
+	assertPatterns?: string[],
+): TddCheck {
+	const assertRegex = buildAssertionRegex(assertPatterns ?? []);
+
+	let anyFileHasNonPlaceholderAssertion = false;
+	let filesChecked = 0;
+	const details: string[] = [];
+
+	for (const testFile of testFiles) {
+		const fullPath = join(worktreePath, testFile);
+		if (!existsSync(fullPath)) {
+			details.push(`${testFile}: file not found`);
+			continue;
+		}
+		filesChecked++;
+
+		const content = readFileSync(fullPath, "utf-8");
+
+		// Check non-comment lines for assertion patterns
+		const lines = content.split("\n");
+		const assertionLines: string[] = [];
+
+		for (const line of lines) {
+			const trimmedLine = line.trim();
+			// Skip comment-only lines
+			if (
+				trimmedLine.startsWith("//") ||
+				trimmedLine.startsWith("*") ||
+				trimmedLine.startsWith("/*")
+			) {
+				continue;
+			}
+			if (assertRegex.test(trimmedLine)) {
+				assertionLines.push(trimmedLine);
+			}
+		}
+
+		if (assertionLines.length === 0) {
+			details.push(`${testFile}: no assertion statements found`);
+			continue;
+		}
+
+		// Check for placeholder assertions (all literal args)
+		const hasNonPlaceholder = assertionLines.some((line) => !isPlaceholderLine(line));
+
+		if (hasNonPlaceholder) {
+			anyFileHasNonPlaceholderAssertion = true;
+			details.push(`${testFile}: ${assertionLines.length} assertion(s) found`);
+		} else {
+			details.push(`${testFile}: only placeholder assertions found (all literal arguments)`);
+		}
+	}
+
+	if (filesChecked === 0) {
+		return {
+			name: "test-assertions",
+			passed: true,
+			detail: "No test files to check",
+		};
+	}
+
+	if (anyFileHasNonPlaceholderAssertion) {
+		return {
+			name: "test-assertions",
+			passed: true,
+			detail: details.join("; "),
+		};
+	}
+
+	return {
+		name: "test-assertions",
+		passed: false,
+		detail: details.join("; "),
+	};
+}
+
+// ─── Symbol Coverage ───────────────────────────────────────────────
+
+/**
+ * Extract runtime export names from implementation file content.
+ * Filters out type-only exports (export type, export interface).
+ *
+ * @returns Array of export symbol names (runtime only)
+ */
+function extractRuntimeExports(content: string): string[] {
+	const exports: string[] = [];
+
+	// 1. export function name(...)
+	const funcRegex = /export\s+(?:default\s+)?function\s+(\w+)/g;
+	let match: RegExpExecArray | null;
+	while ((match = funcRegex.exec(content)) !== null) {
+		exports.push(match[1]!);
+	}
+
+	// 2. export class Name { ... }
+	const classRegex = /export\s+(?:default\s+)?class\s+(\w+)/g;
+	while ((match = classRegex.exec(content)) !== null) {
+		exports.push(match[1]!);
+	}
+
+	// 3. export const/let/var name = ...
+	const varRegex = /export\s+(?:default\s+)?(?:const|let|var)\s+(\w+)/g;
+	while ((match = varRegex.exec(content)) !== null) {
+		exports.push(match[1]!);
+	}
+
+	// 4. export enum Name { ... }
+	const enumRegex = /export\s+(?:default\s+)?enum\s+(\w+)/g;
+	while ((match = enumRegex.exec(content)) !== null) {
+		exports.push(match[1]!);
+	}
+
+	// 5. export { name1, name2, ... } — named re-export block
+	const namedExportRegex = /export\s+\{\s*([^}]+)\s*\}/g;
+	while ((match = namedExportRegex.exec(content)) !== null) {
+		const names = match[1]!
+			.split(",")
+			.map((n) => n.trim())
+			.filter(Boolean);
+		for (const name of names) {
+			// Handle 'orig as alias' — use the alias for assertion matching
+			const exportName = name
+				.split(/\s+as\s+/)
+				.pop()!
+				.trim();
+			if (exportName) exports.push(exportName);
+		}
+	}
+
+	return [...new Set(exports)]; // Deduplicate
+}
+
+/**
+ * Check if a line of test code contains an assertion call.
+ */
+function lineHasAssertion(line: string): boolean {
+	return DEFAULT_ASSERT_REGEX.test(line);
+}
+
+/**
+ * Check that implementation symbols are exercised in test assertions.
+ *
+ * For each implementation file, extracts runtime exports (filtering out
+ * type-only exports like `export type` and `export interface`). Then
+ * verifies that at least one symbol from each file appears in an assertion
+ * context within the test files.
+ *
+ * Relaxed rule: at least one symbol per impl file must be covered by at
+ * least one assertion in the test suite. This accommodates mock-isolated
+ * tests where DI inverts symbol references.
+ *
+ * @param testFiles - List of test file paths (relative to worktreePath)
+ * @param implFiles - List of implementation file paths (relative to worktreePath)
+ * @param worktreePath - Path to the worktree
+ * @param _assertPatterns - Optional custom assertion function name patterns (unused, for symmetry)
+ * @returns TddCheck with pass/fail
+ */
+export function checkTestCoversSymbols(
+	testFiles: string[],
+	implFiles: string[],
+	worktreePath: string,
+	_assertPatterns?: string[],
+): TddCheck {
+	// Edge cases
+	if (testFiles.length === 0) {
+		return {
+			name: "test-covers-symbols",
+			passed: true,
+			detail: "No test files — nothing to verify",
+		};
+	}
+
+	if (implFiles.length === 0) {
+		return {
+			name: "test-covers-symbols",
+			passed: true,
+			detail: "No implementation files — nothing to verify",
+		};
+	}
+
+	// Step 1: Extract runtime exports from each impl file
+	type FileExports = { file: string; runtimeExports: string[] };
+	const allFileExports: FileExports[] = [];
+
+	for (const implFile of implFiles) {
+		const fullPath = join(worktreePath, implFile);
+		let runtimeExports: string[] = [];
+
+		try {
+			if (existsSync(fullPath)) {
+				const content = readFileSync(fullPath, "utf-8");
+				runtimeExports = extractRuntimeExports(content);
+			}
+		} catch {
+			// If reading fails, treat as no exports
+		}
+
+		allFileExports.push({ file: implFile, runtimeExports });
+	}
+
+	// Step 2: Check if all exported files have zero runtime exports
+	const filesWithExports = allFileExports.filter((fe) => fe.runtimeExports.length > 0);
+
+	if (filesWithExports.length === 0) {
+		return {
+			name: "test-covers-symbols",
+			passed: true,
+			detail: "No runtime exports found in implementation files (type-only or no exports)",
+		};
+	}
+
+	// Step 3: Read test files and check which symbols appear in assertion contexts
+	const allTestContent = testFiles
+		.map((tf) => {
+			const fullPath = join(worktreePath, tf);
+			try {
+				if (existsSync(fullPath)) return readFileSync(fullPath, "utf-8");
+			} catch {
+				// Ignore read errors
+			}
+			return "";
+		})
+		.filter(Boolean)
+		.join("\n");
+
+	if (!allTestContent) {
+		return {
+			name: "test-covers-symbols",
+			passed: false,
+			detail: "Test files could not be read",
+		};
+	}
+
+	// Step 4: For each file, check if at least one of its runtime exports
+	// appears in an assertion context within any test file
+	const uncoveredFiles: string[] = [];
+
+	for (const fe of filesWithExports) {
+		const isCovered = fe.runtimeExports.some((symbol) => {
+			// Check each line that contains an assertion pattern
+			const testLines = allTestContent.split("\n");
+			return testLines.some((line) => {
+				if (!lineHasAssertion(line)) return false;
+				// The symbol must appear as a word boundary match on the same line
+				// as an assertion call (handles destructured imports, direct references)
+				const symbolRegex = new RegExp(`\\b${symbol.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
+				return symbolRegex.test(line);
+			});
+		});
+
+		if (!isCovered) {
+			uncoveredFiles.push(fe.file);
+		}
+	}
+
+	if (uncoveredFiles.length > 0) {
+		return {
+			name: "test-covers-symbols",
+			passed: false,
+			detail: `Uncovered implementation files: ${uncoveredFiles.join(", ")}. No runtime exports from these files appear in test assertions.`,
+		};
+	}
+
+	return {
+		name: "test-covers-symbols",
+		passed: true,
+		detail: `All ${filesWithExports.length} implementation file(s) with runtime exports have symbols covered in test assertions`,
+	};
+}
+
 // ─── Main Orchestration ────────────────────────────────────────────
 
 /**
@@ -169,20 +524,21 @@ export function buildTddGateResult(checks: TddCheck[]): TddGateResult {
  * 2. Classify changed files into test files and implementation files
  * 3. Run TDD checks:
  *    a. "tests-written" — at least one test file in diff
- *    b. "tests-reference-implementation" — test files reference new implementation code
+ *    b. "test-assertions" — test files contain assertion statements
+ *    c. "test-covers-symbols" — implementation symbols appear in test assertions
  * 4. Return aggregate result
  *
  * @param exec - Exec function (from pi.exec or mock)
  * @param worktreePath - Path to the worktree
  * @param defaultBranch - Default branch name (e.g. "main")
- * @param testPatterns - Optional custom test file patterns (default: standard patterns)
+ * @param assertPatterns - Optional custom assertion function names (overrides defaults)
  * @returns TddGateResult
  */
 export async function runTddGate(
 	exec: ExecFn,
 	worktreePath: string,
 	defaultBranch: string,
-	_testPatterns?: string[],
+	assertPatterns?: string[],
 ): Promise<TddGateResult> {
 	const checks: TddCheck[] = [];
 	let changedFiles: string[] = [];
@@ -242,126 +598,53 @@ export async function runTddGate(
 		});
 	}
 
-	// Step 3c: Check "tests-reference-implementation"
+	// Step 3b: Check "test-assertions"
+	if (testFiles.length > 0) {
+		try {
+			const assertionsResult = checkTestAssertions(testFiles, worktreePath, assertPatterns);
+			checks.push(assertionsResult);
+		} catch (err: unknown) {
+			const msg = err instanceof Error ? err.message : String(err);
+			checks.push({
+				name: "test-assertions",
+				passed: true,
+				detail: `Could not verify test assertions (non-blocking): ${msg}`,
+			});
+		}
+	}
+	// If no test files, we skip test-assertions (already reported by tests-written)
+
+	// Step 3c: Check "test-covers-symbols"
 	if (testFiles.length === 0) {
 		checks.push({
-			name: "tests-reference-implementation",
+			name: "test-covers-symbols",
 			passed: true,
 			detail: "No test files — nothing to verify",
 		});
 	} else if (implFiles.length === 0) {
 		checks.push({
-			name: "tests-reference-implementation",
+			name: "test-covers-symbols",
 			passed: true,
 			detail: "No implementation files — nothing to verify",
 		});
 	} else {
 		try {
-			const refResult = await checkTestsReferenceImpl(exec, worktreePath, testFiles, implFiles);
-			checks.push(refResult);
+			const coversResult = checkTestCoversSymbols(
+				testFiles,
+				implFiles,
+				worktreePath,
+				assertPatterns,
+			);
+			checks.push(coversResult);
 		} catch (err: unknown) {
 			const msg = err instanceof Error ? err.message : String(err);
 			checks.push({
-				name: "tests-reference-implementation",
+				name: "test-covers-symbols",
 				passed: true,
-				detail: `Could not verify test-implementation references (non-blocking): ${msg}`,
+				detail: `Could not verify symbol coverage (non-blocking): ${msg}`,
 			});
 		}
 	}
 
 	return buildTddGateResult(checks);
-}
-
-/**
- * Check that test files reference implementation files.
- *
- * Reads test file contents and checks for imports/requires of implementation files.
- * This is a lightweight check — it looks for file names and export names
- * from implementation files appearing in test files.
- */
-async function checkTestsReferenceImpl(
-	exec: ExecFn,
-	worktreePath: string,
-	testFiles: string[],
-	implFiles: string[],
-): Promise<TddCheck> {
-	// Extract potential export names from implementation files
-	const implKeywords = new Set<string>();
-	for (const implFile of implFiles) {
-		// Add the file's basename without extension
-		const base = basename(implFile);
-		const dotIdx = base.lastIndexOf(".");
-		const name = dotIdx > 0 ? base.slice(0, dotIdx) : base;
-		implKeywords.add(name);
-		implKeywords.add(`./${name}`);
-		implKeywords.add(`../${name}`);
-
-		// Try to read implementation file and extract export names
-		try {
-			const fullPath = join(worktreePath, implFile);
-			if (existsSync(fullPath)) {
-				const content = readFileSync(fullPath, "utf-8");
-				// Extract export function/class/const names
-				const exportRegex =
-					/export\s+(?:default\s+)?(?:function|class|const|let|var|interface|type|enum)\s+(\w+)/g;
-				let match: RegExpExecArray | null;
-				while ((match = exportRegex.exec(content)) !== null) {
-					implKeywords.add(match[1]!);
-				}
-				// Also extract named exports: export { Foo, Bar }
-				const namedExportRegex = /export\s+\{\s*([^}]+)\s*\}/g;
-				while ((match = namedExportRegex.exec(content)) !== null) {
-					const names = match[1]!.split(",").map((n) =>
-						n
-							.trim()
-							.split(/\s+as\s+/)[0]!
-							.trim(),
-					);
-					for (const n of names) {
-						if (n) implKeywords.add(n);
-					}
-				}
-			}
-		} catch {
-			// If reading fails, we still have basenames
-		}
-	}
-
-	// Check each test file for references to implementation
-	let anyReferenceFound = false;
-	for (const testFile of testFiles) {
-		try {
-			const fullPath = join(worktreePath, testFile);
-			if (!existsSync(fullPath)) continue;
-
-			const content = readFileSync(fullPath, "utf-8");
-
-			// Check if any implementation keyword appears in the test
-			for (const keyword of implKeywords) {
-				if (keyword.length < 2) continue; // Skip very short keywords
-				if (content.includes(keyword)) {
-					anyReferenceFound = true;
-					break;
-				}
-			}
-
-			if (anyReferenceFound) break;
-		} catch {
-			continue;
-		}
-	}
-
-	if (anyReferenceFound) {
-		return {
-			name: "tests-reference-implementation",
-			passed: true,
-			detail: "Test files reference implementation code",
-		};
-	}
-
-	return {
-		name: "tests-reference-implementation",
-		passed: false,
-		detail: "Test files do not reference any implementation code",
-	};
 }

--- a/.pi/extensions/supervisor/config/types.ts
+++ b/.pi/extensions/supervisor/config/types.ts
@@ -31,6 +31,10 @@ export interface SupervisorConfig {
 	commentSummaryThreshold?: number;
 	/** Max characters per comment body before truncation with overflow note. Default: 2000. */
 	maxCommentChars?: number;
+	/** Custom assertion function names for TDD gate.
+	 *  When set, checkTestAssertions and checkTestCoversSymbols will also
+	 *  recognize these function names as valid assertion patterns. */
+	assertFunctionNames?: string[];
 }
 
 export interface AgentFrontmatter {

--- a/.pi/extensions/supervisor/pipeline/audit.ts
+++ b/.pi/extensions/supervisor/pipeline/audit.ts
@@ -160,7 +160,12 @@ export async function runTscAndLspAudit(
 		ctx.ui.setStatus("supervisor", "Running TDD gate...");
 		getDebugLogger().info("pipeline-audit", "Running TDD gate", { worktreePath });
 		try {
-			const tddResult = await runTddGate(execFn, worktreePath, config.defaultBranch || "main");
+			const tddResult = await runTddGate(
+				execFn,
+				worktreePath,
+				config.defaultBranch || "main",
+				config.assertFunctionNames,
+			);
 
 			if (tddResult.status === "failed") {
 				const failedCheckNames = tddResult.checks

--- a/.pi/extensions/supervisor/test/tdd-gate.test.mts
+++ b/.pi/extensions/supervisor/test/tdd-gate.test.mts
@@ -20,6 +20,8 @@ import {
 	classifyChangedFiles,
 	buildTddGateResult,
 	runTddGate,
+	checkTestAssertions,
+	checkTestCoversSymbols,
 } from "../checks/tdd-gate.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -53,7 +55,7 @@ describe("TddGateResult interface", () => {
 			status: "failed",
 			checks: [
 				{ name: "tests-written", passed: false, detail: "No test files found in diff" },
-				{ name: "tests-reference-implementation", passed: true },
+				{ name: "test-covers-symbols", passed: true },
 			],
 			rejectionReason: "Tests not written",
 		};
@@ -62,7 +64,7 @@ describe("TddGateResult interface", () => {
 		assert.equal(result.checks[0]!.name, "tests-written");
 		assert.equal(result.checks[0]!.passed, false);
 		assert.equal(result.checks[0]!.detail, "No test files found in diff");
-		assert.equal(result.checks[1]!.name, "tests-reference-implementation");
+		assert.equal(result.checks[1]!.name, "test-covers-symbols");
 		assert.equal(result.checks[1]!.passed, true);
 	});
 
@@ -83,23 +85,25 @@ describe("TddGateResult interface", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("TddCheck interface", () => {
-	it("name field accepts all literal string values", () => {
+	it("name field accepts all new and legacy literal string values", () => {
 		const written: TddCheck = { name: "tests-written", passed: true };
-		const reference: TddCheck = { name: "tests-reference-implementation", passed: true };
+		const assertions: TddCheck = { name: "test-assertions", passed: true };
+		const symbols: TddCheck = { name: "test-covers-symbols", passed: true };
 
 		assert.equal(written.name, "tests-written");
-		assert.equal(reference.name, "tests-reference-implementation");
+		assert.equal(assertions.name, "test-assertions");
+		assert.equal(symbols.name, "test-covers-symbols");
 	});
 
 	it("detail field is optional", () => {
 		const withDetail: TddCheck = {
-			name: "tests-written",
+			name: "test-assertions",
 			passed: false,
-			detail: "No test files found",
+			detail: "No assertion statements found",
 		};
 		const without: TddCheck = { name: "tests-written", passed: true };
 
-		assert.equal(withDetail.detail, "No test files found");
+		assert.equal(withDetail.detail, "No assertion statements found");
 		assert.equal(without.detail, undefined);
 	});
 });
@@ -230,33 +234,34 @@ describe("buildTddGateResult()", () => {
 	it("returns passed when all checks pass", () => {
 		const checks: TddCheck[] = [
 			{ name: "tests-written", passed: true },
-			{ name: "tests-reference-implementation", passed: true },
+			{ name: "test-assertions", passed: true },
+			{ name: "test-covers-symbols", passed: true },
 		];
 		const result = buildTddGateResult(checks);
 		assert.equal(result.status, "passed");
-		assert.equal(result.checks.length, 2);
+		assert.equal(result.checks.length, 3);
 		assert.equal(result.rejectionReason, undefined);
 	});
 
 	it("returns failed when any check fails", () => {
 		const checks: TddCheck[] = [
 			{ name: "tests-written", passed: true },
-			{ name: "tests-reference-implementation", passed: false, detail: "No imports from impl" },
+			{ name: "test-covers-symbols", passed: false, detail: "No symbols covered" },
 		];
 		const result = buildTddGateResult(checks);
 		assert.equal(result.status, "failed");
-		assert.ok(result.rejectionReason!.includes("tests-reference-implementation"));
+		assert.ok(result.rejectionReason!.includes("test-covers-symbols"));
 	});
 
 	it("returns failed with multiple failing check names in reason", () => {
 		const checks: TddCheck[] = [
 			{ name: "tests-written", passed: false, detail: "No test files found" },
-			{ name: "tests-reference-implementation", passed: false, detail: "No imports from impl" },
+			{ name: "test-assertions", passed: false, detail: "No assertions found" },
 		];
 		const result = buildTddGateResult(checks);
 		assert.equal(result.status, "failed");
 		assert.ok(result.rejectionReason!.includes("tests-written"));
-		assert.ok(result.rejectionReason!.includes("tests-reference-implementation"));
+		assert.ok(result.rejectionReason!.includes("test-assertions"));
 	});
 
 	it("returns error for empty checks array", () => {
@@ -264,6 +269,389 @@ describe("buildTddGateResult()", () => {
 		assert.equal(result.status, "error");
 		assert.equal(result.checks.length, 0);
 		assert.equal(result.rejectionReason, "No checks run");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Domain: checkTestAssertions
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("checkTestAssertions()", () => {
+	function createTempFile(dir: string, relPath: string, content: string): string {
+		const fullPath = join(dir, relPath);
+		mkdirSync(dirname(fullPath), { recursive: true });
+		writeFileSync(fullPath, content);
+		return fullPath;
+	}
+
+	it("empty test file (zero content) → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-empty");
+		createTempFile(dir, "test.test.ts", "");
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+		assert.match(result.detail!, /no assertion statements found/i);
+	});
+
+	it("test file with only imports and describe block, no assertions → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-only-import");
+		createTempFile(
+			dir,
+			"test.test.ts",
+			`import { foo } from "./foo";\ndescribe("foo", () => {\n  it("works", () => {});\n});`,
+		);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+	});
+
+	it("test file with assert.equal(a, b) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-eq");
+		createTempFile(dir, "test.test.ts", `import assert from "node:assert";\nassert.equal(a, b);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with expect(fn()).toBe(42) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-expect");
+		createTempFile(dir, "test.test.ts", `expect(fn()).toBe(42);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with t.is(result, expected) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-tap");
+		createTempFile(dir, "test.test.ts", `t.is(result, expected);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with ok(condition) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-ok");
+		createTempFile(dir, "test.test.ts", `ok(condition);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with deepEqual(actual, expected) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-deep");
+		createTempFile(dir, "test.test.ts", `deepEqual(actual, expected);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with assert.ok(value) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-ok-method");
+		createTempFile(dir, "test.test.ts", `assert.ok(value);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with only comment containing assert text → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-assert-comment");
+		createTempFile(
+			dir,
+			"test.test.ts",
+			`// assert.equal(a, b) but it's just a comment\nok = true;`,
+		);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+	});
+
+	it("test file with expect(true).toBe(true) (placeholder) → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-placeholder-expect");
+		createTempFile(dir, "test.test.ts", `expect(true).toBe(true);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+		assert.match(result.detail!, /placeholder|trivial|literal/i);
+	});
+
+	it("test file with assert.equal(3, 3) (placeholder) → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-placeholder-eq");
+		createTempFile(dir, "test.test.ts", `assert.equal(3, 3);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+	});
+
+	it("test file with assert.ok(true) (placeholder) → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-placeholder-ok");
+		createTempFile(dir, "test.test.ts", `assert.ok(true);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+	});
+
+	it("test file with assert.equal(calculateTotal(items), 42) → passes (non-literal first arg)", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-nonliteral-arg");
+		createTempFile(dir, "test.test.ts", `assert.equal(calculateTotal(items), 42);`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file with assert.ok(hasPermission(user)) → passes (non-literal arg)", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-nonliteral-fn");
+		createTempFile(dir, "test.test.ts", `assert.ok(hasPermission(user));`);
+		const result = checkTestAssertions(["test.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("test file that doesn't exist → passes with detail mentioning file not found", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-notfound");
+		mkdirSync(dir, { recursive: true });
+		const result = checkTestAssertions(["nonexistent.test.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+		assert.match(result.detail!, /not found|no test files/i);
+	});
+
+	it("custom assertFunctionNames list includes ['verify'], test uses verify.strictEqual(a, b) → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-custom-assert");
+		createTempFile(dir, "test.test.ts", `verify.strictEqual(a, b);`);
+		const result = checkTestAssertions(["test.test.ts"], dir, ["verify"]);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("empty assertFunctionNames list falls back to default patterns", () => {
+		const dir = join(process.cwd(), "ignore/tdd-test-empty-custom");
+		createTempFile(dir, "test.test.ts", `expect(a).toBe(b);`);
+		const result = checkTestAssertions(["test.test.ts"], dir, []);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Domain: checkTestCoversSymbols
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("checkTestCoversSymbols()", () => {
+	function createTempFile(dir: string, relPath: string, content: string): string {
+		const fullPath = join(dir, relPath);
+		mkdirSync(dirname(fullPath), { recursive: true });
+		writeFileSync(fullPath, content);
+		return fullPath;
+	}
+
+	it("impl exports function, test asserts on it → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-fn");
+		createTempFile(
+			dir,
+			"src/calc.ts",
+			"export function calculateTotal(items: number[]): number { return 42; }",
+		);
+		createTempFile(
+			dir,
+			"src/calc.test.ts",
+			`import { calculateTotal } from "./calc";\nassert.equal(calculateTotal([1,2]), 3);`,
+		);
+		const result = checkTestCoversSymbols(["src/calc.test.ts"], ["src/calc.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("impl exports const, test asserts on it → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-const");
+		createTempFile(dir, "src/size.ts", "export const MAX_SIZE = 100;");
+		createTempFile(
+			dir,
+			"src/size.test.ts",
+			`import { MAX_SIZE } from "./size";\nassert.equal(MAX_SIZE, 100);`,
+		);
+		const result = checkTestCoversSymbols(["src/size.test.ts"], ["src/size.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("impl exports class, test asserts with it → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-class");
+		createTempFile(
+			dir,
+			"src/calc.ts",
+			"export class Calculator { add(a: number, b: number) { return a + b; } }",
+		);
+		createTempFile(
+			dir,
+			"src/calc.test.ts",
+			`import { Calculator } from "./calc";\nconst calc = new Calculator();\nassert.ok(calc instanceof Calculator);`,
+		);
+		const result = checkTestCoversSymbols(["src/calc.test.ts"], ["src/calc.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("impl has only type-only exports → passes with detail about skipped types", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-typeonly");
+		createTempFile(
+			dir,
+			"src/types.ts",
+			"export type Options = { debug: boolean };\nexport interface Config { host: string; }",
+		);
+		createTempFile(
+			dir,
+			"src/types.test.ts",
+			`import type { Options, Config } from "./types";\nconst opts: Options = { debug: true };`,
+		);
+		const result = checkTestCoversSymbols(["src/types.test.ts"], ["src/types.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+		assert.match(result.detail!, /type-only|no runtime exports|skipped/i);
+	});
+
+	it("impl has zero exports → passes with detail", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-zero-exports");
+		createTempFile(dir, "src/util.ts", "function internalHelper() { return 42; }");
+		createTempFile(
+			dir,
+			"src/util.test.ts",
+			"import assert from 'node:assert';\nassert.equal(true, true);",
+		);
+		const result = checkTestCoversSymbols(["src/util.test.ts"], ["src/util.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+		assert.match(result.detail!, /no exports|no runtime exports/i);
+	});
+
+	it("impl exports function but test only imports without asserting → fails", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-no-assert");
+		createTempFile(
+			dir,
+			"src/calc.ts",
+			"export function calculateTotal(items: number[]): number { return 42; }",
+		);
+		createTempFile(
+			dir,
+			"src/calc.test.ts",
+			`import { calculateTotal } from "./calc";\ndescribe("calc", () => {\n  it("exists", () => {});\n});`,
+		);
+		const result = checkTestCoversSymbols(["src/calc.test.ts"], ["src/calc.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+	});
+
+	it("mock-isolated test with one covered symbol per file → passes (relaxed rule)", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-mock");
+		createTempFile(
+			dir,
+			"src/user-service.ts",
+			"export class UserService { getUser(id: string) { return null; } }\nexport class EmailService { send(email: string) {} }",
+		);
+		createTempFile(
+			dir,
+			"src/user-service.test.ts",
+			`import { UserService } from "./user-service";\nconst svc = new UserService();\nassert.ok(svc instanceof UserService);`,
+		);
+		const result = checkTestCoversSymbols(
+			["src/user-service.test.ts"],
+			["src/user-service.ts"],
+			dir,
+		);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("export { helper, util } named re-export block → detected", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-named-rexport");
+		createTempFile(
+			dir,
+			"src/helpers.ts",
+			"export function helper() { return 1; }\nexport function util() { return 2; }",
+		);
+		createTempFile(dir, "src/index.ts", "export { helper, util } from './helpers';");
+		createTempFile(
+			dir,
+			"src/index.test.ts",
+			`import { helper } from "./index";\nassert.ok(helper());`,
+		);
+		const result = checkTestCoversSymbols(
+			["src/index.test.ts"],
+			["src/index.ts", "src/helpers.ts"],
+			dir,
+		);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("no test files provided → passes with detail", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-no-tests");
+		mkdirSync(dir, { recursive: true });
+		const result = checkTestCoversSymbols([], ["src/foo.ts"], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+		assert.match(result.detail!, /no test files/i);
+	});
+
+	it("no impl files provided → passes with detail", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-no-impl");
+		mkdirSync(dir, { recursive: true });
+		const result = checkTestCoversSymbols(["src/foo.test.ts"], [], dir);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+		assert.match(result.detail!, /no implementation files/i);
+	});
+
+	it("two impl files, both covered → passes", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-multi-file");
+		createTempFile(
+			dir,
+			"src/calc.ts",
+			"export function calculateTotal(items: number[]): number { return 42; }",
+		);
+		createTempFile(
+			dir,
+			"src/format.ts",
+			"export function formatCurrency(n: number): string { return '$' + n; }",
+		);
+		createTempFile(
+			dir,
+			"src/test.test.ts",
+			`import { calculateTotal } from "./calc";\nimport { formatCurrency } from "./format";\nassert.equal(calculateTotal([1,2]), 3);\nassert.equal(formatCurrency(5), '$5');`,
+		);
+		const result = checkTestCoversSymbols(
+			["src/test.test.ts"],
+			["src/calc.ts", "src/format.ts"],
+			dir,
+		);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, true);
+	});
+
+	it("two impl files, one uncovered → fails with detail naming uncovered file", () => {
+		const dir = join(process.cwd(), "ignore/tdd-covers-one-uncovered");
+		createTempFile(
+			dir,
+			"src/calc.ts",
+			"export function calculateTotal(items: number[]): number { return 42; }",
+		);
+		createTempFile(
+			dir,
+			"src/logger.ts",
+			"export function log(message: string): void { console.log(message); }",
+		);
+		createTempFile(
+			dir,
+			"src/test.test.ts",
+			`import { calculateTotal } from "./calc";\nassert.equal(calculateTotal([1,2]), 3);`,
+		);
+		const result = checkTestCoversSymbols(
+			["src/test.test.ts"],
+			["src/calc.ts", "src/logger.ts"],
+			dir,
+		);
+		rmSync(dir, { recursive: true, force: true });
+		assert.equal(result.passed, false);
+		assert.match(result.detail!, /logger/i);
 	});
 });
 
@@ -280,7 +668,6 @@ interface ExecCall {
 /**
  * Create a mock exec function that returns pre-configured results.
  */
-
 function createMockExec(
 	results: Array<{ code: number; stdout: string; stderr: string }>,
 	calls?: ExecCall[],
@@ -346,7 +733,7 @@ describe("runTddGate()", () => {
 		);
 
 		const result = await runTddGate(mockExec, "/repo/worktree", "main");
-		assert.equal(result.checks.length, 2);
+		assert.equal(result.checks.length, 3);
 		// tests-written should pass because we have a test file
 		const writtenCheck = result.checks.find((c) => c.name === "tests-written");
 		assert.ok(writtenCheck, "tests-written check should exist");
@@ -382,28 +769,40 @@ describe("runTddGate()", () => {
 		assert.equal(writtenCheck!.passed, true);
 	});
 
-	it("check 'tests-reference-implementation' passes when test files reference new code", async () => {
-		const calls: ExecCall[] = [];
-		const mockExec: ExecFn = async (cmd, args, opts) => {
-			calls.push({ cmd, args: args || [], opts });
-			if (cmd === "git" && args[0] === "diff") {
-				return { code: 0, stdout: "src/impl.ts\nsrc/impl.test.ts", stderr: "" };
-			}
-			if (cmd === "git" && args[0] === "checkout") {
-				return { code: 0, stdout: "", stderr: "" };
-			}
-			// Test runner detection: find command returns nothing (no test files found via find)
-			if (cmd === "find") {
-				return { code: 0, stdout: "", stderr: "" };
-			}
-			// Test runner detection: which command fails
-			if (cmd === "which") {
-				return { code: 1, stdout: "", stderr: "not found" };
-			}
-			return { code: 0, stdout: "", stderr: "" };
-		};
+	it("all 3 checks present in correct order when test+impl files present", async () => {
+		const mockExec = createMockExec([
+			{ code: 0, stdout: "src/impl.ts\nsrc/impl.test.ts", stderr: "" },
+		]);
 
-		const testDir = join(process.cwd(), "ignore/tdd-gate-ref-test");
+		const result = await runTddGate(mockExec, "/repo/worktree", "main");
+		assert.equal(result.checks.length, 3);
+		assert.equal(result.checks[0]!.name, "tests-written");
+		assert.equal(result.checks[1]!.name, "test-assertions");
+		assert.equal(result.checks[2]!.name, "test-covers-symbols");
+	});
+
+	it("when no test files in diff, test-assertions is skipped, test-covers-symbols passes with detail", async () => {
+		const mockExec = createMockExec([{ code: 0, stdout: "src/impl.ts", stderr: "" }]);
+
+		const result = await runTddGate(mockExec, "/repo/worktree", "main");
+		const assertionsCheck = result.checks.find((c) => c.name === "test-assertions");
+		const coversCheck = result.checks.find((c) => c.name === "test-covers-symbols");
+		assert.equal(assertionsCheck, undefined); // Skipped when no test files
+		assert.ok(coversCheck!.passed);
+		assert.match(coversCheck!.detail!, /no test files/i);
+	});
+
+	it("when no impl files in diff, test-covers-symbols passes with detail", async () => {
+		const mockExec = createMockExec([{ code: 0, stdout: "src/foo.test.ts", stderr: "" }]);
+
+		const result = await runTddGate(mockExec, "/repo/worktree", "main");
+		const coversCheck = result.checks.find((c) => c.name === "test-covers-symbols");
+		assert.ok(coversCheck!.passed);
+		assert.match(coversCheck!.detail!, /no implementation files/i);
+	});
+
+	it("check 'test-covers-symbols' passes when test files cover new code", async () => {
+		const testDir = join(process.cwd(), "ignore/tdd-gate-covers-pass-test");
 		const implFile = join(testDir, "src/impl.ts");
 		const testFile = join(testDir, "src/impl.test.ts");
 		mkdirSync(dirname(implFile), { recursive: true });
@@ -413,24 +812,18 @@ describe("runTddGate()", () => {
 			"import { newFeature } from './impl'; describe('newFeature', () => { it('works', () => { assert.equal(newFeature(), 42); }); });",
 		);
 
-		const result = await runTddGate(mockExec, testDir, "main");
+		const mockExec: ExecFn = async (cmd, args) => {
+			if (cmd === "git" && args[0] === "diff") {
+				return { code: 0, stdout: "src/impl.ts\nsrc/impl.test.ts", stderr: "" };
+			}
+			return { code: 0, stdout: "", stderr: "" };
+		};
 
-		// Cleanup
+		const result = await runTddGate(mockExec, testDir, "main");
 		rmSync(testDir, { recursive: true, force: true });
 
-		const referenceCheck = result.checks.find((c) => c.name === "tests-reference-implementation");
-		assert.equal(referenceCheck!.passed, true);
-	});
-
-	it("check 'tests-reference-implementation' passes when no test files exist", async () => {
-		const mockExec = createMockExec([{ code: 0, stdout: "src/impl.ts", stderr: "" }]);
-
-		const result = await runTddGate(mockExec, "/repo/worktree", "main");
-		const writtenCheck = result.checks.find((c) => c.name === "tests-written");
-		assert.equal(writtenCheck!.passed, false);
-		const referenceCheck = result.checks.find((c) => c.name === "tests-reference-implementation");
-		assert.equal(referenceCheck!.passed, true);
-		assert.ok(referenceCheck!.detail!.includes("No test files"));
+		const coversCheck = result.checks.find((c) => c.name === "test-covers-symbols");
+		assert.equal(coversCheck!.passed, true);
 	});
 
 	it("returns passed when only test files changed (no impl to verify)", async () => {
@@ -440,8 +833,6 @@ describe("runTddGate()", () => {
 
 		const result = await runTddGate(mockExec, "/repo/worktree", "main");
 
-		// With only test files and no impl, tests-written passes,
-		// tests-reference-implementation is skipped (no impl)
 		assert.equal(result.status, "passed");
 	});
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #718

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 46s | 54.5K | 64 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 20s | 51.5K | 19 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 49s | 38.7K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 11m 30s | 128.8K | 96 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 35s | 66.0K | 21 | deepseek-v4-flash |

**Total:** 5 agents · 21m 1s · 339.4K tokens · 215 tool calls
**Issue:** https://github.com/SchneiderDaniel/agentcastle/issues/718
Closes #718