### PR TITLE
feat(#817): supervisor: show model name, token breakdown, cache, and cost in agent result

### DIFF
--- a/.pi/extensions/supervisor/config/types.ts
+++ b/.pi/extensions/supervisor/config/types.ts
@@ -102,6 +102,22 @@ export interface AgentRunResult {
 	thinkingOutput?: string;
 	/** Whether budget (token/tool limit) was exceeded */
 	budgetExceeded?: boolean;
+
+	// ─── Per-agent usage breakdown ────────────────────────
+	/** Model identifier used for this agent run */
+	model?: string;
+	/** Input tokens consumed (from last assistant message usage) */
+	inputTokens?: number;
+	/** Output tokens produced (from last assistant message usage) */
+	outputTokens?: number;
+	/** Prompt cache read tokens */
+	cacheRead?: number;
+	/** Prompt cache write tokens */
+	cacheWrite?: number;
+	/** Monetary cost of the agent run */
+	cost?: number;
+	/** Number of LLM turns (assistant messages with usage) */
+	turnCount?: number;
 }
 
 // ─── AgentRunState: mutable state during agent execution ────────────
@@ -169,6 +185,22 @@ export interface SupervisorMessageDetails {
 	auditScore?: string;
 	/** Task prompt given to the agent (displayed in expanded view) */
 	taskPrompt?: string;
+
+	// ─── Per-agent usage breakdown ────────────────────────
+	/** Model identifier used for this agent run */
+	model?: string;
+	/** Input tokens consumed (from last assistant message usage) */
+	inputTokens?: number;
+	/** Output tokens produced (from last assistant message usage) */
+	outputTokens?: number;
+	/** Prompt cache read tokens */
+	cacheRead?: number;
+	/** Prompt cache write tokens */
+	cacheWrite?: number;
+	/** Monetary cost of the agent run */
+	cost?: number;
+	/** Number of LLM turns (assistant messages with usage) */
+	turnCount?: number;
 }
 
 // ─── Dependency gate types ─────────────────────────────────────────

--- a/.pi/extensions/supervisor/pipeline/handler.ts
+++ b/.pi/extensions/supervisor/pipeline/handler.ts
@@ -928,6 +928,13 @@ export async function handleSupervisorCommand(
 					summaryLine: result.summaryLine,
 					thinkingOutput: result.thinkingOutput,
 					taskPrompt: task,
+					model: agent.config.model,
+					inputTokens: result.inputTokens,
+					outputTokens: result.outputTokens,
+					cacheRead: result.cacheRead,
+					cacheWrite: result.cacheWrite,
+					cost: result.cost,
+					turnCount: result.turnCount,
 				},
 				auditInfo ? `${auditInfo.score.passing}/${auditInfo.score.total}` : undefined,
 			);

--- a/.pi/extensions/supervisor/pipeline/notifications.ts
+++ b/.pi/extensions/supervisor/pipeline/notifications.ts
@@ -130,6 +130,13 @@ export function sendAgentResultMessage(
 		output: string;
 		thinkingOutput?: string;
 		taskPrompt?: string;
+		model?: string;
+		inputTokens?: number;
+		outputTokens?: number;
+		cacheRead?: number;
+		cacheWrite?: number;
+		cost?: number;
+		turnCount?: number;
 	},
 	auditScore?: string,
 ): void {
@@ -149,6 +156,13 @@ export function sendAgentResultMessage(
 			hasThinking: !!result.thinkingOutput,
 			auditScore,
 			taskPrompt: result.taskPrompt,
+			model: result.model,
+			inputTokens: result.inputTokens,
+			outputTokens: result.outputTokens,
+			cacheRead: result.cacheRead,
+			cacheWrite: result.cacheWrite,
+			cost: result.cost,
+			turnCount: result.turnCount,
 		} satisfies SupervisorMessageDetails,
 	});
 }

--- a/.pi/extensions/supervisor/session/message-renderer.ts
+++ b/.pi/extensions/supervisor/session/message-renderer.ts
@@ -42,15 +42,73 @@ export function createMessageRenderer(pi: ExtensionAPI) {
 			),
 		);
 
