### PR TITLE
feat(#827): Bug: check-extensions - findImportFindings misses mixed default+named imports

### DIFF
--- a/.pi/extensions/check-extensions/ast-scanner.ts
+++ b/.pi/extensions/check-extensions/ast-scanner.ts
@@ -303,6 +303,53 @@ function findImportFindings(filePath: string, content: string, extName: string):
 			continue;
 		}
 
+		// Check for mixed default + named imports (Pattern 4)
+		// e.g. import pi, { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+		//      import * as pi, { ExtensionAPI, on } from "..."
+		const mixedImportMatch = trimmed.match(
+			/^import\s+(?:\*\s+as\s+)?(\w+)\s*,\s*\{\s*([^}]+)\s*\}\s+from\s+["']([^"']+)["']/,
+		);
+		if (mixedImportMatch && piModulePattern.test(mixedImportMatch[3]!)) {
+			const defaultName = mixedImportMatch[1]!;
+			const namedList = mixedImportMatch[2]!.trim();
+			// Emit default import finding (like Pattern 3)
+			if (defaultName === "pi" || defaultName.toLowerCase().includes("pi")) {
+				findings.push({
+					extensionName: extName,
+					file: filePath,
+					apiName: "pi",
+					line: i + 1,
+					column: 1,
+					lineContent: trimmed,
+					matchContext: "import-value",
+					callArgs: [],
+					changelogVersion: "",
+					isBreaking: false,
+					category: "",
+				});
+			}
+			// Emit named import findings (like Pattern 2)
+			const trimmedNames = namedList.split(",").map((name) => name.trim());
+			for (const name of trimmedNames) {
+				if (PI_APIS.has(name)) {
+					findings.push({
+						extensionName: extName,
+						file: filePath,
+						apiName: `pi.${name}`,
+						line: i + 1,
+						column: 1,
+						lineContent: trimmed,
+						matchContext: "import-value",
+						callArgs: [],
+						changelogVersion: "",
+						isBreaking: false,
+						category: "",
+					});
+				}
+			}
+			continue;
+		}
+
 		// Check for default/namespace import from pi
 		const defaultImportMatch = trimmed.match(
 			/^import\s+(?:\*\s+as\s+)?(\w+)\s+from\s+["']([^"']+)["']/,

--- a/.pi/extensions/check-extensions/test/check-extensions.test.mts
+++ b/.pi/extensions/check-extensions/test/check-extensions.test.mts
@@ -1454,6 +1454,386 @@ describe("ast-scanner", () => {
 		);
 	});
 
