### PR TITLE
feat(#796): piignore-companion: Trust-check should warn about directory-only and broad glob patterns

### DIFF
--- a/.pi/extensions/piignore/README.md
+++ b/.pi/extensions/piignore/README.md
@@ -97,8 +97,21 @@ the handler treats the project as untrusted (fail-closed) and applies safe-defau
 ## Global Companion (Optional)
 
 The companion extension `global-companion.ts` participates in the `project_trust`
-event to warn about restrictive `.piignore` patterns before trust is granted.
-It does **not** make trust decisions — it only observes and warns.
+event to warn about potentially problematic `.piignore` patterns before trust is
+granted. It does **not** make trust decisions — it only observes and warns.
+
+### Detects
+
+- **Restrictive patterns** — `*`, `**`, `/`, `/*`, `/**` that match everything
+- **Unanchored generic directories** — `build/`, `dist/`, `tmp/`, `cache/`, `logs/`,
+  `node_modules/` and other commonly auto-generated directories that may block
+  important paths at any depth
+- **Broad file-type globs** — `*.log`, `*.db`, `*.sqlite`, `*.tar`, `*.zip`,
+  `*.lock` and other non-essential file types matched project-wide
+- **Name-heuristic patterns** — `**/*secret*`, `**/*token*`, `**/*password*`
+  and similar patterns that match based on filename substring heuristics
+
+All warnings are grouped into a single notification to avoid warning fatigue.
 
 ### Install
 

--- a/.pi/extensions/piignore/global-companion.ts
+++ b/.pi/extensions/piignore/global-companion.ts
@@ -23,6 +23,91 @@ interface Pattern {
 	negate: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// Over-broad pattern detection
+// ---------------------------------------------------------------------------
+
+interface PatternWarning {
+	category: "unanchored-dir" | "broad-file-glob" | "name-heuristic";
+	patterns: string[];
+}
+
+/**
+ * Generic directory names that are commonly non-essential and likely
+ * over-broad when used as unanchored dir patterns (ending with /).
+ * Not exhaustive — curated to avoid warning fatigue on legitimate
+ * narrow dir ignores like `secrets/`, `docs/`, `src/`.
+ */
+const GENERIC_DIR_NAMES = new Set([
+	"build",
+	"dist",
+	"tmp",
+	"temp",
+	"cache",
+	"caches",
+	"logs",
+	"log",
+	"old",
+	"node_modules",
+	"bower_components",
+	"jspm_packages",
+	"vendor",
+	"target",
+	"out",
+	"output",
+]);
+
+/**
+ * File extensions that are commonly non-essential (logs, caches,
+ * archives, temp files). Warnings are only raised for these specific
+ * extensions to avoid false positives on project-specific types.
+ */
+const NON_ESSENTIAL_EXTENSIONS = new Set([
+	"log",
+	"db",
+	"sqlite",
+	"sqlite3",
+	"tar",
+	"zip",
+	"gz",
+	"bz2",
+	"7z",
+	"rar",
+	"bak",
+	"tmp",
+	"temp",
+	"cache",
+	"pid",
+	"lock",
+	"swp",
+	"swo",
+]);
+
+/**
+ * Sensitive keywords that, when used in name-heuristic patterns with
+ * wildcard adjacency (e.g. `**​/*secret*`, `*token*`), suggest the
+ * pattern is matching on name heuristics rather than exact paths.
+ */
+const SENSITIVE_KEYWORDS = [
+	"secret",
+	"token",
+	"password",
+	"credential",
+	"cert",
+	"private",
+	"key",
+	"auth",
+];
+
+/**
+ * Human-readable labels for each over-broad pattern category.
+ */
+const CATEGORY_LABELS: Record<PatternWarning["category"], string> = {
+	"unanchored-dir": "Unanchored generic directories",
+	"broad-file-glob": "Broad file-type globs",
+	"name-heuristic": "Name-heuristic patterns",
+};
+
 /**
  * Check if a raw .piignore line is a restrictive pattern that would
  * block most or all paths. These are patterns like `*`, `**`, `/`,
@@ -50,6 +135,149 @@ function parseIgnoreRaw(content: string): string[] {
 		lines.push(trimmed);
 	}
 	return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Over-broad pattern detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect unanchored directory-only patterns that match generic dir names
+ * at any depth (e.g. `build/`, `tmp/`, `node_modules/`).
+ *
+ * Returns true when:
+ * - Pattern ends with /
+ * - Has no leading / (root-anchored)
+ * - Has no internal / (path-anchored)
+ * - The directory name is in GENERIC_DIR_NAMES
+ */
+export function isUnanchoredDirPattern(line: string): boolean {
+	const trimmed = line.trim();
+	if (trimmed === "" || trimmed.startsWith("#")) return false;
+	// Strip negation prefix to check the actual pattern
+	const pattern = trimmed.startsWith("!") ? trimmed.slice(1).trim() : trimmed;
+
+	// Must end with /
+	if (!pattern.endsWith("/")) return false;
+
+	// Must NOT have leading / (root-anchored)
+	if (pattern.startsWith("/")) return false;
+
+	// Must NOT have internal / (path-anchored)
+	const dirName = pattern.slice(0, -1); // remove trailing /
+	if (dirName.includes("/")) return false;
+
+	// Dir name must be in the generic set
+	return GENERIC_DIR_NAMES.has(dirName);
+}
+
+/**
+ * Detect broad file-type glob patterns that match all files of a
+ * non-essential type project-wide (e.g. `*.log`, `**​/*.db`).
+ *
+ * Returns true when:
+ * - Pattern matches `*.{ext}` or `**​/*.{ext}` where ext is in
+ *   NON_ESSENTIAL_EXTENSIONS
+ */
+export function isBroadFileGlob(line: string): boolean {
+	const trimmed = line.trim();
+	if (trimmed === "" || trimmed.startsWith("#")) return false;
+	// Strip negation prefix to check the actual pattern
+	const pattern = trimmed.startsWith("!") ? trimmed.slice(1).trim() : trimmed;
+
+	// Match `*.{ext}` where ext is in NON_ESSENTIAL_EXTENSIONS
+	const singleStar = /^\*\.([a-zA-Z][a-zA-Z0-9]*)$/.exec(pattern);
+	if (singleStar && NON_ESSENTIAL_EXTENSIONS.has(singleStar[1])) {
+		return true;
+	}
+
+	// Match `**​/*.{ext}` where ext is in NON_ESSENTIAL_EXTENSIONS
+	const doubleStar = /^\*\*\/\*\.([a-zA-Z][a-zA-Z0-9]*)$/.exec(pattern);
+	if (doubleStar && NON_ESSENTIAL_EXTENSIONS.has(doubleStar[1])) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Detect name-heuristic patterns that match on sensitive keywords
+ * with wildcard adjacency (e.g. `**​/*secret*`, `*token*`).
+ *
+ * Returns true when:
+ * - Pattern contains a SENSITIVE_KEYWORDS term
+ * - The keyword has `*` adjacent on at least one side (substring-heuristic)
+ *
+ * This avoids flagging literal filenames like `secrets/` or `secret.txt`
+ * that happen to contain a keyword substring.
+ */
+export function isNameHeuristicPattern(line: string): boolean {
+	const trimmed = line.trim();
+	if (trimmed === "" || trimmed.startsWith("#")) return false;
+	// Strip negation prefix to check the actual pattern
+	const pattern = trimmed.startsWith("!") ? trimmed.slice(1).trim() : trimmed;
+
+	for (const keyword of SENSITIVE_KEYWORDS) {
+		// Check for *adjacent-to-keyword patterns: *keyword*, *keyword, keyword*
+		const escapedKeyword = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		const regex = new RegExp(`\\*${escapedKeyword}|${escapedKeyword}\\*`);
+		if (regex.test(pattern)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Classify each line into zero or one overbroad category.
+ * Returns deduplicated warnings grouped by category.
+ */
+export function detectOverbroadPatterns(lines: string[]): PatternWarning[] {
+	const warnings: PatternWarning[] = [];
+
+	const unanchoredDirs: string[] = [];
+	const broadGlobs: string[] = [];
+	const heuristicPatterns: string[] = [];
+
+	for (const line of lines) {
+		if (isRestrictiveRaw(line)) continue; // handled by existing check — not overbroad
+		if (isUnanchoredDirPattern(line)) {
+			unanchoredDirs.push(line);
+		} else if (isBroadFileGlob(line)) {
+			broadGlobs.push(line);
+		} else if (isNameHeuristicPattern(line)) {
+			heuristicPatterns.push(line);
+		}
+	}
+
+	if (unanchoredDirs.length > 0) {
+		warnings.push({ category: "unanchored-dir", patterns: unanchoredDirs });
+	}
+	if (broadGlobs.length > 0) {
+		warnings.push({ category: "broad-file-glob", patterns: broadGlobs });
+	}
+	if (heuristicPatterns.length > 0) {
+		warnings.push({ category: "name-heuristic", patterns: heuristicPatterns });
+	}
+
+	return warnings;
+}
+
+/**
+ * Format a list of PatternWarning into a concise, human-readable
+ * notification message grouped by category. Returns empty string
+ * when there are no warnings (signals no notification needed).
+ */
+export function buildWarningMessage(warnings: PatternWarning[]): string {
+	if (warnings.length === 0) return "";
+
+	const parts: string[] = [];
+	for (const warning of warnings) {
+		parts.push(`  ${CATEGORY_LABELS[warning.category]}: ${warning.patterns.join(", ")}`);
+	}
+
+	return `\u26a0\ufe0f piignore: .piignore contains over-broad patterns:\n${parts.join("\n")}. Review before granting trust.`;
 }
 
 // ---------------------------------------------------------------------------
@@ -89,10 +317,25 @@ export default function (pi: {
 
 			const lines = parseIgnoreRaw(content);
 			const restrictivePatterns = lines.filter(isRestrictiveRaw);
+			const overbroadWarnings = detectOverbroadPatterns(lines);
 
-			if (restrictivePatterns.length > 0 && extCtx.hasUI && extCtx.ui) {
+			// Build combined warning message
+			const messageParts: string[] = [];
+			if (restrictivePatterns.length > 0) {
+				messageParts.push(
+					`restrictive patterns (${restrictivePatterns.join(", ")}) that may block most files`,
+				);
+			}
+			if (overbroadWarnings.length > 0) {
+				const categoryLines = overbroadWarnings.map(
+					(w) => `  ${CATEGORY_LABELS[w.category]}: ${w.patterns.join(", ")}`,
+				);
+				messageParts.push(`over-broad patterns:\n${categoryLines.join("\n")}`);
+			}
+
+			if (messageParts.length > 0 && extCtx.hasUI && extCtx.ui) {
 				extCtx.ui.notify(
-					`⚠️ piignore: .piignore contains restrictive patterns (${restrictivePatterns.join(", ")}) that may block most files. Review before granting trust.`,
+					`⚠️ piignore: .piignore contains ${messageParts.join(" and ")}. Review before granting trust.`,
 					"warning",
 				);
 			}

--- a/.pi/extensions/piignore/test/piignore-companion.test.mts
+++ b/.pi/extensions/piignore/test/piignore-companion.test.mts
@@ -16,7 +16,14 @@ import path from "node:path";
 import { describe, it, beforeEach, afterEach } from "node:test";
 
 // Import from implementation for TDD gate verification
-import { default as createCompanion } from "../global-companion.ts";
+import {
+	default as createCompanion,
+	isUnanchoredDirPattern,
+	isBroadFileGlob,
+	isNameHeuristicPattern,
+	detectOverbroadPatterns,
+	buildWarningMessage,
+} from "../global-companion.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
 // Types
@@ -69,6 +76,344 @@ function createMockAPI(): MockExtensionAPI {
 		},
 	};
 }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 1: Detection function units
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("isUnanchoredDirPattern", () => {
+	it("returns true for unanchored generic dir (build/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("build/"), true);
+	});
+
+	it("returns true for unanchored generic dir (dist/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("dist/"), true);
+	});
+
+	it("returns true for unanchored generic dir (tmp/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("tmp/"), true);
+	});
+
+	it("returns true for unanchored generic dir (cache/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("cache/"), true);
+	});
+
+	it("returns true for unanchored generic dir (logs/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("logs/"), true);
+	});
+
+	it("returns true for unanchored generic dir (old/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("old/"), true);
+	});
+
+	it("returns true for unanchored generic dir (node_modules/)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("node_modules/"), true);
+	});
+
+	it("returns false for secrets/ (safe-default, not generic)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("secrets/"), false);
+	});
+
+	it("returns false for docs/ (not generic)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("docs/"), false);
+	});
+
+	it("returns false for src/ (not generic)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("src/"), false);
+	});
+
+	it("returns false for /build/ (leading / anchors to root)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("/build/"), false);
+	});
+
+	it("returns false for src/build/ (internal / anchors scope)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("src/build/"), false);
+	});
+
+	it("returns false for build (no trailing /)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("build"), false);
+	});
+
+	it("returns false for build.log (not a dir pattern)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("build.log"), false);
+	});
+
+	it("returns false for .env (literal, no trailing /)", () => {
+		assert.strictEqual(isUnanchoredDirPattern(".env"), false);
+	});
+
+	it("returns false for empty string", () => {
+		assert.strictEqual(isUnanchoredDirPattern(""), false);
+	});
+
+	it("returns true for whitespace-padded build/ (trimmed)", () => {
+		assert.strictEqual(isUnanchoredDirPattern("  build/  "), true);
+	});
+});
+
+describe("isBroadFileGlob", () => {
+	it("returns true for *.log", () => {
+		assert.strictEqual(isBroadFileGlob("*.log"), true);
+	});
+
+	it("returns true for *.db", () => {
+		assert.strictEqual(isBroadFileGlob("*.db"), true);
+	});
+
+	it("returns true for *.sqlite", () => {
+		assert.strictEqual(isBroadFileGlob("*.sqlite"), true);
+	});
+
+	it("returns true for *.tar", () => {
+		assert.strictEqual(isBroadFileGlob("*.tar"), true);
+	});
+
+	it("returns true for *.zip", () => {
+		assert.strictEqual(isBroadFileGlob("*.zip"), true);
+	});
+
+	it("returns true for *.gz", () => {
+		assert.strictEqual(isBroadFileGlob("*.gz"), true);
+	});
+
+	it("returns true for *.bak", () => {
+		assert.strictEqual(isBroadFileGlob("*.bak"), true);
+	});
+
+	it("returns true for *.tmp", () => {
+		assert.strictEqual(isBroadFileGlob("*.tmp"), true);
+	});
+
+	it("returns true for *.cache", () => {
+		assert.strictEqual(isBroadFileGlob("*.cache"), true);
+	});
+
+	it("returns true for *.pid", () => {
+		assert.strictEqual(isBroadFileGlob("*.pid"), true);
+	});
+
+	it("returns true for *.lock", () => {
+		assert.strictEqual(isBroadFileGlob("*.lock"), true);
+	});
+
+	it("returns true for **/*.log (double-star variant)", () => {
+		assert.strictEqual(isBroadFileGlob("**/*.log"), true);
+	});
+
+	it("returns false for *.env (safe-default, not in curated set)", () => {
+		assert.strictEqual(isBroadFileGlob("*.env"), false);
+	});
+
+	it("returns false for .env (literal, no wildcard)", () => {
+		assert.strictEqual(isBroadFileGlob(".env"), false);
+	});
+
+	it("returns false for .env.* (no leading * glob)", () => {
+		assert.strictEqual(isBroadFileGlob(".env.*"), false);
+	});
+
+	it("returns false for **/*.pem (safe-default, not in curated set)", () => {
+		assert.strictEqual(isBroadFileGlob("**/*.pem"), false);
+	});
+
+	it("returns false for **/*.key (safe-default, not in curated set)", () => {
+		assert.strictEqual(isBroadFileGlob("**/*.key"), false);
+	});
+
+	it("returns false for *.md (not in curated set)", () => {
+		assert.strictEqual(isBroadFileGlob("*.md"), false);
+	});
+
+	it("returns false for *.js (not in curated set)", () => {
+		assert.strictEqual(isBroadFileGlob("*.js"), false);
+	});
+
+	it("returns false for secrets/ (not a file glob)", () => {
+		assert.strictEqual(isBroadFileGlob("secrets/"), false);
+	});
+
+	it("returns false for build/ (not a file glob)", () => {
+		assert.strictEqual(isBroadFileGlob("build/"), false);
+	});
+
+	it("returns false for * (not an ext pattern)", () => {
+		assert.strictEqual(isBroadFileGlob("*"), false);
+	});
+
+	it("returns false for ** (not an ext pattern)", () => {
+		assert.strictEqual(isBroadFileGlob("**"), false);
+	});
+
+	it("returns false for empty string", () => {
+		assert.strictEqual(isBroadFileGlob(""), false);
+	});
+});
+
+describe("isNameHeuristicPattern", () => {
+	it("returns true for **/*secret*", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*secret*"), true);
+	});
+
+	it("returns true for **/*token*", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*token*"), true);
+	});
+
+	it("returns true for **/*password*", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*password*"), true);
+	});
+
+	it("returns true for **/*credential*", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*credential*"), true);
+	});
+
+	it("returns true for **/*cert*", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*cert*"), true);
+	});
+
+	it("returns true for **/*private*", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*private*"), true);
+	});
+
+	it("returns true for *secret*", () => {
+		assert.strictEqual(isNameHeuristicPattern("*secret*"), true);
+	});
+
+	it("returns true for secret*", () => {
+		assert.strictEqual(isNameHeuristicPattern("secret*"), true);
+	});
+
+	it("returns true for *secret", () => {
+		assert.strictEqual(isNameHeuristicPattern("*secret"), true);
+	});
+
+	it("returns false for secrets/ (literal dir, no star adjacency)", () => {
+		assert.strictEqual(isNameHeuristicPattern("secrets/"), false);
+	});
+
+	it("returns false for secret.txt (literal file, no star)", () => {
+		assert.strictEqual(isNameHeuristicPattern("secret.txt"), false);
+	});
+
+	it("returns false for **/*.pem (no keyword match)", () => {
+		assert.strictEqual(isNameHeuristicPattern("**/*.pem"), false);
+	});
+
+	it("returns false for *.env (no keyword match)", () => {
+		assert.strictEqual(isNameHeuristicPattern("*.env"), false);
+	});
+
+	it("returns false for build/ (no keyword match)", () => {
+		assert.strictEqual(isNameHeuristicPattern("build/"), false);
+	});
+
+	it("returns false for empty string", () => {
+		assert.strictEqual(isNameHeuristicPattern(""), false);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2: Aggregation and formatting
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("detectOverbroadPatterns", () => {
+	it("returns [] for empty input", () => {
+		const result = detectOverbroadPatterns([]);
+		assert.strictEqual(result.length, 0);
+	});
+
+	it("returns [] for normal patterns (secrets/, .env)", () => {
+		const result = detectOverbroadPatterns(["secrets/", ".env"]);
+		assert.strictEqual(result.length, 0);
+	});
+
+	it("returns unanchored-dir warning for build/", () => {
+		const result = detectOverbroadPatterns(["build/"]);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].category, "unanchored-dir");
+		assert.deepStrictEqual(result[0].patterns, ["build/"]);
+	});
+
+	it("returns broad-file-glob warning for *.log", () => {
+		const result = detectOverbroadPatterns(["*.log"]);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].category, "broad-file-glob");
+		assert.deepStrictEqual(result[0].patterns, ["*.log"]);
+	});
+
+	it("returns name-heuristic warning for **/*secret*", () => {
+		const result = detectOverbroadPatterns(["**/*secret*"]);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].category, "name-heuristic");
+		assert.deepStrictEqual(result[0].patterns, ["**/*secret*"]);
+	});
+
+	it("merges same-category patterns (build/, tmp/)", () => {
+		const result = detectOverbroadPatterns(["build/", "tmp/"]);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].category, "unanchored-dir");
+		assert.deepStrictEqual(result[0].patterns, ["build/", "tmp/"]);
+	});
+
+	it("returns separate categories for different patterns", () => {
+		const result = detectOverbroadPatterns(["build/", "*.log"]);
+		assert.strictEqual(result.length, 2);
+		const categories = result.map((w) => w.category).sort();
+		assert.deepStrictEqual(categories, ["broad-file-glob", "unanchored-dir"]);
+	});
+
+	it("returns all three categories", () => {
+		const result = detectOverbroadPatterns(["build/", "*.log", "**/*secret*"]);
+		assert.strictEqual(result.length, 3);
+		const categories = result.map((w) => w.category).sort();
+		assert.deepStrictEqual(categories, ["broad-file-glob", "name-heuristic", "unanchored-dir"]);
+	});
+
+	it("skips restrictive patterns (*, **) — not overbroad", () => {
+		const result = detectOverbroadPatterns(["*", "**"]);
+		assert.strictEqual(result.length, 0);
+	});
+
+	it("ignores comments", () => {
+		const result = detectOverbroadPatterns(["# comment", "build/"]);
+		assert.strictEqual(result.length, 1);
+		assert.strictEqual(result[0].category, "unanchored-dir");
+		assert.deepStrictEqual(result[0].patterns, ["build/"]);
+	});
+
+	it("safe-default patterns produce no warnings", () => {
+		const result = detectOverbroadPatterns(["*.env", "secrets/", ".env.*", "**/*.pem", "**/*.key"]);
+		assert.strictEqual(result.length, 0);
+	});
+});
+
+describe("buildWarningMessage", () => {
+	it("returns empty string for empty warnings", () => {
+		assert.strictEqual(buildWarningMessage([]), "");
+	});
+
+	it("includes category label and pattern for single warning", () => {
+		const msg = buildWarningMessage([{ category: "unanchored-dir", patterns: ["build/"] }]);
+		assert.ok(msg.includes("Unanchored generic directories"), msg);
+		assert.ok(msg.includes("build/"), msg);
+	});
+
+	it("includes all patterns for single category with multiple patterns", () => {
+		const msg = buildWarningMessage([{ category: "unanchored-dir", patterns: ["build/", "tmp/"] }]);
+		assert.ok(msg.includes("build/"), msg);
+		assert.ok(msg.includes("tmp/"), msg);
+	});
+
+	it("includes all categories in output", () => {
+		const msg = buildWarningMessage([
+			{ category: "unanchored-dir", patterns: ["build/"] },
+			{ category: "broad-file-glob", patterns: ["*.log"] },
+			{ category: "name-heuristic", patterns: ["**/*secret*"] },
+		]);
+		assert.ok(msg.includes("Unanchored generic directories"), msg);
+		assert.ok(msg.includes("Broad file-type globs"), msg);
+		assert.ok(msg.includes("Name-heuristic patterns"), msg);
+	});
+});
 
 // ═══════════════════════════════════════════════════════════════════════
 // Phase 3: Global companion (piignore-trust-check)
