### PR TITLE
feat(#835): Bug: session-logger - local variable 'path' shadows node:path module import

### DIFF
--- a/.pi/extensions/session-logger/pipeline.ts
+++ b/.pi/extensions/session-logger/pipeline.ts
@@ -196,13 +196,13 @@ export class LoggerPipeline {
 		if (!this.gate.sessionEnabled) return;
 
 		const input = event.input as { path?: string; content?: { length?: number } };
-		const path = input.path ?? "";
+		const filePath = input.path ?? "";
 		if (event.toolName === "read") {
-			this.stats.recordFileModification("read", path);
+			this.stats.recordFileModification("read", filePath);
 		} else if (event.toolName === "write") {
-			this.stats.recordFileModification("write", path, input.content?.length ?? 0);
+			this.stats.recordFileModification("write", filePath, input.content?.length ?? 0);
 		} else if (event.toolName === "edit") {
-			this.stats.recordFileModification("edit", path);
+			this.stats.recordFileModification("edit", filePath);
 		}
 	}
 

--- a/.pi/extensions/session-logger/test/session-logger-pipeline.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-pipeline.test.mts
@@ -305,6 +305,34 @@ describe("LoggerPipeline onToolCall — file modification tracking", () => {
 		const snap = pipeline.getStats().getSnapshot();
 		assert.strictEqual(snap.fileModifications.length, 0);
 	});
+
+	it("input with no path field defaults to empty string", () => {
+		const gate = createGate(true);
+		const pipeline = new LoggerPipeline(gate);
+		pipeline.onToolCall({
+			type: "tool_call",
+			toolCallId: "c5",
+			toolName: "read",
+			input: {},
+		} as any);
+		const snap = pipeline.getStats().getSnapshot();
+		assert.strictEqual(snap.fileModifications.length, 1);
+		assert.strictEqual(snap.fileModifications[0].path, "");
+	});
+
+	it("input with path empty string works correctly", () => {
+		const gate = createGate(true);
+		const pipeline = new LoggerPipeline(gate);
+		pipeline.onToolCall({
+			type: "tool_call",
+			toolCallId: "c6",
+			toolName: "read",
+			input: { path: "" },
+		} as any);
+		const snap = pipeline.getStats().getSnapshot();
+		assert.strictEqual(snap.fileModifications.length, 1);
+		assert.strictEqual(snap.fileModifications[0].path, "");
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #835

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 52s | 34.0K | 24 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 9s | 8.9K | 1 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 32s | 13.3K | 9 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 2s | 21.4K | 15 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 47s | 18.3K | 11 | deepseek-v4-flash |

**Total:** 5 agents · 4m 24s · 95.9K tokens · 60 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/835
Closes #835