### PR TITLE
feat(#837): Bug: session-advice - detectRedundantReads double-counts waste tokens on merge

### DIFF
--- a/.pi/extensions/session-advice/test/redundant-reads.test.ts
+++ b/.pi/extensions/session-advice/test/redundant-reads.test.ts
@@ -36,16 +36,106 @@ describe("detectRedundantReads", () => {
 	});
 
 	it("3 reads of same file across turns 0,1,2 → 2 signals (each pair within 2-turn window)", () => {
-		const data = makeSession([
-			readEntry("/repo/src/app.ts", 0),
-			readEntry("/repo/src/app.ts", 1),
-			readEntry("/repo/src/app.ts", 2),
-		]);
-		assert.strictEqual(
-			detectRedundantReads(data).length,
-			2,
-			"should produce 2 signals (1 per pair)",
+		const signals = detectRedundantReads(
+			makeSession([
+				readEntry("/repo/src/app.ts", 0),
+				readEntry("/repo/src/app.ts", 1),
+				readEntry("/repo/src/app.ts", 2),
+			]),
 		);
+		assert.strictEqual(signals.length, 2, "should produce 2 signals (1 per pair)");
+		// Each signal's wastedTokens covers disjoint entry sets — no double-count.
+		// Entry text is "/repo/src/app.ts" (15 chars) → ceil(15/4) = 4 tokens per entry.
+		assert.strictEqual(signals[0].wastedTokens, 4, "signal1: redundant entry at turn 1 = 4 tokens");
+		assert.strictEqual(signals[1].wastedTokens, 4, "signal2: redundant entry at turn 2 = 4 tokens");
+	});
+
+	it("3 reads with explicit assistantCost → no double-count", () => {
+		const signals = detectRedundantReads(
+			makeSession([
+				{
+					type: "tool_use",
+					toolName: "read",
+					args: { path: "/repo/src/app.ts" },
+					text: "/repo/src/app.ts",
+					turnIndex: 0,
+					assistantCost: 100,
+				},
+				{
+					type: "tool_use",
+					toolName: "read",
+					args: { path: "/repo/src/app.ts" },
+					text: "/repo/src/app.ts",
+					turnIndex: 1,
+					assistantCost: 200,
+				},
+				{
+					type: "tool_use",
+					toolName: "read",
+					args: { path: "/repo/src/app.ts" },
+					text: "/repo/src/app.ts",
+					turnIndex: 2,
+					assistantCost: 300,
+				},
+			]),
+		);
+		assert.strictEqual(signals.length, 2, "should produce 2 signals");
+		// Signal1: redundantEntries = [entry[1] (cost 200)] → wastedTokens = 200
+		// Signal2: redundantEntries = [entry[2] (cost 300)] → wastedTokens = 300
+		// No entry appears in both signals' redundantEntries.
+		assert.strictEqual(signals[0].wastedTokens, 200, "signal1: entry[1] cost = 200");
+		assert.strictEqual(signals[1].wastedTokens, 300, "signal2: entry[2] cost = 300");
+	});
+
+	it("4 reads of same file across turns 0,1,2,3 → 3 signals, each with one entry in redundantEntries", () => {
+		const signals = detectRedundantReads(
+			makeSession([
+				readEntry("/repo/src/app.ts", 0),
+				readEntry("/repo/src/app.ts", 1),
+				readEntry("/repo/src/app.ts", 2),
+				readEntry("/repo/src/app.ts", 3),
+			]),
+		);
+		assert.strictEqual(signals.length, 3, "should produce 3 signals");
+		// Each signal's redundantEntries contains exactly one entry.
+		// Signal1: redundant = [turn 0] → redundantEntries = [entry[1]]
+		// Signal2: redundant = [turn 1] (turn 0 reported) → redundantEntries = [entry[2]]
+		// Signal3: redundant = [turn 2] (turns 0,1 reported) → redundantEntries = [entry[3]]
+		for (let i = 0; i < 3; i++) {
+			assert.strictEqual(signals[i].occurrences, 1, `signal${i}: occurrences should be 1`);
+		}
+	});
+
+	it("exact 2-turn boundary: same file at turns 0 and 2 → 1 signal", () => {
+		const signals = detectRedundantReads(
+			makeSession([
+				readEntry("/repo/src/app.ts", 0),
+				{
+					type: "tool_use",
+					toolName: "bash",
+					args: { command: "npm test" },
+					text: "npm test",
+					turnIndex: 0,
+				},
+				readEntry("/repo/src/app.ts", 2),
+			]),
+		);
+		assert.strictEqual(signals.length, 1, "distance ≤ 2 should flag");
+		// redundantEntries = [entry[2]] only, entry[0] excluded
+		assert.strictEqual(signals[0].occurrences, 1, "should count 1 redundant occurrence");
+	});
+
+	it("gap then return: reads at turns 0, 3 (gap >2), 4 (within window of turn 3) → 1 signal", () => {
+		const signals = detectRedundantReads(
+			makeSession([
+				readEntry("/repo/src/app.ts", 0),
+				readEntry("/repo/src/app.ts", 3),
+				readEntry("/repo/src/app.ts", 4),
+			]),
+		);
+		assert.strictEqual(signals.length, 1, "only turn 4 is redundant with turn 3");
+		// redundantEntries = [entry[4]] — turn 3 is baseline, turn 4 is waste
+		assert.strictEqual(signals[0].occurrences, 1, "should count 1 redundant occurrence");
 	});
 
 	it("empty session → 0 signals", () => {

--- a/.pi/extensions/session-advice/test/session-analyzer.test.ts
+++ b/.pi/extensions/session-advice/test/session-analyzer.test.ts
@@ -26,6 +26,44 @@ describe("analyzeSession — dedup/merge", () => {
 		);
 	});
 
+	it("redundant-read merge: 3 reads with explicit costs → no double-count in wastedTokens", () => {
+		const signals = analyzeSession(
+			makeSession([
+				{
+					type: "tool_use",
+					toolName: "read",
+					args: { path: "/repo/src/app.ts" },
+					text: "/repo/src/app.ts",
+					turnIndex: 0,
+					assistantCost: 100,
+				},
+				{
+					type: "tool_use",
+					toolName: "read",
+					args: { path: "/repo/src/app.ts" },
+					text: "/repo/src/app.ts",
+					turnIndex: 1,
+					assistantCost: 200,
+				},
+				{
+					type: "tool_use",
+					toolName: "read",
+					args: { path: "/repo/src/app.ts" },
+					text: "/repo/src/app.ts",
+					turnIndex: 2,
+					assistantCost: 300,
+				},
+			]),
+		);
+		const merged = signals.filter((s) => s.signal === "redundant-read");
+		assert.strictEqual(merged.length, 1, "should merge into 1 signal");
+		// Signal1 had redundantEntries = [entry[1] (cost 200)], Signal2 had [entry[2] (cost 300)].
+		// After merge: wastedTokens = 200 + 300 = 500 (entry[1] counted once, entry[2] counted once).
+		// Without the fix, wastedTokens would be 700 (entry[1] double-counted in both signals).
+		assert.strictEqual(merged[0].wastedTokens, 500, "no double-count: 200 + 300 = 500");
+		assert.strictEqual(merged[0].occurrences, 2, "2 total redundant occurrences");
+	});
+
 	it("2 detectors produce different keys → 2 separate signals", () => {
 		const data = makeSession([
 			bashEntry("cat file | grep foo", 0),

--- a/.pi/extensions/session-advice/waste-signals/redundant-reads.ts
+++ b/.pi/extensions/session-advice/waste-signals/redundant-reads.ts
@@ -18,7 +18,12 @@ function shortPath(p: string): string {
  */
 export function detectRedundantReads(data: SessionData): WasteSignal[] {
 	const results: WasteSignal[] = [];
-	const reads: Array<{ path: string; turnIndex: number; entry: SessionEntry }> = [];
+	const reads: Array<{
+		path: string;
+		turnIndex: number;
+		entry: SessionEntry;
+		reported?: boolean;
+	}> = [];
 
 	for (const e of data.entries) {
 		if (e.toolName !== "read") continue;
@@ -27,7 +32,10 @@ export function detectRedundantReads(data: SessionData): WasteSignal[] {
 
 		const redundant = reads.filter(
 			(r) =>
-				r.path === p && Math.abs(r.turnIndex - e.turnIndex) <= 2 && r.turnIndex !== e.turnIndex,
+				r.path === p &&
+				Math.abs(r.turnIndex - e.turnIndex) <= 2 &&
+				r.turnIndex !== e.turnIndex &&
+				!r.reported,
 		);
 		if (redundant.length > 0) {
 			const allEntries = [...redundant.map((r) => r.entry), e];
@@ -48,9 +56,16 @@ export function detectRedundantReads(data: SessionData): WasteSignal[] {
 				],
 				context: { files: [p], turnRange: [firstTurn, lastTurn] },
 			});
+			// Mark redundant entries as reported so each entry's cost
+			// appears in exactly one signal's redundantEntries.
+			for (const r of redundant) r.reported = true;
 		}
 
-		reads.push({ path: p, turnIndex: e.turnIndex, entry: e });
+		reads.push({
+			path: p,
+			turnIndex: e.turnIndex,
+			entry: e,
+		});
 	}
 
 	return results;


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #837

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 4s | 57.2K | 40 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 37s | 37.3K | 10 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 54s | 21.8K | 9 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 58s | 34.2K | 23 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 25s | 40.1K | 21 | deepseek-v4-flash |

**Total:** 5 agents · 8m 58s · 190.6K tokens · 103 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/837
Closes #837