@@ -380,5 +725,315 @@ describe("piignore-trust-check companion", () => {
 				handler({ projectPath: ctx.cwd || "" }, ctx);
 			}, `handler should not throw for cwd="${ctx.cwd}"`);
 		}
+	});
+
+	// ── Over-broad pattern warnings ──────────────────────────────────
+
+	it("project has .piignore with unanchored dir (build/) — warns", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "build/\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		let warnMsg = "";
+		let warnCount = 0;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: (msg: string) => {
+					warned = true;
+					warnCount++;
+					warnMsg = msg;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.ok(warned, "should warn about unanchored dir");
+		assert.ok(warnMsg.includes("build/"), `msg should mention build/, got: ${warnMsg}`);
+		assert.ok(
+			warnMsg.includes("Unanchored generic directories"),
+			`msg should contain category label`,
+		);
+		assert.strictEqual(warnCount, 1, "should call ui.notify exactly once");
+	});
+
+	it("project has .piignore with broad file glob (*.log) — warns", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "*.log\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		let warnCount = 0;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: () => {
+					warned = true;
+					warnCount++;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.ok(warned, "should warn about broad file glob");
+		assert.strictEqual(warnCount, 1, "should call ui.notify exactly once");
+	});
+
+	it("project has .piignore with name-heuristic pattern (**/*secret*) — warns", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "**/*secret*\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		let warnCount = 0;
+		let warnMsg = "";
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: (msg: string) => {
+					warned = true;
+					warnCount++;
+					warnMsg = msg;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.ok(warned, "should warn about name-heuristic pattern");
+		assert.ok(warnMsg.includes("secret"), `msg should mention secret, got: ${warnMsg}`);
+		assert.strictEqual(warnCount, 1, "should call ui.notify exactly once");
+	});
+
+	it("multiple over-broad patterns — single notification", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "build/\n*.log\n**/*secret*\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		let warnCount = 0;
+		let warnMsg = "";
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: (msg: string) => {
+					warned = true;
+					warnCount++;
+					warnMsg = msg;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.ok(warned, "should warn");
+		assert.strictEqual(warnCount, 1, "should be single notification");
+		assert.ok(warnMsg.includes("build/"), `msg should mention build/, got: ${warnMsg}`);
+		assert.ok(warnMsg.includes("*.log"), `msg should mention *.log`);
+		assert.ok(warnMsg.includes("secret"), `msg should mention secret`);
+	});
+
+	it("restrictive + overbroad patterns — combined single notification", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "**\nbuild/\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		let warnCount = 0;
+		let warnMsg = "";
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: (msg: string) => {
+					warned = true;
+					warnCount++;
+					warnMsg = msg;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.ok(warned, "should warn");
+		assert.strictEqual(warnCount, 1, "should be single notification");
+		assert.ok(warnMsg.includes("restrictive"), `msg should mention restrictive`);
+		assert.ok(warnMsg.includes("build/"), `msg should mention build/`);
+	});
+
+	it("safe-default patterns (.env, secrets/) — no warning (backward compat)", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), ".env\nsecrets/\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: () => {
+					warned = true;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided", "should return undecided");
+		assert.strictEqual(warned, false, "should NOT warn about safe-default patterns");
+	});
+
+	it("all safe-default block patterns produce no warning", () => {
+		fs.writeFileSync(
+			path.join(testDir, ".piignore"),
+			"*.env\n**/*.pem\n**/*.key\n.env.*\nsecrets/\n",
+			"utf-8",
+		);
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: () => {
+					warned = true;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided", "should return undecided");
+		assert.strictEqual(warned, false, "should NOT warn about safe-default patterns");
+	});
+
+	it("empty .piignore — no warning", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: () => {
+					warned = true;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided", "should return undecided");
+		assert.strictEqual(warned, false, "should NOT warn about empty .piignore");
+	});
+
+	it("comments-only .piignore — no warning", () => {
+		fs.writeFileSync(
+			path.join(testDir, ".piignore"),
+			"# this is a comment\n# another comment\n",
+			"utf-8",
+		);
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: {
+				notify: () => {
+					warned = true;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.strictEqual(warned, false, "should NOT warn about comments-only .piignore");
+	});
+
+	it("hasUI: false — no notification even with overbroad patterns", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "build/\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		let warned = false;
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: false,
+			ui: {
+				notify: () => {
+					warned = true;
+				},
+			},
+		};
+
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+		assert.strictEqual(warned, false, "should NOT notify when hasUI is false");
+	});
+
+	it("ui is undefined — no notification (graceful degradation)", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "build/\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		const ctx: ProjectTrustContext = {
+			cwd: testDir,
+			hasUI: true,
+			ui: undefined as unknown as { notify: (message: string, type: string) => void },
+		};
+
+		// Should not throw
+		const result = handler({ projectPath: testDir }, ctx);
+		assert.strictEqual(result.trusted, "undecided");
+	});
+
+	it("overbroad patterns with hasUI: true, ui undefined — no crash", () => {
+		fs.writeFileSync(path.join(testDir, ".piignore"), "build/\n", "utf-8");
+
+		const api = createMockAPI();
+		createCompanion(api as any);
+		const handler = api.getProjectTrustHandler()!;
+
+		const ctx = {
+			cwd: testDir,
+			hasUI: true,
+			// no ui property
+		};
+
+		// Should not throw
+		const result = handler({ projectPath: testDir }, ctx as any);
+		assert.strictEqual(result.trusted, "undecided");
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #796

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 28s | 44.6K | 31 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 30s | 29.2K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 37s | 28.5K | 7 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 49s | 76.2K | 45 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 53s | 50.8K | 14 | deepseek-v4-flash |

**Total:** 5 agents · 13m 17s · 229.3K tokens · 109 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/796
Closes #796