-		// Stats line: tools, tokens, duration
-		const statsParts: string[] = [];
-		if (details.toolCount > 0)
-			statsParts.push(`${details.toolCount} tool${details.toolCount === 1 ? "" : "s"}`);
-		if (details.tokenCount > 0) statsParts.push(`${formatTokens(details.tokenCount)} tokens`);
-		if (details.durationMs > 0) statsParts.push(formatDuration(details.durationMs));
-		if (statsParts.length > 0) {
-			c.addChild(new Spacer(1));
-			c.addChild(new Text(fit(theme.fg("dim", statsParts.join(" · "))), 1, 0));
+		// Stats line: model, token breakdown, cache, cost, tools, duration
+		const hasNewFields =
+			details.model !== undefined ||
+			details.inputTokens !== undefined ||
+			details.outputTokens !== undefined ||
+			details.cacheRead !== undefined ||
+			details.cacheWrite !== undefined ||
+			details.cost !== undefined;
+
+		if (hasNewFields) {
+			// New format with per-agent usage breakdown
+			const statsParts: string[] = [];
+
+			// Model name (shortened: last segment after '/')
+			if (details.model) {
+				const shortModel = details.model.split("/").pop() || details.model;
+				statsParts.push(`model: ${shortModel}`);
+			}
+
+			// Input/output token breakdown (↑N ↓N)
+			// Only show when at least one is non-zero (omit zero noise)
+			const hasInput = details.inputTokens !== undefined && details.inputTokens > 0;
+			const hasOutput = details.outputTokens !== undefined && details.outputTokens > 0;
+			if (hasInput || hasOutput) {
+				const inStr = hasInput ? formatTokens(details.inputTokens!) : "0";
+				const outStr = hasOutput ? formatTokens(details.outputTokens!) : "0";
+				statsParts.push(`↑${inStr} ↓${outStr}`);
+			}
+
+			// Cache read/write (R/W)
+			if (details.cacheRead !== undefined && details.cacheRead > 0) {
+				statsParts.push(`R${formatTokens(details.cacheRead)}`);
+			}
+			if (details.cacheWrite !== undefined && details.cacheWrite > 0) {
+				statsParts.push(`W${formatTokens(details.cacheWrite)}`);
+			}
+
+			// Cost ($N.NNNN) — omit when zero
+			if (details.cost !== undefined && details.cost > 0) {
+				statsParts.push(`$${details.cost.toFixed(4)}`);
+			}
+
+			// Tools
+			if (details.toolCount > 0) {
+				statsParts.push(`${details.toolCount} tool${details.toolCount === 1 ? "" : "s"}`);
+			}
+
+			// Duration (always shown when available)
+			if (details.durationMs > 0) {
+				statsParts.push(formatDuration(details.durationMs));
+			}
+
+			if (statsParts.length > 0) {
+				c.addChild(new Spacer(1));
+				c.addChild(new Text(fit(theme.fg("dim", statsParts.join(" · "))), 1, 0));
+			}
+		} else {
+			// Old format (backward compat) — tools, tokens, duration
+			const statsParts: string[] = [];
+			if (details.toolCount > 0)
+				statsParts.push(`${details.toolCount} tool${details.toolCount === 1 ? "" : "s"}`);
+			if (details.tokenCount > 0) statsParts.push(`${formatTokens(details.tokenCount)} tokens`);
+			if (details.durationMs > 0) statsParts.push(formatDuration(details.durationMs));
+			if (statsParts.length > 0) {
+				c.addChild(new Spacer(1));
+				c.addChild(new Text(fit(theme.fg("dim", statsParts.join(" · "))), 1, 0));
+			}
 		}
 
 		// Audit score (confidence tracking)

--- a/.pi/extensions/supervisor/session/result.ts
+++ b/.pi/extensions/supervisor/session/result.ts
@@ -151,6 +151,13 @@ export function buildAgentRunResult(
 	// messages produces O(N²/2) overcount — root cause of 28M token report
 	// for moderate refactor session (GH #314).
 	let tokenCount = state.tokenCount;
+
+	// Per-agent usage breakdown extraction
+	let inputTokens: number | undefined;
+	let outputTokens: number | undefined;
+	let cost: number | undefined;
+	let turnCount: number | undefined;
+
 	if (Array.isArray(messages) && messages.length > 0) {
 		const lastAsstMsg = [...messages].reverse().find((m) => m && m.role === "assistant" && m.usage);
 		if (lastAsstMsg?.usage) {
@@ -159,7 +166,23 @@ export function buildAgentRunResult(
 			if (typeof lastTotal === "number" && !Number.isNaN(lastTotal) && lastTotal > 0) {
 				tokenCount = Math.max(state.tokenCount, lastTotal);
 			}
+			// Extract token breakdown
+			if (typeof u.input === "number" && !Number.isNaN(u.input)) inputTokens = u.input;
+			if (typeof u.output === "number" && !Number.isNaN(u.output)) outputTokens = u.output;
+			// Extract cost from usage.cost.total
+			if (u.cost && typeof u.cost.total === "number") cost = u.cost.total;
 		}
+
+		// Turn count: count assistant messages with usage.input > 0
+		turnCount = messages.filter(
+			(m) =>
+				m &&
+				m.role === "assistant" &&
+				m.usage &&
+				typeof m.usage.input === "number" &&
+				m.usage.input > 0,
+		).length;
+		if (turnCount === 0) turnCount = undefined;
 	}
 
 	return {
@@ -175,5 +198,12 @@ export function buildAgentRunResult(
 		errorOutput: "",
 		thinkingOutput,
 		budgetExceeded: state.budgetExceeded || undefined,
+		// Per-agent usage breakdown
+		inputTokens,
+		outputTokens,
+		cacheRead: state.cacheRead,
+		cacheWrite: state.cacheWrite,
+		cost,
+		turnCount,
 	};
 }

--- a/.pi/extensions/supervisor/test/message-renderer.test.mts
+++ b/.pi/extensions/supervisor/test/message-renderer.test.mts
@@ -489,6 +489,212 @@ describe("edge cases and error handling", () => {
 	});
 });
 
+// ─── Phase 3b: Rich stats line ───────────────────────────────────
+
+describe("rich stats line (new format with per-agent breakdown)", () => {
+	before(() => {
+		initTheme();
+	});
+
+	it("full stats line rendered format", () => {
+		const details = makeDetails({
+			model: "claude-sonnet-4-5",
+			inputTokens: 1200,
+			outputTokens: 8500,
+			cacheRead: 500,
+			cacheWrite: 200,
+			cost: 0.0234,
+			toolCount: 3,
+			durationMs: 45000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find(
+			(l) => l.includes("model:") && l.includes("↑") && l.includes("↓") && l.includes("$"),
+		);
+		assert.ok(statsLine, `expected full stats line, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("model: claude-sonnet-4-5"), "should show model");
+		assert.ok(
+			statsLine!.includes("↑1.2K") || statsLine!.includes("↑1,200"),
+			"should show input tokens",
+		);
+		assert.ok(
+			statsLine!.includes("↓8.5K") || statsLine!.includes("↓8,500"),
+			"should show output tokens",
+		);
+		assert.ok(statsLine!.includes("R500"), "should show cache read");
+		assert.ok(statsLine!.includes("W200"), "should show cache write");
+		assert.ok(statsLine!.includes("$0.0234"), "should show cost");
+		assert.ok(statsLine!.includes("3 tools"), "should show tool count");
+		assert.ok(statsLine!.includes("45s"), "should show duration");
+	});
+
+	it("model name shortened: last segment after /", () => {
+		const details = makeDetails({
+			model: "anthropic/claude-sonnet-4-20250514",
+			durationMs: 5000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("model:"));
+		assert.ok(statsLine, `expected model in line, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("claude-sonnet-4-20250514"), "should use short model name");
+		assert.ok(!statsLine!.includes("anthropic"), "should NOT include full path");
+	});
+
+	it("no model → stats line starts with ↑ or tools or duration (no model prefix)", () => {
+		const details = makeDetails({
+			inputTokens: 500,
+			outputTokens: 1000,
+			durationMs: 10000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("↑"));
+		assert.ok(statsLine, `expected stats line with ↑, got: ${JSON.stringify(lines)}`);
+		assert.ok(!statsLine!.startsWith("model:"), "should NOT start with model:");
+	});
+
+	it("no input/output tokens → no ↑N ↓N segment", () => {
+		const details = makeDetails({
+			model: "test-model",
+			cost: 0.01,
+			durationMs: 5000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("$"));
+		assert.ok(statsLine, `expected stats line, got: ${JSON.stringify(lines)}`);
+		assert.ok(!statsLine!.includes("↑"), "should NOT have ↑↓ segment");
+		assert.ok(statsLine!.includes("model: test-model"), "should have model");
+	});
+
+	it("no cacheRead → no RN; no cacheWrite → no WN", () => {
+		const details = makeDetails({
+			model: "m",
+			inputTokens: 100,
+			outputTokens: 200,
+			durationMs: 3000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("↑100"));
+		assert.ok(statsLine, `expected stats line, got: ${JSON.stringify(lines)}`);
+		assert.ok(!statsLine!.includes("R"), "should NOT have cache read");
+		assert.ok(!statsLine!.includes("W"), "should NOT have cache write");
+	});
+
+	it("cost at 0 → omitted (no $0.0000)", () => {
+		const details = makeDetails({
+			model: "m",
+			cost: 0,
+			durationMs: 5000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("model:"));
+		assert.ok(statsLine, `expected stats line, got: ${JSON.stringify(lines)}`);
+		assert.ok(!statsLine!.includes("$"), "should NOT show $0.0000");
+	});
+
+	it("cost defined non-zero → $0.0234 format", () => {
+		const details = makeDetails({
+			model: "m",
+			cost: 0.0234,
+			durationMs: 5000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("$"));
+		assert.ok(statsLine, `expected cost line, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("$0.0234"), `should format cost as $0.0234, got: ${statsLine}`);
+	});
+
+	it("input/output use formatTokens (1.2K, 8.5M, 500)", () => {
+		const details = makeDetails({
+			model: "m",
+			inputTokens: 1200,
+			outputTokens: 8500000,
+			cacheRead: 500,
+			cacheWrite: 1200,
+			durationMs: 5000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("↑") || l.includes("model:"));
+		assert.ok(statsLine, `expected stats line, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("↑1.2K"), `expected 1.2K format, got: ${statsLine}`);
+		assert.ok(statsLine!.includes("↓8.5M"), `expected 8.5M format, got: ${statsLine}`);
+		assert.ok(statsLine!.includes("R500"), `expected R500, got: ${statsLine}`);
+		assert.ok(statsLine!.includes("W1.2K"), `expected W1.2K, got: ${statsLine}`);
+	});
+
+	it("backward compat: old details without new fields → old stats line", () => {
+		const details = makeDetails({
+			toolCount: 3,
+			tokenCount: 12500,
+			durationMs: 45000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find(
+			(l) => l.includes("tools") && l.includes("tokens") && l.includes("s"),
+		);
+		assert.ok(statsLine, `expected old-format stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("3 tools"), "should show tools");
+		assert.ok(statsLine!.includes("12.5K tokens"), "should show tokens");
+		assert.ok(statsLine!.includes("45s"), "should show duration");
+	});
+
+	it("backward compat: old details with partial new fields → no crash", () => {
+		const details = makeDetails({
+			model: "claude-sonnet-4-5",
+			durationMs: 30000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("model:"));
+		assert.ok(statsLine, `expected model in stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("model: claude-sonnet-4-5"), "should show model");
+		assert.ok(statsLine!.includes("30s"), "should show duration");
+	});
+
+	it("all fields zero → shows only model + duration", () => {
+		const details = makeDetails({
+			model: "my-model",
+			toolCount: 0,
+			tokenCount: 0,
+			durationMs: 10000,
+			inputTokens: 0,
+			outputTokens: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			cost: 0,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("model: my-model"));
+		assert.ok(statsLine, `expected model+duration, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("10s"), "should show duration");
+		assert.ok(!statsLine!.includes("↑"), "should NOT show ↑↓ for zeros");
+		assert.ok(!statsLine!.includes("R"), "should NOT show cache read for zeros");
+		assert.ok(!statsLine!.includes("W"), "should NOT show cache write for zeros");
+		assert.ok(!statsLine!.includes("$"), "should NOT show cost for zeros");
+	});
+
+	it("all fields zero + no model → shows only duration", () => {
+		const details = makeDetails({
+			toolCount: 0,
+			tokenCount: 0,
+			durationMs: 10000,
+		});
+		const c = renderMessage(details, undefined, false) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("10s"));
+		assert.ok(statsLine, `expected duration only, got: ${JSON.stringify(lines)}`);
+	});
+});
+
 // ─── Phase 4: Summary renderer regression ───────────────────────
 
 describe("summary renderer (createSummaryRenderer) — no regressions", () => {

--- a/.pi/extensions/supervisor/test/session-result.test.mts
+++ b/.pi/extensions/supervisor/test/session-result.test.mts
@@ -201,6 +201,199 @@ describe("buildRawOutputFromMessages — truncation (Phase 4)", () => {
 	});
 });
 
+// ─── Helpers for breakdown extraction tests ────────────────────────
+
+function makeUsage(
+	input?: number,
+	output?: number,
+	cacheRead?: number,
+	cacheWrite?: number,
+	cost?: number,
+	totalTokens?: number,
+): Record<string, unknown> | undefined {
+	const usage: Record<string, unknown> = {};
+	if (input !== undefined) usage.input = input;
+	if (output !== undefined) usage.output = output;
+	if (cacheRead !== undefined) usage.cacheRead = cacheRead;
+	if (cacheWrite !== undefined) usage.cacheWrite = cacheWrite;
+	if (cost !== undefined) usage.cost = { total: cost };
+	if (totalTokens !== undefined) usage.totalTokens = totalTokens;
+	return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
+function makeMessage(
+	role: string,
+	contentBlocks?: Record<string, unknown>[],
+	usage?: Record<string, unknown>,
+): Record<string, unknown> {
+	const msg: Record<string, unknown> = {
+		role,
+		content: contentBlocks || [],
+	};
+	if (usage) msg.usage = usage;
+	return msg;
+}
+
+// ─── buildAgentRunResult — breakdown extraction (Phase 2) ────────
+
+describe("buildAgentRunResult — breakdown extraction", () => {
+	it("full extraction: last assistant message has all usage fields", () => {
+		const state = createState({
+			cacheRead: 500,
+			cacheWrite: 200,
+			tokenCount: 10001,
+		});
+		const messages = [
+			makeMessage("user", [makeTextBlock("hello")]),
+			makeMessage(
+				"assistant",
+				[makeTextBlock("response")],
+				makeUsage(1234, 8567, 500, 200, 0.0234, 10001),
+			),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 45000, messages);
+		assert.equal(result.inputTokens, 1234);
+		assert.equal(result.outputTokens, 8567);
+		assert.equal(result.cacheRead, 500);
+		assert.equal(result.cacheWrite, 200);
+		assert.equal(result.cost, 0.0234);
+		assert.equal(result.turnCount, 1);
+	});
+
+	it("partial usage: only input and output present, no cache/cost", () => {
+		const state = createState({ tokenCount: 5000 });
+		const messages = [
+			makeMessage("user", [makeTextBlock("hello")]),
+			makeMessage("assistant", [makeTextBlock("response")], makeUsage(1000, 2000)),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 10000, messages);
+		assert.equal(result.inputTokens, 1000);
+		assert.equal(result.outputTokens, 2000);
+		assert.equal(result.cacheRead, undefined);
+		assert.equal(result.cacheWrite, undefined);
+		assert.equal(result.cost, undefined);
+		assert.equal(result.turnCount, 1);
+	});
+
+	it("no usage on any message — all new fields undefined", () => {
+		const state = createState({ tokenCount: 500 });
+		const messages = [
+			makeMessage("user", [makeTextBlock("hello")]),
+			makeMessage("assistant", [makeTextBlock("response")]),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 5000, messages);
+		assert.equal(result.inputTokens, undefined);
+		assert.equal(result.outputTokens, undefined);
+		assert.equal(result.cacheRead, undefined);
+		assert.equal(result.cacheWrite, undefined);
+		assert.equal(result.cost, undefined);
+		assert.equal(result.turnCount, undefined);
+		assert.equal(result.tokenCount, 500); // fallback to state.tokenCount
+	});
+
+	it("empty messages array — all new fields undefined", () => {
+		const state = createState({ tokenCount: 0 });
+		const result = buildAgentRunResult(state, "developer", true, 1000, []);
+		assert.equal(result.inputTokens, undefined);
+		assert.equal(result.outputTokens, undefined);
+		assert.equal(result.cost, undefined);
+		assert.equal(result.turnCount, undefined);
+	});
+
+	it("null/undefined messages array — all new fields undefined", () => {
+		const state = createState({ tokenCount: 0 });
+		const result1 = buildAgentRunResult(state, "developer", true, 1000, null as any);
+		assert.equal(result1.inputTokens, undefined);
+		assert.equal(result1.turnCount, undefined);
+
+		const result2 = buildAgentRunResult(state, "developer", true, 1000, undefined as any);
+		assert.equal(result2.inputTokens, undefined);
+		assert.equal(result2.turnCount, undefined);
+	});
+
+	it("multiple assistant messages — last with usage wins", () => {
+		const state = createState({ cacheRead: 300, cacheWrite: 100, tokenCount: 9999 });
+		const messages = [
+			makeMessage("user", [makeTextBlock("q1")]),
+			makeMessage(
+				"assistant",
+				[makeTextBlock("a1")],
+				makeUsage(100, 200, undefined, undefined, 0.001, 300),
+			),
+			makeMessage("user", [makeTextBlock("q2")]),
+			makeMessage(
+				"assistant",
+				[makeTextBlock("a2")],
+				makeUsage(2000, 4000, undefined, undefined, 0.005, 6000),
+			),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 30000, messages);
+		// Last assistant message usage wins
+		assert.equal(result.inputTokens, 2000);
+		assert.equal(result.outputTokens, 4000);
+		assert.equal(result.cost, 0.005);
+		// Turn count counts all assistant messages with usage.input > 0
+		assert.equal(result.turnCount, 2);
+	});
+
+	it("assistant messages but none with usage — turnCount is 0 (undefined)", () => {
+		const state = createState({ tokenCount: 0 });
+		const messages = [
+			makeMessage("user", [makeTextBlock("q")]),
+			makeMessage("assistant", [makeTextBlock("a")]),
+			makeMessage("assistant", [makeTextBlock("a2")]),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 5000, messages);
+		assert.equal(result.inputTokens, undefined);
+		assert.equal(result.outputTokens, undefined);
+		assert.equal(result.turnCount, undefined);
+	});
+
+	it("usage.cost.total is 0 — cost set to 0", () => {
+		const state = createState({ tokenCount: 100 });
+		const messages = [
+			makeMessage(
+				"assistant",
+				[makeTextBlock("response")],
+				makeUsage(50, 50, undefined, undefined, 0, 100),
+			),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 1000, messages);
+		assert.equal(result.cost, 0);
+	});
+
+	it("usage.cost missing but input/output present — cost undefined", () => {
+		const state = createState({ tokenCount: 100 });
+		const messages = [makeMessage("assistant", [makeTextBlock("response")], makeUsage(50, 50))];
+		const result = buildAgentRunResult(state, "developer", true, 1000, messages);
+		assert.equal(result.inputTokens, 50);
+		assert.equal(result.outputTokens, 50);
+		assert.equal(result.cost, undefined);
+	});
+
+	it("cacheRead/cacheWrite come from state, not from raw messages", () => {
+		const state = createState({ cacheRead: 999, cacheWrite: 888, tokenCount: 500 });
+		const messages = [
+			makeMessage("assistant", [makeTextBlock("hi")], makeUsage(100, 200, 111, 222, 0.01, 300)),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 5000, messages);
+		// Cache values come from state, not from usage
+		assert.equal(result.cacheRead, 999);
+		assert.equal(result.cacheWrite, 888);
+	});
+
+	it("tokenCount stable: existing fallback logic unchanged when new fields absent", () => {
+		const state = createState({ tokenCount: 500 });
+		const messages = [
+			makeMessage("user", [makeTextBlock("q")]),
+			makeMessage("assistant", [makeTextBlock("a")]),
+		];
+		const result = buildAgentRunResult(state, "developer", true, 5000, messages);
+		assert.equal(result.tokenCount, 500);
+		assert.equal(result.inputTokens, undefined);
+	});
+});
+
 // ─── buildAgentRunResult — budgetExceeded propagation ─────────────
 
 describe("buildAgentRunResult — budgetExceeded propagation", () => {

--- a/.pi/prompts/requirement/requirement:issue-cutter.md
+++ b/.pi/prompts/requirement/requirement:issue-cutter.md
@@ -288,11 +288,11 @@ CHILD_ID=$(gh api graphql \
 echo "Child ID: $CHILD_ID"
 ```
 
-**Step 5: Link the child to the epic.**
+**Step 5: Link child as sub-issue via GraphQL (this creates the real parent-child relationship, NOT a comment or body mention).**
 
 ```bash
 EPIC_ID=$(cat tmp/epic_id.txt)
-gh api graphql \
+RESULT=$(gh api graphql \
   -F issueId="$EPIC_ID" \
   -F subIssueId="$CHILD_ID" \
   -f query='
@@ -301,8 +301,17 @@ gh api graphql \
         issue { number }
         subIssue { number }
       }
-    }'
-echo "Linked #$CHILD_NUM as sub-issue of Epic #$1"
+    }' --jq '.')
+
+# Verify no GraphQL errors
+if echo "$RESULT" | jq -e '.errors' > /dev/null 2>&1; then
+  echo "ERROR: addSubIssue mutation failed"
+  echo "$RESULT" | jq '.errors'
+  echo "Sub-issue #$CHILD_NUM was CREATED but NOT linked as child of Epic #$1."
+  echo "Stopping: remaining sub-issues will NOT be created."
+  exit 1
+fi
+echo "Sub-issue #$CHILD_NUM linked as child of Epic #$1 (GraphQL parent-child, not comment)"
 ```
 
 **Step 6: Set dependency chain**
@@ -356,7 +365,7 @@ echo "$CHILD_NUM" > tmp/sub<N>_num.txt
 #### 6c — Print summary
 
 ```
-✅ Sub-issues created and linked under Epic #$1:
+✅ Sub-issues created and linked AS CHILDREN (sub-issues, not comments) under Epic #$1:
   #101  [database]  (1) Add recipe_tag column to database schema
   #102  [backend]   (2) Implement tag service and API endpoint  🔗 blocked by #101
   #103  [frontend]  (3) Build tag filter UI component           🔗 blocked by #102
@@ -392,6 +401,7 @@ Every sub-issue body follows this exact format:
 
 _Why this piece exists and how it relates to the parent epic._
 Parent epic: #$1
+Linked: Sub-issue (GraphQL `addSubIssue`). Not just body text or comment — Step 6b creates real parent-child relationship on GitHub.
 Implementation order: <N> of <total>
 
 ## User Story


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #817

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 45s | 85.2K | 47 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 2m 3s | 83.6K | 35 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 49s | 55.8K | 30 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 20s | 88.1K | 33 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 54s | 69.6K | 30 | deepseek-v4-flash |

**Total:** 5 agents · 13m 51s · 382.4K tokens · 175 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/817
Closes #817