### PR TITLE
feat(#886): Duplicate Code: supervisor - render-loop renderer duplication across message-renderer.ts and subagent/renderer.ts (31 lines, 4 locations)

### DIFF
--- a/.pi/extensions/supervisor/lib/render-helpers.ts
+++ b/.pi/extensions/supervisor/lib/render-helpers.ts
@@ -1,0 +1,33 @@
+// ─── Render Helpers ──────────────────────────────────────────────
+// TUI rendering primitives used across multiple renderers.
+// Separated from lib/formatting.ts to avoid coupling pure string
+// formatting with TUI component dependencies (Container, Text, etc.).
+
+import { Text, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import type { Container } from "@earendil-works/pi-tui";
+
+/**
+ * Render a list of text lines into a container, skipping empty/whitespace-only lines.
+ *
+ * Each non-empty line is styled with `theme.fg("dim", line)` and wrapped to `width`
+ * columns via `wrapTextWithAnsi`. Every wrapped segment is added as a `Text` child.
+ *
+ * @param container - The TUI container to add children to (mutated in place)
+ * @param lines     - Pre-split lines of text (caller owns split/truncation decisions)
+ * @param theme     - Theme object with a `fg` method matching TUI conventions
+ * @param width     - Maximum column width for text wrapping
+ */
+export function renderTextLines(
+	container: Container,
+	lines: string[],
+	theme: { fg: (color: string, text: string) => string },
+	width: number,
+): void {
+	for (const line of lines) {
+		if (!line.trim()) continue;
+		const styled = theme.fg("dim", line);
+		for (const wrapped of wrapTextWithAnsi(styled, width)) {
+			container.addChild(new Text(wrapped, 1, 0));
+		}
+	}
+}

--- a/.pi/extensions/supervisor/session/message-renderer.ts
+++ b/.pi/extensions/supervisor/session/message-renderer.ts
@@ -13,6 +13,7 @@ import {
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
 import { formatTokens, formatDuration, getTermWidth, boldText } from "../lib/formatting.ts";
+import { renderTextLines } from "../lib/render-helpers.ts";
 import { renderSubagentResult } from "../subagent/renderer.ts";
 import type { SubagentDetails } from "../subagent/types.ts";
 
@@ -171,13 +172,7 @@ export function createMessageRenderer(pi: ExtensionAPI) {
 				const maxTaskLines = 50;
 				const showLines = taskLines.slice(0, maxTaskLines);
 				const overflowCount = taskLines.length - maxTaskLines;
-				for (const line of showLines) {
-					if (!line.trim()) continue; // Skip empty lines
-					const styled = theme.fg("dim", line);
-					for (const wrapped of wrapTextWithAnsi(styled, w)) {
-						c.addChild(new Text(wrapped, 1, 0));
-					}
-				}
+				renderTextLines(c, showLines, theme, w);
 				if (overflowCount > 0) {
 					const notice =
 						overflowCount === 1
@@ -193,13 +188,7 @@ export function createMessageRenderer(pi: ExtensionAPI) {
 			c.addChild(new Spacer(1));
 			c.addChild(new Text(fit(theme.fg("dim", "── Thinking ──")), 1, 0));
 			const thinkingLines = details.thinkingOutput.split("\n");
-			for (const line of thinkingLines) {
-				if (!line.trim()) continue;
-				const styled = theme.fg("dim", line);
-				for (const wrapped of wrapTextWithAnsi(styled, w)) {
-					c.addChild(new Text(wrapped, 1, 0));
-				}
-			}
+			renderTextLines(c, thinkingLines, theme, w);
 		}
 
 		// Text output rendered as Markdown
@@ -217,13 +206,7 @@ export function createMessageRenderer(pi: ExtensionAPI) {
 				details.rawOutput.length > 500
 					? details.rawOutput.slice(0, 500) + "..."
 					: details.rawOutput;
-			for (const line of preview.split("\n")) {
-				if (!line.trim()) continue;
-				const styled = theme.fg("dim", line);
-				for (const wrapped of wrapTextWithAnsi(styled, w)) {
-					c.addChild(new Text(wrapped, 1, 0));
-				}
-			}
+			renderTextLines(c, preview.split("\n"), theme, w);
 		}
 
 		return c;

--- a/.pi/extensions/supervisor/subagent/renderer.ts
+++ b/.pi/extensions/supervisor/subagent/renderer.ts
@@ -2,16 +2,10 @@
 // TUI renderCall and renderResult for the subagent tool.
 // Provides native-looking inline rendering with expand/collapse via Ctrl+O.
 
-import {
-	Container,
-	Markdown,
-	Spacer,
-	Text,
-	truncateToWidth,
-	wrapTextWithAnsi,
-} from "@earendil-works/pi-tui";
+import { Container, Markdown, Spacer, Text, truncateToWidth } from "@earendil-works/pi-tui";
 import { getMarkdownTheme } from "@earendil-works/pi-coding-agent";
 import { formatTokens, formatDuration, getTermWidth, boldText } from "../lib/formatting.ts";
+import { renderTextLines } from "../lib/render-helpers.ts";
 import { formatToolCall } from "../event/session-events.ts";
 import type { SubagentDetails, SubagentToolCall, AgentToolResult } from "./types.ts";
 
@@ -144,13 +138,7 @@ export function renderSubagentResult(
 		const maxTaskLines = 50;
 		const showLines = taskLines.slice(0, maxTaskLines);
 		const overflowCount = taskLines.length - maxTaskLines;
-		for (const line of showLines) {
-			if (!line.trim()) continue;
-			const styled = theme.fg("dim", line);
-			for (const wrapped of wrapTextWithAnsi(styled, w)) {
-				container.addChild(new Text(wrapped, 1, 0));
-			}
-		}
+		renderTextLines(container, showLines, theme, w);
 		if (overflowCount > 0) {
 			const notice =
 				overflowCount === 1

--- a/.pi/extensions/supervisor/test/render-helpers.test.mts
+++ b/.pi/extensions/supervisor/test/render-helpers.test.mts
@@ -1,0 +1,124 @@
+/**
+ * Tests: render-helpers.ts — renderTextLines unit tests.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/supervisor/test/render-helpers.test.mts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { Container, Text, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { renderTextLines } from "../lib/render-helpers.ts";
+
+// ─── Fixtures ────────────────────────────────────────────────────
+
+const mockTheme = {
+	fg: (_color: string, text: string) => text,
+};
+
+/** Strip ANSI escape sequences from a string */
+function stripAnsi(s: string): string {
+	return s.replace(/\x1b\[\d+m/g, "").replace(/\x1b\[0m/g, "");
+}
+
+/**
+ * Render a Container to an array of stripped text lines.
+ * Note: Text.render(width) pads output to full width with leading space.
+ * Use .trim() for content comparisons unless checking padding behavior.
+ */
+function renderStripped(container: Container, width = 80): string[] {
+	const raw = container.render(width);
+	return raw.map((line: string) => stripAnsi(line).trim());
+}
+
+// ─── Tests ───────────────────────────────────────────────────────
+
+describe("renderTextLines", () => {
+	it("happy path: renders two non-empty lines as Text children", () => {
+		const c = new Container();
+		renderTextLines(c, ["hello", "world"], mockTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 2);
+		assert.equal(lines[0], "hello");
+		assert.equal(lines[1], "world");
+	});
+
+	it("empty lines array adds zero children", () => {
+		const c = new Container();
+		renderTextLines(c, [], mockTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 0);
+	});
+
+	it("all empty/whitespace-only lines are skipped — zero children", () => {
+		const c = new Container();
+		renderTextLines(c, ["", "  ", "\t", "   "], mockTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 0);
+	});
+
+	it("single non-empty line adds one Text child", () => {
+		const c = new Container();
+		renderTextLines(c, ["single"], mockTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 1);
+		assert.equal(lines[0], "single");
+	});
+
+	it("mixed content: only non-empty lines produce children", () => {
+		const c = new Container();
+		renderTextLines(c, ["first", "", "  ", "second", "\t"], mockTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 2);
+		assert.equal(lines[0], "first");
+		assert.equal(lines[1], "second");
+	});
+
+	it("width parameter is forwarded to wrapTextWithAnsi — long lines wrap", () => {
+		const c = new Container();
+		const longLine = "a".repeat(200);
+		renderTextLines(c, [longLine], mockTheme, 20);
+		const lines = renderStripped(c);
+		// At width=20, each wrapped segment is at most 20 chars
+		assert.ok(lines.length >= 10, `expected at least 10 wrapped lines, got ${lines.length}`);
+		for (const line of lines) {
+			assert.ok(
+				line.length <= 20,
+				`wrapped segment should be ≤20 chars, got: "${line}" (${line.length})`,
+			);
+		}
+	});
+
+	it("theme.fg('dim', ...) is applied to each non-empty line", () => {
+		const trackTheme = {
+			fg: (color: string, text: string) => {
+				assert.equal(color, "dim", `expected "dim" color, got "${color}"`);
+				return `styled:${text}`;
+			},
+		};
+		const c = new Container();
+		renderTextLines(c, ["alpha", "beta"], trackTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 2);
+		assert.ok(lines[0].includes("styled:alpha"), `expected styled:alpha, got: ${lines[0]}`);
+		assert.ok(lines[1].includes("styled:beta"), `expected styled:beta, got: ${lines[1]}`);
+	});
+
+	it("container mutability: appends to existing children", () => {
+		const c = new Container();
+		c.addChild(new Text("existing", 1, 0));
+		renderTextLines(c, ["new1", "new2"], mockTheme, 80);
+		const lines = renderStripped(c);
+		assert.equal(lines.length, 3);
+		assert.equal(lines[0], "existing");
+		assert.equal(lines[1], "new1");
+		assert.equal(lines[2], "new2");
+	});
+
+	it("interop: wrapTextWithAnsi produces same output as direct call", () => {
+		// Verify the internal wrap behavior matches expectations
+		const styled = mockTheme.fg("dim", "hello world");
+		const wrapped = [...wrapTextWithAnsi(styled, 80)];
+		assert.deepEqual(wrapped, ["hello world"]);
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #886

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 19s | 49.2K | 43 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 55s | 28.6K | 24 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 5s | 32.7K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 0s | 53.0K | 25 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 30s | 36.5K | 33 | deepseek-v4-flash |

**Total:** 5 agents · 10m 50s · 199.9K tokens · 139 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/886
Closes #886