+	// ═══════════════════════════════════════════════════════════════
+	// Bug fix: mixed default + named imports (Pattern 4)
+	// ═══════════════════════════════════════════════════════════════
+
+	it("Pattern 4: mixed import 'pi, { on }' produces 2 findings (default + named)", async () => {
+		const extDir = join(tmpDir, "mixed-ext-1");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import pi, { on } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			2,
+			`Expected 2 import-value findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi", "pi.on"]);
+	});
+
+	it("Pattern 4: mixed import 'pi, { ExtensionAPI }' produces 1 finding (default only, not in PI_APIS)", async () => {
+		const extDir = join(tmpDir, "mixed-ext-2");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import pi, { ExtensionAPI } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			1,
+			`Expected 1 import-value finding, got ${valueImports.length}`,
+		);
+		assert.strictEqual(valueImports[0]!.apiName, "pi");
+	});
+
+	it("Pattern 4: 'import * as pi, { on }' produces 2 findings", async () => {
+		const extDir = join(tmpDir, "mixed-ext-3");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import * as pi, { on } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			2,
+			`Expected 2 import-value findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi", "pi.on"]);
+	});
+
+	it("Pattern 4: 'import pi, { on, exec }' produces 3 findings", async () => {
+		const extDir = join(tmpDir, "mixed-ext-4");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import pi, { on, exec } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on", "pi.exec"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			3,
+			`Expected 3 import-value findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi", "pi.exec", "pi.on"]);
+	});
+
+	it("Pattern 4: 'import pi, { on } from \"pi\"' produces 2 findings (pi source)", async () => {
+		const extDir = join(tmpDir, "mixed-ext-5");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(join(extDir, "index.ts"), `import pi, { on } from "pi";\n`);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			2,
+			`Expected 2 import-value findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi", "pi.on"]);
+	});
+
+	// Phase 2: non-pi module and no-pi-name edge cases
+
+	it("Pattern 4: non-pi module 'import fs, { readFile } from \"node:fs\"' produces 0 findings", async () => {
+		const extDir = join(tmpDir, "mixed-ext-6");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(join(extDir, "index.ts"), `import fs, { readFile } from "node:fs";\n`);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			0,
+			`Expected 0 import-value findings, got ${valueImports.length}`,
+		);
+	});
+
+	it("Pattern 4: 'import something, { on } from \"@earendil-works/pi-coding-agent\"' produces 1 finding (pi.on only)", async () => {
+		const extDir = join(tmpDir, "mixed-ext-7");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import something, { on } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			1,
+			`Expected 1 import-value finding, got ${valueImports.length}`,
+		);
+		assert.strictEqual(valueImports[0]!.apiName, "pi.on");
+	});
+
+	it("Pattern 4: empty named import 'pi, {}' produces 1 finding (default only)", async () => {
+		const extDir = join(tmpDir, "mixed-ext-8");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import pi, { } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			1,
+			`Expected 1 import-value finding, got ${valueImports.length}`,
+		);
+		assert.strictEqual(valueImports[0]!.apiName, "pi");
+	});
+
+	it("Pattern 4: 'import pi, { on, notAnApi } from ...' produces 2 findings (pi + pi.on)", async () => {
+		const extDir = join(tmpDir, "mixed-ext-9");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import pi, { on, notAnApi } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			2,
+			`Expected 2 import-value findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi", "pi.on"]);
+	});
+
+	// Phase 3: regression guards
+
+	it("Regression: Pattern 2 still works for named-only imports", async () => {
+		const extDir = join(tmpDir, "regr-p2-1");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import { on, exec } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on", "pi.exec"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			2,
+			`Expected 2 import-value findings, got ${valueImports.length}`,
+		);
+		const apiNames = valueImports.map((f) => f.apiName).sort();
+		assert.deepStrictEqual(apiNames, ["pi.exec", "pi.on"]);
+	});
+
+	it("Regression: Pattern 3 still works for default imports", async () => {
+		const extDir = join(tmpDir, "regr-p3-1");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(join(extDir, "index.ts"), `import pi from "@earendil-works/pi-coding-agent";\n`);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			1,
+			`Expected 1 import-value finding, got ${valueImports.length}`,
+		);
+		assert.strictEqual(valueImports[0]!.apiName, "pi");
+	});
+
+	it("Regression: Pattern 1 still works for type imports", async () => {
+		const extDir = join(tmpDir, "regr-p1-1");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import type { ExtensionContext } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const typeImports = result.findings.filter((f) => f.matchContext === "import-type");
+		assert.strictEqual(
+			typeImports.length,
+			1,
+			`Expected 1 import-type finding, got ${typeImports.length}`,
+		);
+	});
+
+	it("Regression: Pattern 3 namespace import '* as pi' still works", async () => {
+		const extDir = join(tmpDir, "regr-p3-2");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import * as pi from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			1,
+			`Expected 1 import-value finding, got ${valueImports.length}`,
+		);
+		assert.strictEqual(valueImports[0]!.apiName, "pi");
+	});
+
+	it("Regression: false-positive prevention still works with mixed import (not interfering)", async () => {
+		const extDir = join(tmpDir, "regr-fp-1");
+		mkdirSync(extDir, { recursive: true });
+		writeFileSync(
+			join(extDir, "index.ts"),
+			`import { connect, ExecResult } from "@earendil-works/pi-coding-agent";\n`,
+		);
+
+		const execFn = async (): Promise<{
+			stdout: string;
+			stderr: string;
+			code: number;
+			killed: boolean;
+		}> => {
+			return { stdout: "", stderr: "", code: 0, killed: false };
+		};
+
+		const result = await scanExtensionsAST(extDir, ["pi.on", "pi.exec"], execFn, astGrepPath);
+		const valueImports = result.findings.filter((f) => f.matchContext === "import-value");
+		assert.strictEqual(
+			valueImports.length,
+			0,
+			`Expected 0 import-value findings, got ${valueImports.length}`,
+		);
+	});
+
 	it("Boundary: empty extensions dir returns empty", async () => {
 		const execFn = async (): Promise<{
 			stdout: string;

--- a/.pi/extensions/worktree-sandbox/index.ts
+++ b/.pi/extensions/worktree-sandbox/index.ts
@@ -75,34 +75,6 @@ export function hasShellExpansion(token: string): boolean {
 }
 
 /**
- * Find the first suspicious token (with shell expansion) in a command.
- * Scans tokens from shell-quote parse() and returns the first string token
- * that contains shell expansion characters ($, `, ~, {, *).
- *
- * Returns null if no suspicious token is found or command is empty.
- */
-export function findSuspiciousArg(command: string, _sandboxRoot: string): string | null {
-	if (!command || !command.trim()) return null;
-	// Check raw command text for shell expansion characters first.
-	// shell-quote parse() resolves $VAR to env values, so tokenized
-	// values may not contain $ signs. The raw check catches $, `, ~, {, *.
-	if (/[\$`~{*]/.test(command)) {
-		const tokens = tokenizeCommand(command);
-		for (const token of tokens) {
-			if (typeof token === "string" && hasShellExpansion(token)) {
-				return token;
-			}
-		}
-		// Tokenized values resolved env vars — return first non-plain string segment
-		const match = command.match(
-			/\$[a-zA-Z_][a-zA-Z0-9_]*|\$\([^)]+\)|`[^`]+`|~[^\s]*|\{[^}]+\}|\*[^\s]*/,
-		);
-		if (match) return match[0];
-	}
-	return null;
-}
-
-/**
  * Separator operators that start a new command in a shell pipeline.
  */
 const SEPARATORS = new Set(["|", "||", "|&", ";", ";;", "&&", "&"]);


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #827

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 26s | 69.6K | 43 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 16s | 21.5K | 18 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 42s | 45.8K | 4 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 37s | 72.8K | 23 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 6s | 31.2K | 12 | deepseek-v4-flash |

**Total:** 5 agents · 8m 9s · 240.9K tokens · 100 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/827
Closes #827