### PR TITLE
feat(#916): Reinvention: ripgrep-search - manual line truncation replaces truncateLine()

### DIFF
--- a/.pi/extensions/ripgrep-search/index.ts
+++ b/.pi/extensions/ripgrep-search/index.ts
@@ -4,6 +4,7 @@
  */
 
 import type { ExtensionAPI, Theme } from "@earendil-works/pi-coding-agent";
+import { truncateLine } from "@earendil-works/pi-coding-agent";
 import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { mkdtemp, rm, stat, readdir, writeFile } from "node:fs/promises";
@@ -26,7 +27,6 @@ import {
 
 const MAX_TOTAL_RESULTS = 500;
 const DEFAULT_DISPLAY_RESULTS = 10;
-const MAX_LINE_LENGTH = 500; // truncate individual match lines to prevent context-window blowup
 
 // ---------------------------------------------------------------------------
 // Mode awareness — ExtensionMode mirrors upstream type for mode gating
@@ -135,10 +135,7 @@ export function buildStructuredSummary(
 	const displayResults = searchResult.results.slice(0, maxDisplay);
 	for (let i = 0; i < displayResults.length; i++) {
 		const r = displayResults[i]!;
-		const truncatedText =
-			r.text.length > MAX_LINE_LENGTH
-				? r.text.slice(0, MAX_LINE_LENGTH) + "... [truncated]"
-				: r.text;
+		const truncatedText = truncateLine(r.text).text;
 		text += `${i + 1}. ${r.file}:${r.line}:${r.column}:${truncatedText}\n`;
 	}
 

--- a/.pi/extensions/ripgrep-search/test/ripgrep-search.test.mts
+++ b/.pi/extensions/ripgrep-search/test/ripgrep-search.test.mts
@@ -1376,6 +1376,70 @@ describe("buildStructuredSummary", () => {
 		assert.ok(summary.text.includes("[Showing first 10 of 15 results across 1 file."));
 		assert.strictEqual(summary.details.truncated, true);
 	});
+
+	// ── Phase 1: Truncation behavior in buildStructuredSummary ──
+
+	describe("line truncation via truncateLine", () => {
+		it("line > 500 chars → truncated text ends with '... [truncated]' suffix", () => {
+			const longText = "x".repeat(600);
+			const results = [{ file: "a.ts", line: 1, column: 1, text: longText }];
+			const result: RgResult = { total_returned: 1, results };
+			const summary = buildStructuredSummary(result, "ripgrep", "q", ".");
+			assert.ok(summary.text.includes("... [truncated]"), "Should have truncation suffix");
+			// Total line in output should be 500 + suffix length
+			const lineMatch = summary.text.match(/1\. a\.ts:1:1:(.+)/);
+			assert.ok(lineMatch, "Should match result line format");
+			const displayedText = lineMatch![1]!;
+			assert.ok(displayedText.endsWith("... [truncated]"));
+			assert.strictEqual(displayedText.length, 500 + "... [truncated]".length);
+		});
+
+		it("line ≤ 500 chars → text passed through unchanged", () => {
+			const shortText = "Hello world";
+			const results = [{ file: "a.ts", line: 1, column: 1, text: shortText }];
+			const result: RgResult = { total_returned: 1, results };
+			const summary = buildStructuredSummary(result, "ripgrep", "q", ".");
+			assert.ok(summary.text.includes("Hello world"), "Short text should pass through unchanged");
+			assert.ok(
+				!summary.text.includes("... [truncated]"),
+				"Short text should not have truncation suffix",
+			);
+		});
+
+		it("line exactly 500 chars → no truncation", () => {
+			const exactText = "x".repeat(500);
+			const results = [{ file: "a.ts", line: 1, column: 1, text: exactText }];
+			const result: RgResult = { total_returned: 1, results };
+			const summary = buildStructuredSummary(result, "ripgrep", "q", ".");
+			// Should NOT contain truncation suffix — exactly at boundary
+			assert.ok(
+				!summary.text.includes("... [truncated]"),
+				"Exact 500-char line should not be truncated",
+			);
+			// All 500 chars should be present
+			assert.ok(summary.text.includes(exactText), "All 500 chars should be visible");
+		});
+
+		it("line at 501 chars → truncation applied, suffix present and length correct", () => {
+			const text501 = "x".repeat(501);
+			const results = [{ file: "a.ts", line: 1, column: 1, text: text501 }];
+			const result: RgResult = { total_returned: 1, results };
+			const summary = buildStructuredSummary(result, "ripgrep", "q", ".");
+			const lineMatch = summary.text.match(/1\. a\.ts:1:1:(.+)/);
+			assert.ok(lineMatch, "Should match result line format");
+			const displayedText = lineMatch![1]!;
+			assert.ok(
+				displayedText.endsWith("... [truncated]"),
+				"501-char line should be truncated with suffix",
+			);
+			// 500 chars + suffix
+			assert.strictEqual(
+				displayedText.length,
+				500 + "... [truncated]".length,
+				"Truncated line should be exactly 500 chars + suffix",
+			);
+		});
+	});
 });
 
 // buildSearchErrorText


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #916

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 20s | 35.2K | 32 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 49s | 24.2K | 16 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 42s | 36.5K | 9 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 58s | 46.0K | 23 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 23s | 38.7K | 16 | deepseek-v4-flash |

**Total:** 5 agents · 6m 12s · 180.7K tokens · 96 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/916
Closes #916