### PR TITLE
feat(#794): piignore:  entry blocks agent access to pi extension packages (false positive)

### DIFF
--- a/.piignore
+++ b/.piignore
@@ -24,7 +24,6 @@ credentials.*
 # --------------------------------------------------------------------
 # Pi agent sessions & internals (huge, irrelevant for coding)
 # --------------------------------------------------------------------
-.pi/npm/
 .pi/chromium-deps/
 .pi/crawl4ai-venv/
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #794

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 57s | 50.0K | 38 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 18s | 25.1K | 29 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 33s | 12.8K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 45s | 23.5K | 7 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 3s | 27.6K | 17 | deepseek-v4-flash |

**Total:** 5 agents · 6m 35s · 139.0K tokens · 105 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/794
Closes #794