### PR TITLE
feat(#833): Bug: session-logger - ensureSymlink without error handling crashes session start

### DIFF
--- a/.pi/extensions/session-logger/pipeline.ts
+++ b/.pi/extensions/session-logger/pipeline.ts
@@ -30,10 +30,10 @@ export class LoggerPipeline {
 	private sessionName: string | undefined;
 	private mode: string | undefined;
 
-	constructor(gate: SessionLoggerGate) {
+	constructor(gate: SessionLoggerGate, files?: FileOps) {
 		this.gate = gate;
 		this.stats = createSessionStats();
-		this.files = createFileOps();
+		this.files = files ?? createFileOps();
 	}
 
 	/** Expose stats for testing / snapshot access. */
@@ -94,7 +94,14 @@ export class LoggerPipeline {
 		this.stats.seedStats(sm);
 
 		this.sessionsDir = path.resolve(sm.getCwd(), ".pi", "sessions");
-		await this.files.ensureSymlink(this.sessionFile!, this.sessionsDir);
+		try {
+			await this.files.ensureSymlink(this.sessionFile!, this.sessionsDir);
+		} catch (err) {
+			console.error(`[session-logger] Failed to create session symlink: ${(err as Error).message}`);
+			this.sessionFile = undefined;
+			this.sessionsDir = undefined;
+			return;
+		}
 
 		// Recovery: scan all .jsonl files in sessions dir for missing .md/.metadata.json.
 		// If session_shutdown didn't fire (crash, kill, race), we catch up now.

--- a/.pi/extensions/session-logger/test/session-logger-pipeline.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-pipeline.test.mts
@@ -9,8 +9,9 @@
  */
 
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import { LoggerPipeline, beginSession } from "../pipeline.ts";
+import type { FileOps } from "../files.ts";
 import type { SessionLoggerGate } from "../types.ts";
 
 // ---------------------------------------------------------------------------
@@ -408,5 +409,309 @@ describe("LoggerPipeline onSessionStart", () => {
 		});
 		assert.strictEqual(pipeline.getSessionName(), undefined);
 		assert.strictEqual(pipeline.getMode(), undefined);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// LoggerPipeline — onSessionStart ensureSymlink error handling
+// ---------------------------------------------------------------------------
+
+function createMockFileOps(
+	ensureSymlinkImpl?: (sessionFile: string, sessionsDir: string) => Promise<void>,
+): FileOps & { ensureSymlinkCalls: number } {
+	let calls = 0;
+	return {
+		ensureSymlink: async (sessionFile: string, sessionsDir: string) => {
+			calls++;
+			if (ensureSymlinkImpl) {
+				return ensureSymlinkImpl(sessionFile, sessionsDir);
+			}
+		},
+		ensureMdSymlink: async () => {},
+		ensureLatestMetadataSymlink: async () => {},
+		writeMetadata: async () => {},
+		writeSessionReport: async () => {},
+		get ensureSymlinkCalls() {
+			return calls;
+		},
+	};
+}
+
+function createSessionStartCtxWithFile(overrides?: {
+	sessionFile?: string;
+	cwd?: string;
+	entries?: any[];
+}): any {
+	const hasFile = "sessionFile" in (overrides ?? {});
+	return {
+		mode: "tui",
+		sessionManager: {
+			getSessionFile: () => (hasFile ? overrides!.sessionFile : "/tmp/.pi/session.jsonl"),
+			getCwd: () => overrides?.cwd ?? "/tmp",
+			getEntries: () => overrides?.entries ?? [],
+		},
+	};
+}
+
+describe("LoggerPipeline onSessionStart — ensureSymlink error handling", () => {
+	it("ensureSymlink succeeds — sessionFile and sessionsDir are set", async () => {
+		const gate = createGate(true);
+		const mockFiles = createMockFileOps(async () => {});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const ctx = createSessionStartCtxWithFile({
+			sessionFile: "/tmp/.pi/session.jsonl",
+			cwd: "/tmp",
+		});
+
+		await pipeline.onSessionStart({}, ctx);
+
+		assert.strictEqual(pipeline.getSessionFile(), "/tmp/.pi/session.jsonl");
+		assert.strictEqual(pipeline.getSessionsDir(), "/tmp/.pi/sessions");
+		assert.strictEqual(mockFiles.ensureSymlinkCalls, 1);
+	});
+
+	it("ensureSymlink throws EACCES — gracefully degrades", async () => {
+		const gate = createGate(true);
+		const e = new Error("EACCES: permission denied");
+		(e as NodeJS.ErrnoException).code = "EACCES";
+		const mockFiles = createMockFileOps(async () => {
+			throw e;
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+				cwd: "/tmp",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			assert.strictEqual(pipeline.getSessionFile(), undefined);
+			assert.strictEqual(pipeline.getSessionsDir(), undefined);
+			assert.strictEqual(mockFiles.ensureSymlinkCalls, 1);
+			assert.strictEqual(mockConsoleError.mock.calls.length, 1);
+			assert.ok(
+				(mockConsoleError.mock.calls[0].arguments[0] as string).includes("[session-logger]"),
+			);
+		} finally {
+			mockConsoleError.mock.restore();
+		}
+	});
+
+	it("ensureSymlink throws ENOSPC — gracefully degrades", async () => {
+		const gate = createGate(true);
+		const e = new Error("ENOSPC: no space left on device");
+		(e as NodeJS.ErrnoException).code = "ENOSPC";
+		const mockFiles = createMockFileOps(async () => {
+			throw e;
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+				cwd: "/tmp",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			assert.strictEqual(pipeline.getSessionFile(), undefined);
+			assert.strictEqual(pipeline.getSessionsDir(), undefined);
+			assert.strictEqual(mockFiles.ensureSymlinkCalls, 1);
+			assert.strictEqual(mockConsoleError.mock.calls.length, 1);
+		} finally {
+			mockConsoleError.mock.restore();
+		}
+	});
+
+	it("ensureSymlink throws EROFS — gracefully degrades", async () => {
+		const gate = createGate(true);
+		const e = new Error("EROFS: read-only file system");
+		(e as NodeJS.ErrnoException).code = "EROFS";
+		const mockFiles = createMockFileOps(async () => {
+			throw e;
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+				cwd: "/tmp",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			assert.strictEqual(pipeline.getSessionFile(), undefined);
+			assert.strictEqual(pipeline.getSessionsDir(), undefined);
+		} finally {
+			mockConsoleError.mock.restore();
+		}
+	});
+
+	it("ensureSymlink throws EIO — gracefully degrades", async () => {
+		const gate = createGate(true);
+		const e = new Error("EIO: input/output error");
+		(e as NodeJS.ErrnoException).code = "EIO";
+		const mockFiles = createMockFileOps(async () => {
+			throw e;
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+				cwd: "/tmp",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			assert.strictEqual(pipeline.getSessionFile(), undefined);
+			assert.strictEqual(pipeline.getSessionsDir(), undefined);
+		} finally {
+			mockConsoleError.mock.restore();
+		}
+	});
+
+	it("ensureSymlink throws generic Error — gracefully degrades", async () => {
+		const gate = createGate(true);
+		const mockFiles = createMockFileOps(async () => {
+			throw new Error("generic I/O failure");
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+				cwd: "/tmp",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			assert.strictEqual(pipeline.getSessionFile(), undefined);
+			assert.strictEqual(pipeline.getSessionsDir(), undefined);
+			assert.strictEqual(mockFiles.ensureSymlinkCalls, 1);
+			assert.strictEqual(mockConsoleError.mock.calls.length, 1);
+			assert.ok(
+				(mockConsoleError.mock.calls[0].arguments[0] as string).includes("generic I/O failure"),
+			);
+		} finally {
+			mockConsoleError.mock.restore();
+		}
+	});
+
+	it("sessionFile undefined — early return before ensureSymlink", async () => {
+		const gate = createGate(true);
+		const mockFiles = createMockFileOps(async () => {});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const ctx = createSessionStartCtxWithFile({
+			sessionFile: undefined,
+		});
+
+		await pipeline.onSessionStart({}, ctx);
+
+		assert.strictEqual(pipeline.getSessionFile(), undefined);
+		assert.strictEqual(pipeline.getSessionsDir(), undefined);
+		assert.strictEqual(mockFiles.ensureSymlinkCalls, 0, "ensureSymlink should NOT be called");
+	});
+
+	it("gate disabled — beginSession returns false, ensureSymlink NOT called", async () => {
+		const gate = createGate(false);
+		const mockFiles = createMockFileOps(async () => {});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const ctx = createSessionStartCtxWithFile({
+			sessionFile: "/tmp/.pi/session.jsonl",
+		});
+
+		await pipeline.onSessionStart({}, ctx);
+
+		assert.strictEqual(pipeline.getSessionFile(), undefined);
+		assert.strictEqual(mockFiles.ensureSymlinkCalls, 0, "ensureSymlink should NOT be called");
+	});
+
+	it("after ensureSymlink failure — downstream handlers still work as no-ops", async () => {
+		const gate = createGate(true);
+		const mockFiles = createMockFileOps(async () => {
+			throw new Error("EACCES: permission denied");
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		// Call onSessionStart — it will fail
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+				cwd: "/tmp",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			// After failure, sessionFile/sessionsDir are undefined
+			assert.strictEqual(pipeline.getSessionFile(), undefined);
+			assert.strictEqual(pipeline.getSessionsDir(), undefined);
+
+			// Downstream handlers should still not throw
+			pipeline.onSessionCompact();
+			pipeline.onModelSelect({ model: { provider: "openai", id: "gpt-4" } });
+			pipeline.onThinkingLevelSelect({ level: "high" });
+			pipeline.onTurnStart({ turnIndex: 0 });
+			pipeline.onTurnEnd();
+			pipeline.onMessageEnd({
+				message: { role: "assistant", usage: { input: 10, output: 5, totalTokens: 15 } },
+			});
+			pipeline.onToolExecutionStart({ toolCallId: "c1", toolName: "bash" });
+			pipeline.onToolExecutionEnd({
+				toolCallId: "c1",
+				result: { content: [{ type: "text", text: "ok" }] },
+				isError: false,
+			});
+			pipeline.onToolCall({
+				toolName: "read",
+				input: { path: "/tmp/test.txt" },
+			} as any);
+
+			// All should resolve without throwing (handlers are no-ops when sessionFile is undefined)
+			// Actually, the handlers gate on sessionEnabled, not sessionFile.
+			// But gate.sessionEnabled is still true — so handlers will execute.
+			// The stats should still be updated because gate is still enabled.
+			const snap = pipeline.getStats().getSnapshot();
+			assert.strictEqual(snap.compactionCount, 1);
+			assert.strictEqual(snap.modelChanges.length, 1);
+			assert.strictEqual(snap.toolExecutions.length, 1);
+		} finally {
+			mockConsoleError.mock.restore();
+		}
+	});
+
+	it("console.error includes session-logger prefix and error message", async () => {
+		const gate = createGate(true);
+		const mockFiles = createMockFileOps(async () => {
+			throw new Error("ENOSPC: disk full");
+		});
+		const pipeline = new LoggerPipeline(gate, mockFiles);
+
+		const mockConsoleError = mock.method(console, "error");
+		try {
+			const ctx = createSessionStartCtxWithFile({
+				sessionFile: "/tmp/.pi/session.jsonl",
+			});
+
+			await pipeline.onSessionStart({}, ctx);
+
+			assert.strictEqual(mockConsoleError.mock.calls.length, 1);
+			const msg = mockConsoleError.mock.calls[0].arguments[0] as string;
+			assert.ok(msg.includes("[session-logger]"), "should have session-logger prefix");
+			assert.ok(msg.includes("ENOSPC"), "should include error code");
+		} finally {
+			mockConsoleError.mock.restore();
+		}
 	});
 });

--- a/.pi/extensions/session-logger/test/session-logger-wiring.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-wiring.test.mts
@@ -243,7 +243,11 @@ describe("index.ts — session_shutdown trust gate", () => {
 
 describe("index.ts — named exports", () => {
 	it("createSessionLoggerGate is a function and returns gate with defaults", () => {
-		assert.strictEqual(typeof createSessionLoggerGate, "function", "createSessionLoggerGate should be a function");
+		assert.strictEqual(
+			typeof createSessionLoggerGate,
+			"function",
+			"createSessionLoggerGate should be a function",
+		);
 		const gate = createSessionLoggerGate();
 		assert.strictEqual(gate.enabledForNextSession, true);
 		assert.strictEqual(gate.sessionEnabled, true);
@@ -255,7 +259,11 @@ describe("index.ts — named exports", () => {
 	});
 
 	it("toggleSessionLoggerGate toggles and sets gate", () => {
-		assert.strictEqual(typeof toggleSessionLoggerGate, "function", "toggleSessionLoggerGate should be a function");
+		assert.strictEqual(
+			typeof toggleSessionLoggerGate,
+			"function",
+			"toggleSessionLoggerGate should be a function",
+		);
 		const gate = createSessionLoggerGate();
 		const result = toggleSessionLoggerGate(gate);
 		assert.strictEqual(result, false, "toggle should flip from true to false");
@@ -274,7 +282,11 @@ describe("index.ts — named exports", () => {
 	});
 
 	it("beginSessionLoggerSession is a function and copies enabledForNextSession", () => {
-		assert.strictEqual(typeof beginSessionLoggerSession, "function", "beginSessionLoggerSession should be a function");
+		assert.strictEqual(
+			typeof beginSessionLoggerSession,
+			"function",
+			"beginSessionLoggerSession should be a function",
+		);
 		const gate = createSessionLoggerGate();
 		const result = beginSessionLoggerSession(gate);
 		assert.strictEqual(result, true);
@@ -282,7 +294,11 @@ describe("index.ts — named exports", () => {
 	});
 
 	it("getSessionLoggerState returns sessionEnabled when gate is provided", () => {
-		assert.strictEqual(typeof getSessionLoggerState, "function", "getSessionLoggerState should be a function");
+		assert.strictEqual(
+			typeof getSessionLoggerState,
+			"function",
+			"getSessionLoggerState should be a function",
+		);
 		const gate = createSessionLoggerGate();
 		const state = getSessionLoggerState(gate);
 		assert.strictEqual(state, true);
@@ -299,6 +315,50 @@ describe("index.ts — named exports", () => {
 	});
 
 	it("generateMissingReports is a function (re-exported)", () => {
-		assert.strictEqual(typeof generateMissingReports, "function", "generateMissingReports should be a function");
+		assert.strictEqual(
+			typeof generateMissingReports,
+			"function",
+			"generateMissingReports should be a function",
+		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Wiring resilience — session_start handler should not propagate rejection
+// ---------------------------------------------------------------------------
+
+describe("index.ts — session_start handler resilience", () => {
+	it("handler resolves normally when pipeline handles errors internally", async () => {
+		const { pi, handlers } = createMockPi();
+		defaultExport(pi);
+
+		const handler = handlers.find((h) => h.event === "session_start")!;
+		const ctx = createSessionStartCtx({
+			sessionFile: "/tmp/.pi/session.jsonl",
+			cwd: "/tmp",
+		});
+
+		// After fix, pipeline.onSessionStart handles ensureSymlink errors internally
+		// so the handler should resolve without throwing
+		await assert.doesNotReject(async () => {
+			await handler.fn({}, ctx);
+		});
+	});
+
+	it("handler does not crash on session_start when pi.getSessionName is missing", async () => {
+		const { pi, handlers } = createMockPi({
+			getSessionName: undefined as unknown as () => string | undefined,
+		});
+		defaultExport(pi);
+
+		const handler = handlers.find((h) => h.event === "session_start")!;
+		const ctx = createSessionStartCtx({
+			sessionFile: "/tmp/.pi/session.jsonl",
+			cwd: "/tmp",
+		});
+
+		await assert.doesNotReject(async () => {
+			await handler.fn({}, ctx);
+		});
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #833

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 57s | 59.6K | 37 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 0s | 27.9K | 10 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 49s | 30.7K | 12 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 25s | 68.2K | 41 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 43s | 37.5K | 12 | deepseek-v4-flash |

**Total:** 5 agents · 11m 54s · 223.9K tokens · 112 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/833
Closes #833