### PR TITLE
feat(#788): Supervisor: wrap TSC checkpoint in try/catch to prevent pipeline crash on type-check error

### DIFF
--- a/.pi/extensions/supervisor/pipeline/audit.ts
+++ b/.pi/extensions/supervisor/pipeline/audit.ts
@@ -9,7 +9,11 @@ import { resolve as resolvePath } from "node:path";
 import { getDebugLogger } from "../config/debug.ts";
 import { generateBranchName } from "../agent/task.ts";
 import type { ErrorCollector } from "./error-collector.ts";
-import { determineTscCheckpointDecision, getRunTscCheckpoint } from "../checks/tsc-decisions.ts";
+import {
+	determineTscCheckpointDecision,
+	getRunTscCheckpoint,
+	type TscCheckpointResult,
+} from "../checks/tsc-decisions.ts";
 import { determineLspPreAuditDecision, getRunPreAudit } from "../checks/lsp-decisions.ts";
 import { pollCiChecks } from "../checks/ci-gating.ts";
 import { runDuplicateCheck } from "../checks/duplicate-code.ts";
@@ -305,7 +309,15 @@ export async function runTscAndLspAudit(
 		if (runTscCheckpointFn) {
 			ctx.ui.setStatus("supervisor", "Running TSC checkpoint...");
 			getDebugLogger().info("pipeline-audit", "Running TSC checkpoint", { worktreePath });
-			const tscResult = await runTscCheckpointFn(worktreePath);
+			let tscResult: TscCheckpointResult | null = null;
+			try {
+				tscResult = await runTscCheckpointFn(worktreePath);
+			} catch (tscErr: unknown) {
+				const tscMsg = tscErr instanceof Error ? tscErr.message : String(tscErr);
+				ctx.ui.notify(`TSC checkpoint threw: ${tscMsg}. Proceeding to audit.`, "warning");
+				getDebugLogger().warn("pipeline-audit", "TSC checkpoint threw", { error: tscMsg });
+				collector?.push("pipeline-audit", "warn", `TSC checkpoint threw: ${tscMsg}`);
+			}
 			const tscDecision = determineTscCheckpointDecision(tscResult, "Audit");
 
 			getDebugLogger().info("pipeline-audit", "TSC result", {

--- a/.pi/extensions/supervisor/test/pipeline-audit.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline-audit.test.mts
@@ -293,3 +293,111 @@ describe("pipeline-audit.ts — non-standard worktreeBase config (Phase 6)", () 
 		assert.ok(auditSrc.includes(auditPathPattern), "pipeline-audit.ts uses resolvePath");
 	});
 });
+
+// ===========================================================================
+// Phase 7: TSC checkpoint try/catch error boundary (Issue #788)
+// ===========================================================================
+
+describe("pipeline-audit.ts — TSC checkpoint try/catch error boundary (Phase 7)", () => {
+	it("tscResult declared with let outside try block (visible after catch)", () => {
+		const src = readAuditSource();
+		// Verify let-declared tscResult before try block, not const inside it
+		const letDecl = "let tscResult: TscCheckpointResult | null = null;";
+		assert.ok(src.includes(letDecl), "tscResult should be declared with let outside try block");
+		// Verify it appears before the try block in Step 5
+		const step5Idx = src.indexOf("// Step 5: TSC checkpoint (Tier 2)");
+		const tryIdx = src.indexOf("try {", step5Idx);
+		const declIdx = src.indexOf(letDecl, step5Idx);
+		assert.ok(
+			declIdx > step5Idx && declIdx < tryIdx,
+			"let tscResult should appear between Step 5 comment and try block",
+		);
+	});
+
+	it("runTscCheckpointFn call wrapped in try block", () => {
+		const src = readAuditSource();
+		const callIdx = src.indexOf("runTscCheckpointFn(worktreePath)");
+		assert.ok(callIdx >= 0, "runTscCheckpointFn(worktreePath) call exists");
+		// try block should contain the call
+		const beforeCall = src.substring(callIdx - 30, callIdx);
+		assert.ok(beforeCall.includes("try {"), "call should be inside try block");
+	});
+
+	it("catch block calls ctx.ui.notify with warning level", () => {
+		const src = readAuditSource();
+		const catchBlock = src.substring(
+			src.indexOf("catch (tscErr: unknown)"),
+			src.indexOf("catch (tscErr: unknown)") + 400,
+		);
+		assert.ok(
+			catchBlock.includes("ctx.ui.notify(`TSC checkpoint threw:"),
+			"catch block should call ctx.ui.notify with TSC checkpoint message",
+		);
+		assert.ok(
+			catchBlock.includes(', "warning")'),
+			"ctx.ui.notify should be called with warning level",
+		);
+	});
+
+	it("catch block calls getDebugLogger().warn with pipeline-audit module", () => {
+		const src = readAuditSource();
+		const catchBlock = src.substring(
+			src.indexOf("catch (tscErr: unknown)"),
+			src.indexOf("catch (tscErr: unknown)") + 400,
+		);
+		assert.ok(
+			catchBlock.includes('getDebugLogger().warn("pipeline-audit"'),
+			"catch block should call getDebugLogger().warn with pipeline-audit module",
+		);
+	});
+
+	it("catch block calls collector?.push with pipeline-audit module and warn level", () => {
+		const src = readAuditSource();
+		const catchBlock = src.substring(
+			src.indexOf("catch (tscErr: unknown)"),
+			src.indexOf("catch (tscErr: unknown)") + 500,
+		);
+		const pattern1 = 'collector?.push("pipeline-audit", "warn"';
+		const pattern2 = 'collector.push("pipeline-audit", "warn"';
+		assert.ok(
+			catchBlock.includes(pattern1) || catchBlock.includes(pattern2),
+			"catch block should call collector?.push with pipeline-audit module and warn level",
+		);
+	});
+
+	it("determineTscCheckpointDecision call is outside the catch block (no early return)", () => {
+		const src = readAuditSource();
+		const catchIdx = src.indexOf("catch (tscErr: unknown)");
+		assert.ok(catchIdx >= 0, "catch (tscErr: unknown) block exists");
+		const decisionIdx = src.indexOf(
+			'const tscDecision = determineTscCheckpointDecision(tscResult, "Audit");',
+		);
+		assert.ok(decisionIdx >= 0, "determineTscCheckpointDecision call exists");
+		// Decision must come after catch block
+		assert.ok(
+			decisionIdx > catchIdx,
+			"determineTscCheckpointDecision should be after the catch block",
+		);
+	});
+
+	it("determineTscCheckpointDecision and if/else are not wrapped inside try/catch", () => {
+		const src = readAuditSource();
+		const decisionLine = 'const tscDecision = determineTscCheckpointDecision(tscResult, "Audit");';
+		const decisionIdx = src.indexOf(decisionLine);
+		assert.ok(decisionIdx >= 0, "determineTscCheckpointDecision call exists");
+		// Find the catch block closing brace before the decision line
+		const beforeDecision = src.substring(0, decisionIdx);
+		const lastCatchIdx = beforeDecision.lastIndexOf("catch (tscErr: unknown)");
+		assert.ok(lastCatchIdx >= 0, "catch block found before decision call");
+		// Text between catch block end and decision should not contain 'try {'
+		const afterCatch = beforeDecision.substring(lastCatchIdx);
+		// Find the catch block's closing '}'
+		const catchCloseIdx = afterCatch.lastIndexOf("}");
+		assert.ok(catchCloseIdx >= 0, "catch block has closing brace");
+		const between = afterCatch.substring(catchCloseIdx, afterCatch.length);
+		assert.ok(
+			!between.includes("try {"),
+			"determineTscCheckpointDecision should not be inside a try block",
+		);
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #788

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 41s | 66.7K | 41 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 1s | 22.5K | 13 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 35s | 19.2K | 10 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 10s | 33.9K | 15 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 10s | 24.1K | 22 | deepseek-v4-flash |

**Total:** 5 agents · 8m 37s · 166.3K tokens · 101 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/788
Closes #788