### PR TITLE
feat(#830): Bug: lib - isBashSearch misses piped grep with multiple spaces or no space after pipe

### DIFF
--- a/.pi/extensions/lib/bash-query.test.ts
+++ b/.pi/extensions/lib/bash-query.test.ts
@@ -88,6 +88,32 @@ describe("isBashSearch", () => {
 		assert.strictEqual(isBashSearch("more file | grep foo"), true);
 	});
 
+	// ── Bug fix: pipe grep/rg with variant spacing ──
+
+	it("piped file→grep: cat file |  grep foo (two spaces after pipe) → true", () => {
+		assert.strictEqual(isBashSearch("cat file |  grep foo"), true);
+	});
+
+	it("piped file→grep: cat file |grep foo (no space after pipe) → true", () => {
+		assert.strictEqual(isBashSearch("cat file |grep foo"), true);
+	});
+
+	it("piped file→rg: cat file |  rg foo (two spaces after pipe) → true", () => {
+		assert.strictEqual(isBashSearch("cat file |  rg foo"), true);
+	});
+
+	it("piped file→rg: cat file |rg foo (no space after pipe) → true", () => {
+		assert.strictEqual(isBashSearch("cat file |rg foo"), true);
+	});
+
+	it("pipe grep word boundary: cat file | grepped → false (prefix match)", () => {
+		assert.strictEqual(isBashSearch("cat file | grepped"), false);
+	});
+
+	it("pipe rg word boundary: cat file | rgfoo → false (prefix match)", () => {
+		assert.strictEqual(isBashSearch("cat file | rgfoo"), false);
+	});
+
 	it("command-output pipe: git branch | grep feature → false", () => {
 		assert.strictEqual(isBashSearch("git branch -a | grep feature"), false);
 	});
@@ -206,6 +232,10 @@ describe("isBashSearchOrRead", () => {
 
 	it("piped file→grep: cat file | grep foo → true", () => {
 		assert.strictEqual(isBashSearchOrRead("cat file | grep foo"), true);
+	});
+
+	it("piped file→grep variant spacing: cat file |  grep foo → true (cross-check)", () => {
+		assert.strictEqual(isBashSearchOrRead("cat file |  grep foo"), true);
 	});
 
 	it("tail -f log | grep error → true (piped read→grep)", () => {

--- a/.pi/extensions/lib/bash-query.ts
+++ b/.pi/extensions/lib/bash-query.ts
@@ -64,7 +64,7 @@ export function isBashSearch(cmd: string): boolean {
 	// Piped file→grep: starts with file-read cmd and pipes to grep/rg
 	// Subsumes advisor.ts isPipedFileGrep()
 	for (const fileCmd of READ_CMDS) {
-		if (lower.startsWith(fileCmd + " ") && (lower.includes("| grep") || lower.includes("| rg"))) {
+		if (lower.startsWith(fileCmd + " ") && /\|\s*grep\b|\|\s*rg\b/.test(lower)) {
 			return true;
 		}
 	}

--- a/.pi/extensions/session-advice/test/session-advice-advisor.test.mts
+++ b/.pi/extensions/session-advice/test/session-advice-advisor.test.mts
@@ -8,6 +8,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { analyzeSession } from "../advisor.ts";
+import { detectTurnInefficiency } from "../waste-signals/turn-inefficiency.ts";
 import type { SessionData, SessionEntry } from "../advisor.ts";
 
 // ---------------------------------------------------------------------------
@@ -644,6 +645,33 @@ describe("detectTurnInefficiency — Phase 2: Expand legitimate discovery tools 
 		const signals = analyzeSession(data);
 		const inefficient = signals.filter((s) => s.signal === "turn-inefficiency");
 		assert.strictEqual(inefficient.length, 0, "multiple discovery tools prevent flagging");
+	});
+
+	it("detectTurnInefficiency is exported and callable — runtime cross-check", () => {
+		assert.ok(Array.isArray(detectTurnInefficiency(makeSession([]))), "should return array");
+		assert.strictEqual(
+			detectTurnInefficiency(makeSession([])).length,
+			0,
+			"empty session should produce no signals",
+		);
+	});
+
+	it("variant pipe spacing: 15× cat file |  grep foo → search/read-like, NOT discovery → flagged", () => {
+		// Integration test: isBashSearchOrRead must detect "|  grep" (two spaces after pipe)
+		// to correctly classify this as search/read-like (not discovery). If the bug persists,
+		// this would be treated as discovery and NOT flagged.
+		const entries: SessionEntry[] = [readEntry("/repo/file.ts", 0)];
+		for (let i = 0; i < 15; i++) {
+			entries.push(nonDiscoveryBashEntry("cat file |  grep foo", 1));
+		}
+		const data = makeSession(entries);
+		const signals = analyzeSession(data);
+		const inefficient = signals.filter((s) => s.signal === "turn-inefficiency");
+		assert.strictEqual(
+			inefficient.length,
+			1,
+			"variant pipe spacing should be search/read-like, not discovery → should flag",
+		);
 	});
 });
 

--- a/.pi/extensions/session-advice/waste-signals/turn-inefficiency.ts
+++ b/.pi/extensions/session-advice/waste-signals/turn-inefficiency.ts
@@ -28,10 +28,16 @@ function isBashSearchOrRead(cmd: string): boolean {
 	if (!cmd) return false;
 	const low = cmd.toLowerCase();
 	// Check piped grep/rg from file-reading commands only
-	if (/^(cat|head|tail|less|more)\s/.test(low) && (low.includes("| grep") || low.includes("| rg")))
-		return true;
+	if (/^(cat|head|tail|less|more)\s/.test(low) && /\|\s*grep\b|\|\s*rg\b/.test(low)) return true;
 	// Check file read commands
-	if (low.startsWith("cat ") || low.startsWith("head ") || low.startsWith("tail ")) return true;
+	if (
+		low.startsWith("cat ") ||
+		low.startsWith("head ") ||
+		low.startsWith("tail ") ||
+		low.startsWith("less ") ||
+		low.startsWith("more ")
+	)
+		return true;
 	// Check using rg/grep/find as primary command
 	if (low.startsWith("grep ") || low.startsWith("rg ") || low.startsWith("find ")) return true;
 	return false;


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #830

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 32s | 39.2K | 37 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 24s | 19.4K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 42s | 25.6K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 11s | 50.6K | 32 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 46s | 55.6K | 33 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 23s | 67.7K | 17 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 51s | 41.6K | 30 | deepseek-v4-flash |

**Total:** 7 agents · 16m 49s · 299.7K tokens · 175 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/830
Closes #830