### PR TITLE
feat(#780): ICA: tool_call interception ordering — ToolCallRouter

### DIFF
--- a/.pi/extensions/supervisor/agent/runner.ts
+++ b/.pi/extensions/supervisor/agent/runner.ts
@@ -178,6 +178,7 @@ export async function runAgentSubprocess(
 		"--tools",
 		tools,
 		...extFlags,
+		"--no-extensions",
 		"--no-skills",
 		...skillPaths.flatMap((p) => ["--skill", p]),
 		"--no-context-files",


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #780

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| auditor | ✓ SUCCESS | 4m 3s | 107.4K | 73 | deepseek-v4-flash |

**Total:** 1 agents · 4m 3s · 107.4K tokens · 73 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/780
Closes #780