### PR TITLE
feat(#838): Bug: agent-harness - read cache stores [pending] never replaced, causes false positive blocks

### DIFF
--- a/.pi/extensions/agent-harness/agent-harness.ts
+++ b/.pi/extensions/agent-harness/agent-harness.ts
@@ -215,30 +215,29 @@ export class AgentHarness {
 				};
 			}
 
-			// ── 4. Read caching (mode-aware: bypass in non-UI modes) ──
+			// ── 4. Read caching (boolean-existence tracking with sessionTurn TTL) ──
 			else if (toolName === "read") {
 				const path = (args.path ?? "") as string;
 				if (path) {
 					const offset = (args.offset ?? 0) as number;
 					const limit = (args.limit ?? "") as number;
 					const cacheKey = `${path}|${offset}|${limit}`;
-					const cached = this.state.readCache.get(cacheKey, toolCallIndex, this.state.batchId);
+					const cached = this.state.readCache.get(cacheKey, sessionTurn, this.state.batchId);
 					if (cached) {
-						// Same-turn [pending] → pass through (let re-read happen)
-						if (cached.content === "[pending]" && cached.turn === toolCallIndex) {
+						// Same-turn → pass through (let re-read happen in same turn)
+						if (cached.turn === sessionTurn) {
 							// result stays null, pass through
 						} else if (!this.#hasUI) {
 							// Non-TUI mode: bypass read cache block, pass through
-							// Cache store still happens for non-UI reads (written below in else branch)
 						} else {
 							result = {
 								block: true,
-								reason: `Content cached from turn ${cached.turn} — use offset/limit to page or re-read after 3 turns.`,
+								reason: `Content cached from turn ${cached.turn} — use offset/limit to page or re-read after 6 turns.`,
 							};
 						}
 					} else {
-						// Store marker to track that this path+offset+limit was recently read
-						this.state.readCache.set(cacheKey, "[pending]", toolCallIndex, this.state.batchId);
+						// Store existence marker to track that this path+offset+limit was recently read
+						this.state.readCache.set(cacheKey, sessionTurn, this.state.batchId);
 					}
 				}
 			}

--- a/.pi/extensions/agent-harness/lib/harness-state.test.ts
+++ b/.pi/extensions/agent-harness/lib/harness-state.test.ts
@@ -12,18 +12,27 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { createHarnessState } from "./harness-state.ts";
+import { createHarnessState, CACHE_TTL_MS } from "./harness-state.ts";
 import { CACHE_TTL_TURNS } from "./harness-rules.ts";
 
 // ── HarnessState ──
 
 describe("HarnessState", () => {
+	it("createHarnessState exports the factory function", () => {
+		assert.equal(typeof createHarnessState, "function");
+	});
+
+	it("CACHE_TTL_MS exports a positive number", () => {
+		assert.equal(typeof CACHE_TTL_MS, "number");
+		assert.ok(CACHE_TTL_MS > 0);
+	});
+
 	it("createHarnessState returns isolated state", () => {
 		const s1 = createHarnessState();
 		const s2 = createHarnessState();
 
 		s1.toolCallIndex = 5;
-		s1.readCache.set("k", "v", 0);
+		s1.readCache.set("k", 0);
 
 		assert.equal(s2.toolCallIndex, 0);
 		assert.equal(s2.readCache.get("k", 0), null);

--- a/.pi/extensions/agent-harness/lib/harness-state.ts
+++ b/.pi/extensions/agent-harness/lib/harness-state.ts
@@ -15,7 +15,6 @@
 // ── Types ──
 
 export interface CacheEntry {
-	content: string;
 	turn: number;
 	timestamp: number;
 	/** Batch ID for parallel call grouping (optional). */
@@ -39,7 +38,7 @@ export interface ReadCache {
 	/** Get cached entry. Returns null on miss or TTL expiry. */
 	get(key: string, currentTurn: number, currentBatchId?: number): CacheEntry | null;
 	/** Set cached entry with current turn and timestamp. */
-	set(key: string, content: string, turn: number, batchId?: number): void;
+	set(key: string, turn: number, batchId?: number): void;
 	/** Clear all cache entries. */
 	clear(): void;
 }
@@ -149,11 +148,10 @@ export function createHarnessState(): HarnessState {
 			return cacheMap.get(key, currentTurn);
 		},
 
-		set(key: string, content: string, turn: number, batchId?: number): void {
+		set(key: string, turn: number, batchId?: number): void {
 			cacheMap.set(
 				key,
 				{
-					content,
 					turn,
 					timestamp: Date.now(),
 					batchId,

--- a/.pi/extensions/agent-harness/test/index.test.ts
+++ b/.pi/extensions/agent-harness/test/index.test.ts
@@ -201,9 +201,12 @@ describe("AgentHarness — error retry blocking", () => {
 // ── Read cache ──
 
 describe("AgentHarness — read cache", () => {
-	it("first read passes through; second read same path+offset+limit blocks", () => {
+	it("first read passes through; second read next turn same path+offset+limit blocks", () => {
 		const h = new AgentHarness();
 		assert.equal(h.handleToolCall(makeEvent("read", { path: "a.ts" }), makeCtx()), null);
+
+		// Advance to next session turn so same-turn bypass doesn't apply
+		h.handleTurnStart();
 
 		const r = h.handleToolCall(makeEvent("read", { path: "a.ts" }), makeCtx());
 		assert.ok(r?.block);
@@ -235,9 +238,9 @@ describe("AgentHarness — read cache", () => {
 	it("cache miss after TTL expiry", () => {
 		const h = new AgentHarness();
 		h.handleToolCall(makeEvent("read", { path: "a.ts" }), makeCtx());
-		// Advance toolCallIndex past TTL
+		// Advance sessionTurn past TTL via turn boundaries
 		for (let i = 0; i < CACHE_TTL_TURNS; i++) {
-			h.handleToolCall(makeEvent("bash", { command: `echo ${i}` }), makeCtx());
+			h.handleTurnStart();
 		}
 		assert.equal(h.handleToolCall(makeEvent("read", { path: "a.ts" }), makeCtx()), null);
 	});
@@ -290,6 +293,8 @@ describe("AgentHarness — cache invalidation", () => {
 	it("non-modifying bash (ls) does NOT clear read cache", () => {
 		const h = new AgentHarness();
 		h.handleToolCall(makeEvent("read", { path: "a.ts" }), makeCtx());
+		// Advance turn so same-turn bypass doesn't apply
+		h.handleTurnStart();
 		h.handleToolCall(makeEvent("bash", { command: "ls -la" }), makeCtx());
 		assert.ok(h.handleToolCall(makeEvent("read", { path: "a.ts" }), makeCtx())?.block);
 	});
@@ -414,6 +419,7 @@ describe("AgentHarness — blocked calls not recorded", () => {
 	it("blocked cache read -> different path read passes (counter not inflated)", () => {
 		const h = new AgentHarness();
 		h.handleToolCall(makeEvent("read", { path: "test.ts" }), makeCtx());
+		h.handleTurnStart();
 		assert.ok(h.handleToolCall(makeEvent("read", { path: "test.ts" }), makeCtx())?.block);
 		assert.equal(h.handleToolCall(makeEvent("read", { path: "other.ts" }), makeCtx()), null);
 	});
@@ -644,13 +650,16 @@ describe("AgentHarness — extension entry point", () => {
 		});
 		assert.equal(r1, undefined, "first read passes");
 
+		// Advance to next session turn so same-turn bypass doesn't apply
+		await api.fire("turn_start", { type: "turn_start", turnIndex: 1, timestamp: Date.now() });
+
 		const r2 = await api.fire("tool_call", {
 			type: "tool_call",
 			toolCallId: "2",
 			toolName: "read",
 			input: { path: "test.ts" },
 		});
-		assert.ok(r2?.block, "second read same path blocks");
+		assert.ok(r2?.block, "second read next turn blocks");
 	});
 
 	it("bash grep through dispatch", async () => {
@@ -690,9 +699,10 @@ describe("AgentHarness — extension entry point", () => {
 // ── Phase 3: Mode-aware read-cache bypass ──
 
 describe("AgentHarness — mode-aware read cache", () => {
-	it("hasUI: true, cache hit → blocks with cached reason (existing behavior preserved)", () => {
+	it("hasUI: true, cache hit next turn → blocks with cached reason", () => {
 		const h = new AgentHarness();
 		h.handleToolCall(makeEvent("read", { path: "test.ts" }), makeCtx());
+		h.handleTurnStart();
 		const r = h.handleToolCall(makeEvent("read", { path: "test.ts" }), {
 			hasUI: true,
 		} as any);
@@ -709,9 +719,10 @@ describe("AgentHarness — mode-aware read cache", () => {
 		assert.equal(r, null);
 	});
 
-	it("hasUI: undefined, cache hit → blocks (backward compat)", () => {
+	it("hasUI: undefined, cache hit next turn → blocks (backward compat)", () => {
 		const h = new AgentHarness();
 		h.handleToolCall(makeEvent("read", { path: "test.ts" }), makeCtx());
+		h.handleTurnStart();
 		const r = h.handleToolCall(makeEvent("read", { path: "test.ts" }), {});
 		assert.ok(r?.block);
 	});
@@ -760,6 +771,7 @@ describe("AgentHarness — mode-aware read cache", () => {
 	it("hasUI on ctx, but ctx is empty object {} → blocks (backward compat via cast)", () => {
 		const h = new AgentHarness();
 		h.handleToolCall(makeEvent("read", { path: "test.ts" }), {});
+		h.handleTurnStart();
 		const r = h.handleToolCall(makeEvent("read", { path: "test.ts" }), {});
 		assert.ok(r?.block);
 	});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #838

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 8s | 66.8K | 45 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 26s | 39.8K | 15 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 26s | 38.2K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 8s | 56.5K | 26 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 14s | 42.3K | 19 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 14s | 51.0K | 23 | deepseek-v4-flash |

**Total:** 6 agents · 12m 36s · 294.5K tokens · 143 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/838
Closes #838