### PR TITLE
feat(#908): Bug: tsc-checkpoint - runTscCheckpoint silently returns hasErrors:false for malformed tsconfig

### DIFF
--- a/.pi/extensions/tsc-checkpoint/checkpoint.ts
+++ b/.pi/extensions/tsc-checkpoint/checkpoint.ts
@@ -13,26 +13,70 @@ import type { TscDiagnostic, TscCheckpointResult } from "./types.ts";
 import { diagnosticToTscDiagnostic } from "./adapter.ts";
 
 /**
+ * Type for the config parser function — matches ts.getParsedCommandLineOfConfigFile.
+ * Injected as optional parameter for testability (the ts namespace has
+ * non-configurable getters, preventing monkey-patching).
+ */
+type ParseConfigFileFn = (
+	configFileName: string,
+	optionsToExtend: ts.CompilerOptions,
+	host: ts.ParseConfigFileHost,
+) => ts.ParsedCommandLine | undefined;
+
+/**
  * Runs a one-shot tsc check using the TypeScript compiler API.
  * Uses ts.createProgram() instead of watch mode — no file watchers,
  * no incremental state, no lingering callbacks.
+ *
+ * @param worktreePath - Path to the project root (contains tsconfig.json)
+ * @param getParsedCommandLineOfConfigFile - Optional injectable config parser (for testing)
  */
-export async function runTscCheckpoint(worktreePath: string): Promise<TscCheckpointResult> {
+export async function runTscCheckpoint(
+	worktreePath: string,
+	getParsedCommandLineOfConfigFile?: ParseConfigFileFn,
+): Promise<TscCheckpointResult> {
 	const configPath = resolve(worktreePath, "tsconfig.json");
 
 	if (!existsSync(configPath)) {
 		return { diagnostics: [], hasErrors: false };
 	}
 
-	// Parse tsconfig — fallback gracefully on parse failure
-	const parsedConfig = ts.getParsedCommandLineOfConfigFile(
+	// Parse tsconfig — use injected parser or default
+	const parseConfig = getParsedCommandLineOfConfigFile ?? ts.getParsedCommandLineOfConfigFile;
+	const parsedConfig = parseConfig(
 		configPath,
 		{ noEmit: true },
 		ts.sys as unknown as ts.ParseConfigFileHost,
 	);
 
+	// Defensive: getParsedCommandLineOfConfigFile returned undefined
+	// (unreachable in TS 6+ but must not signal success if it occurs)
 	if (!parsedConfig) {
-		return { diagnostics: [], hasErrors: false };
+		return {
+			diagnostics: [
+				{
+					file: "tsconfig.json",
+					line: 0,
+					column: 0,
+					severity: "Error" as const,
+					message:
+						"Failed to parse tsconfig.json — getParsedCommandLineOfConfigFile returned undefined",
+					filePath: configPath,
+				},
+			],
+			hasErrors: true,
+		};
+	}
+
+	// Check for config parse errors (malformed JSON, missing extends, etc.)
+	// before creating a program — these are preconditions that prevent
+	// reliable type-checking.
+	const configErrors = parsedConfig.errors.filter(
+		(d) => d.category === ts.DiagnosticCategory.Error,
+	);
+	if (configErrors.length > 0) {
+		const mapped = configErrors.map((d) => toTscDiagnostic(d, configPath));
+		return { diagnostics: mapped, hasErrors: true };
 	}
 
 	const configDir = dirname(configPath);
@@ -52,4 +96,41 @@ export async function runTscCheckpoint(worktreePath: string): Promise<TscCheckpo
 		: [];
 
 	return { diagnostics: mapped, hasErrors };
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Config Diagnostic Helper
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Map a ts.Diagnostic from config parsing to TscDiagnostic.
+ *
+ * File-based diagnostics delegate to {@link diagnosticToTscDiagnostic}.
+ * Fileless diagnostics (common for config parse errors like "No inputs found",
+ * malformed JSON, circular extends) get a synthetic file pointing to tsconfig.json
+ * so they are not silently dropped by the adapter.
+ */
+export function toTscDiagnostic(diagnostic: ts.Diagnostic, configPath: string): TscDiagnostic {
+	const file = diagnostic.file;
+	if (file) {
+		const configDir = dirname(configPath);
+		const result = diagnosticToTscDiagnostic(diagnostic, configDir);
+		if (result) return result;
+	}
+
+	// Fileless or delegation failed — synthesize diagnostic pointing to tsconfig.json
+	const message =
+		typeof diagnostic.messageText === "string"
+			? diagnostic.messageText
+			: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
+
+	return {
+		file: "tsconfig.json",
+		line: 0,
+		column: 0,
+		severity: "Error",
+		message,
+		code: `TS${diagnostic.code}`,
+		filePath: configPath,
+	};
 }

--- a/.pi/extensions/tsc-checkpoint/test/checkpoint.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/checkpoint.test.ts
@@ -149,6 +149,55 @@ describe("runTscCheckpoint (one-shot ts.createProgram)", () => {
 		}
 	});
 
+	it("Warning-only config diagnostics do not trigger early return — proceeds to createProgram", async () => {
+		const { dir, cleanup } = createFixture();
+		try {
+			// Create valid source files (no type errors)
+			writeFileSync(
+				join(dir, "tsconfig.json"),
+				JSON.stringify({ compilerOptions: { noEmit: true, strict: true } }),
+				"utf-8",
+			);
+			mkdirSync(join(dir, "src"), { recursive: true });
+			writeFileSync(join(dir, "src", "index.ts"), "export const x: number = 1;\n", "utf-8");
+
+			// Inject a mock config parser that returns a ParsedCommandLine with
+			// only Warning-category diagnostics (no Error), verifying the filter
+			// condition parsedConfig.errors.filter(d => d.category === Error)
+			// does not trigger early return and proceeds to createProgram.
+			const mockParseConfig: (
+				configFileName: string,
+				optionsToExtend: ts.CompilerOptions,
+				host: ts.ParseConfigFileHost,
+			) => ts.ParsedCommandLine | undefined = (_configFileName, _optionsToExtend, _host) => ({
+				options: { noEmit: true, strict: true },
+				fileNames: [join(dir, "src", "index.ts")],
+				raw: {},
+				errors: [
+					{
+						category: ts.DiagnosticCategory.Warning,
+						code: 9999,
+						messageText: "Deprecated config option used (test-only warning)",
+						file: undefined,
+						start: undefined,
+						length: undefined,
+					} as ts.Diagnostic,
+				],
+				wildcardDirectories: {},
+				compileOnSave: false,
+			});
+
+			const result = await runTscCheckpoint(dir, mockParseConfig);
+
+			// Warning-only config should not trigger early return —
+			// clean source files should result in no errors
+			assert.strictEqual(result.hasErrors, false);
+			assert.deepStrictEqual(result.diagnostics, []);
+		} finally {
+			cleanup();
+		}
+	});
+
 	it("clean project with no type errors returns empty diagnostics", async () => {
 		const { dir, cleanup } = createFixture();
 		try {

--- a/.pi/extensions/tsc-checkpoint/test/checkpoint.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/checkpoint.test.ts
@@ -13,7 +13,9 @@ import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
-import { runTscCheckpoint } from "../checkpoint.ts";
+import ts from "typescript";
+import { runTscCheckpoint, toTscDiagnostic } from "../checkpoint.ts";
+import { diagnosticToTscDiagnostic } from "../adapter.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
 // Fixture helpers
@@ -41,7 +43,7 @@ describe("runTscCheckpoint (one-shot ts.createProgram)", () => {
 		assert.deepStrictEqual(result, { diagnostics: [], hasErrors: false });
 	});
 
-	it("config parse failure (malformed JSON) returns empty diagnostics", async () => {
+	it("config parse failure (malformed JSON) returns hasErrors: true with diagnostic", async () => {
 		const { dir, cleanup } = createFixture();
 		try {
 			writeFileSync(
@@ -50,13 +52,15 @@ describe("runTscCheckpoint (one-shot ts.createProgram)", () => {
 				"utf-8",
 			);
 			const result = await runTscCheckpoint(dir);
-			assert.deepStrictEqual(result, { diagnostics: [], hasErrors: false });
+			assert.strictEqual(result.hasErrors, true);
+			assert.ok(result.diagnostics.length > 0, "should have at least one diagnostic");
+			assert.strictEqual(result.diagnostics[0]!.file, "tsconfig.json");
 		} finally {
 			cleanup();
 		}
 	});
 
-	it("config parse failure with non-existent extends returns empty diagnostics", async () => {
+	it("config parse failure with non-existent extends returns hasErrors: true with diagnostic", async () => {
 		const { dir, cleanup } = createFixture();
 		try {
 			writeFileSync(
@@ -68,7 +72,78 @@ describe("runTscCheckpoint (one-shot ts.createProgram)", () => {
 				"utf-8",
 			);
 			const result = await runTscCheckpoint(dir);
-			assert.deepStrictEqual(result, { diagnostics: [], hasErrors: false });
+			assert.strictEqual(result.hasErrors, true);
+			assert.ok(result.diagnostics.length > 0, "should have at least one diagnostic");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("whitespace-only tsconfig returns hasErrors: true with diagnostic", async () => {
+		const { dir, cleanup } = createFixture();
+		try {
+			writeFileSync(join(dir, "tsconfig.json"), "   \n  \n  ", "utf-8");
+			const result = await runTscCheckpoint(dir);
+			assert.strictEqual(result.hasErrors, true);
+			assert.ok(result.diagnostics.length > 0, "should have at least one diagnostic");
+			const diag = result.diagnostics[0]!;
+			assert.strictEqual(diag.file, "tsconfig.json");
+			assert.strictEqual(diag.severity, "Error");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("cyclic extends returns hasErrors: true with diagnostic", async () => {
+		const { dir, cleanup } = createFixture();
+		try {
+			writeFileSync(
+				join(dir, "tsconfig.json"),
+				JSON.stringify({
+					compilerOptions: { noEmit: true },
+					extends: "./tsconfig.a.json",
+				}),
+				"utf-8",
+			);
+			writeFileSync(
+				join(dir, "tsconfig.a.json"),
+				JSON.stringify({
+					extends: "./tsconfig.b.json",
+				}),
+				"utf-8",
+			);
+			writeFileSync(
+				join(dir, "tsconfig.b.json"),
+				JSON.stringify({
+					extends: "./tsconfig.a.json",
+				}),
+				"utf-8",
+			);
+
+			const result = await runTscCheckpoint(dir);
+			assert.strictEqual(result.hasErrors, true);
+			assert.ok(result.diagnostics.length > 0, "should have at least one diagnostic");
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("getParsedCommandLineOfConfigFile returning undefined → hasErrors: true with diagnostic", async () => {
+		const { dir, cleanup } = createFixture();
+		try {
+			writeFileSync(
+				join(dir, "tsconfig.json"),
+				JSON.stringify({ compilerOptions: { noEmit: true } }),
+				"utf-8",
+			);
+
+			// Inject a mock that returns undefined to exercise the defensive branch
+			const result = await runTscCheckpoint(dir, () => undefined);
+
+			assert.strictEqual(result.hasErrors, true);
+			assert.strictEqual(result.diagnostics.length, 1);
+			assert.strictEqual(result.diagnostics[0]!.file, "tsconfig.json");
+			assert.strictEqual(result.diagnostics[0]!.severity, "Error");
 		} finally {
 			cleanup();
 		}
@@ -152,6 +227,29 @@ describe("runTscCheckpoint (one-shot ts.createProgram)", () => {
 		}
 	});
 
+	it("config with include: [] and no source files — no crash, correct shape (TS18003 may fire)", async () => {
+		const { dir, cleanup } = createFixture();
+		try {
+			writeFileSync(
+				join(dir, "tsconfig.json"),
+				JSON.stringify({
+					compilerOptions: { noEmit: true, strict: true },
+					include: [],
+				}),
+				"utf-8",
+			);
+			const result = await runTscCheckpoint(dir);
+			// TS 6.0.3 may or may not produce a config error for empty include.
+			// At minimum verify correct shape and no crash.
+			assert.ok("hasErrors" in result);
+			assert.ok("diagnostics" in result);
+			assert.ok(Array.isArray(result.diagnostics));
+			assert.strictEqual(typeof result.hasErrors, "boolean");
+		} finally {
+			cleanup();
+		}
+	});
+
 	it("empty worktreePath string → no crash (correct return shape)", async () => {
 		// resolve("", "tsconfig.json") resolves to CWD, which may have a tsconfig.
 		// This test just verifies no crash and correct return shape.
@@ -159,6 +257,100 @@ describe("runTscCheckpoint (one-shot ts.createProgram)", () => {
 		assert.ok("diagnostics" in result);
 		assert.ok("hasErrors" in result);
 		assert.ok(Array.isArray(result.diagnostics));
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// toTscDiagnostic — config diagnostic helper entity tests
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("toTscDiagnostic (config diagnostic helper)", () => {
+	it("fileless diagnostic → synthetic TscDiagnostic pointing to tsconfig.json", () => {
+		const diag = {
+			category: ts.DiagnosticCategory.Error,
+			code: 1234,
+			messageText: "Test parse error",
+			file: undefined,
+			start: undefined,
+			length: undefined,
+		} as ts.Diagnostic;
+		const configPath = "/fake/project/tsconfig.json";
+		const result = toTscDiagnostic(diag, configPath);
+
+		assert.strictEqual(result.file, "tsconfig.json");
+		assert.strictEqual(result.filePath, configPath);
+		assert.strictEqual(result.line, 0);
+		assert.strictEqual(result.column, 0);
+		assert.strictEqual(result.severity, "Error");
+		assert.strictEqual(result.message, "Test parse error");
+		assert.strictEqual(result.code, "TS1234");
+	});
+
+	it("file-based diagnostic → delegates to diagnosticToTscDiagnostic", () => {
+		const sourceFile = ts.createSourceFile(
+			"test.ts",
+			'const x: number = "str";\n',
+			ts.ScriptTarget.Latest,
+		);
+		const diag: ts.Diagnostic = {
+			category: ts.DiagnosticCategory.Error,
+			code: 2322,
+			messageText: "Type 'string' is not assignable to type 'number'",
+			file: sourceFile,
+			start: 24,
+			length: 5,
+		};
+		const configPath = "/fake/project/tsconfig.json";
+		const result = toTscDiagnostic(diag, configPath);
+		const expected = diagnosticToTscDiagnostic(diag, "/fake/project")!;
+
+		assert.deepStrictEqual(result, expected);
+	});
+
+	it("multiline messageText → flattened via ts.flattenDiagnosticMessageText", () => {
+		const chain: ts.DiagnosticMessageChain = {
+			messageText: "Base error",
+			category: ts.DiagnosticCategory.Error,
+			code: 1111,
+			next: [
+				{
+					messageText: "Nested detail",
+					category: ts.DiagnosticCategory.Error,
+					code: 2222,
+				},
+			],
+		};
+		const diag = {
+			category: ts.DiagnosticCategory.Error,
+			code: 1111,
+			messageText: chain,
+			file: undefined,
+			start: undefined,
+			length: undefined,
+		} as ts.Diagnostic;
+		const result = toTscDiagnostic(diag, "/fake/path/tsconfig.json");
+
+		assert.strictEqual(result.severity, "Error");
+		assert.ok(result.message.includes("Base error"), "message should contain flattened base text");
+		assert.ok(
+			result.message.includes("Nested detail"),
+			"message should contain flattened nested text",
+		);
+	});
+
+	it("zero start position → line: 0, column: 0 for fileless diagnostic", () => {
+		const diag = {
+			category: ts.DiagnosticCategory.Error,
+			code: 5678,
+			messageText: "Some error with no start",
+			file: undefined,
+			start: undefined,
+			length: undefined,
+		} as ts.Diagnostic;
+		const result = toTscDiagnostic(diag, "/fake/path/tsconfig.json");
+
+		assert.strictEqual(result.line, 0);
+		assert.strictEqual(result.column, 0);
 	});
 });
 
@@ -175,8 +367,10 @@ describe("runTscCheckpoint (pipeline contract)", () => {
 		assert.ok("hasErrors" in result);
 	});
 
-	it("has .length === 1 (only worktreePath param)", () => {
-		assert.strictEqual(runTscCheckpoint.length, 1);
+	it("has .length === 2 (worktreePath + optional injectable config parser)", () => {
+		// Second optional parameter exists for testability — the ts namespace
+		// has non-configurable getters preventing monkey-patching.
+		assert.strictEqual(runTscCheckpoint.length, 2);
 	});
 
 	it("return shape matches TscCheckpointResult", async () => {

--- a/.pi/extensions/tsc-checkpoint/test/index.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/index.test.ts
@@ -37,8 +37,8 @@ describe("runTscCheckpoint (pipeline contract)", () => {
 		assert.ok("hasErrors" in result);
 	});
 
-	it("has .length === 1 (only worktreePath param)", () => {
-		assert.strictEqual(runTscCheckpoint.length, 1);
+	it("has .length === 2 (worktreePath + optional injectable config parser)", () => {
+		assert.strictEqual(runTscCheckpoint.length, 2);
 	});
 
 	it("ExtensionAPI type import still present in source (used by tscCheckpoint entry)", async () => {
@@ -46,11 +46,11 @@ describe("runTscCheckpoint (pipeline contract)", () => {
 		assert.ok(typeof mod.default === "function", "default export (tscCheckpoint) still present");
 	});
 
-	it("getRunTscCheckpoint returns function with .length === 1 that returns { diagnostics, hasErrors }", async () => {
+	it("getRunTscCheckpoint returns function with .length === 2 that returns { diagnostics, hasErrors }", async () => {
 		// This mirrors the pipeline contract in tsc-decisions.ts
 		const mod = await import("../index.ts");
 		assert.strictEqual(typeof mod.runTscCheckpoint, "function");
-		assert.strictEqual(mod.runTscCheckpoint.length, 1);
+		assert.strictEqual(mod.runTscCheckpoint.length, 2);
 		const result = await mod.runTscCheckpoint("/nonexistent/path");
 		assert.ok("diagnostics" in result);
 		assert.ok("hasErrors" in result);


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #908

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 5m 6s | 110.8K | 54 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 28s | 43.8K | 15 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 12s | 20.8K | 5 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 7m 0s | 49.4K | 30 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 5m 52s | 46.8K | 28 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 32s | 35.8K | 23 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 44s | 54.0K | 32 | deepseek-v4-flash |

**Total:** 7 agents · 26m 53s · 361.5K tokens · 187 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/908
Closes #908