### PR TITLE
feat(#909): Dead Code: session-logger - beginSessionLoggerSession unused duplicate of beginSession in pipeline.ts

### DIFF
--- a/.pi/extensions/lib/extensionState.test.ts
+++ b/.pi/extensions/lib/extensionState.test.ts
@@ -13,10 +13,10 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 
 // Integration: refactored extensions now use ExtensionState instead of inline file I/O
+import { beginSession } from "../session-logger/pipeline.ts";
 import {
 	createSessionLoggerGate,
 	toggleSessionLoggerGate,
-	beginSessionLoggerSession,
 	getSessionLoggerState,
 } from "../session-logger/index.ts";
 import { splitArgs } from "../session-advice/index.ts";
@@ -477,7 +477,7 @@ describe("ExtensionState — edge cases", () => {
 describe("Integration — session-logger with ExtensionState", () => {
 	it("getSessionLoggerState returns boolean for a valid gate", () => {
 		const gate = createSessionLoggerGate(true);
-		beginSessionLoggerSession(gate);
+		beginSession(gate);
 		assert.strictEqual(getSessionLoggerState(gate), true);
 	});
 
@@ -522,7 +522,7 @@ describe("Integration — session-logger with ExtensionState", () => {
 
 	it("gate lifecycle with ExtensionState: off after next session (full integration)", async () => {
 		const gate = createSessionLoggerGate(true);
-		assert.strictEqual(beginSessionLoggerSession(gate), true);
+		assert.strictEqual(beginSession(gate), true);
 
 		// Toggle off - persists to ExtensionState
 		const enabled = toggleSessionLoggerGate(gate, "off");
@@ -537,7 +537,7 @@ describe("Integration — session-logger with ExtensionState", () => {
 		assert.strictEqual(gate.enabledForNextSession, false);
 
 		// After next session begins
-		assert.strictEqual(beginSessionLoggerSession(gate), false);
+		assert.strictEqual(beginSession(gate), false);
 		await state.set("logger", false);
 		assert.strictEqual(await state.get("logger"), false);
 	});

--- a/.pi/extensions/lib/test/extension-state-integration.test.ts
+++ b/.pi/extensions/lib/test/extension-state-integration.test.ts
@@ -20,10 +20,10 @@ import { tmpdir } from "node:os";
 import { createExtensionStateStore } from "../extension-state.ts";
 
 // Phase 3: Both extensions now use ExtensionState instead of duplicated writeExtState
+import { beginSession } from "../../session-logger/pipeline.ts";
 import {
 	createSessionLoggerGate,
 	toggleSessionLoggerGate,
-	beginSessionLoggerSession,
 	getSessionLoggerState,
 } from "../../session-logger/index.ts";
 
@@ -87,21 +87,21 @@ describe("ExtensionState integration — session-logger", () => {
 		assert.equal(gate.enabledForNextSession, true);
 	});
 
-	it("beginSessionLoggerSession applies enabledForNextSession to sessionEnabled", () => {
+	it("beginSession applies enabledForNextSession to sessionEnabled", () => {
 		const gate = createSessionLoggerGate(true);
 		// First session
-		assert.equal(beginSessionLoggerSession(gate), true);
+		assert.equal(beginSession(gate), true);
 		// Toggle off for next session
 		toggleSessionLoggerGate(gate, "off");
 		assert.equal(gate.sessionEnabled, true); // Current session still on
 		// Next session starts
-		assert.equal(beginSessionLoggerSession(gate), false);
+		assert.equal(beginSession(gate), false);
 		assert.equal(gate.sessionEnabled, false);
 	});
 
 	it("getSessionLoggerState returns correct current session state", () => {
 		const gate = createSessionLoggerGate(true);
-		beginSessionLoggerSession(gate);
+		beginSession(gate);
 		assert.equal(getSessionLoggerState(gate), true);
 	});
 
@@ -115,24 +115,24 @@ describe("ExtensionState integration — session-logger", () => {
 
 	it("session-logger toggle lifecycle: enabled → off → next session disabled", () => {
 		const gate = createSessionLoggerGate(true);
-		beginSessionLoggerSession(gate);
+		beginSession(gate);
 		assert.equal(gate.sessionEnabled, true);
 
 		toggleSessionLoggerGate(gate, "off");
 		assert.equal(gate.enabledForNextSession, false);
 		assert.equal(gate.sessionEnabled, true); // Current session persists
 
-		beginSessionLoggerSession(gate);
+		beginSession(gate);
 		assert.equal(gate.sessionEnabled, false); // Next session reflects toggle
 	});
 
 	it("re-enables logging only when a later session starts", () => {
 		const gate = createSessionLoggerGate(false);
-		assert.equal(beginSessionLoggerSession(gate), false);
+		assert.equal(beginSession(gate), false);
 		assert.equal(toggleSessionLoggerGate(gate, "on"), true);
 		assert.equal(gate.sessionEnabled, false);
 
-		assert.equal(beginSessionLoggerSession(gate), true);
+		assert.equal(beginSession(gate), true);
 		assert.equal(gate.sessionEnabled, true);
 	});
 });

--- a/.pi/extensions/session-logger/index.ts
+++ b/.pi/extensions/session-logger/index.ts
@@ -33,11 +33,6 @@ export function toggleSessionLoggerGate(gate: SessionLoggerGate, args?: string):
 	return gate.enabledForNextSession;
 }
 
-export function beginSessionLoggerSession(gate: SessionLoggerGate): boolean {
-	gate.sessionEnabled = gate.enabledForNextSession;
-	return gate.sessionEnabled;
-}
-
 /**
  * Get the effective session-logger state for the current session.
  * Returns `sessionEnabled` from the gate, or `null` if gate is null/undefined.

--- a/.pi/extensions/session-logger/test/session-logger-dead-code.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-dead-code.test.mts
@@ -33,3 +33,20 @@ describe("recoverMissingReports dead code removal", () => {
 		assert.strictEqual(typeof mod.generateMissingReports, "function");
 	});
 });
+
+describe("beginSessionLoggerSession dead code removal", () => {
+	it("should NOT be exported from index.ts (was dead code — use beginSession from pipeline.ts instead)", async () => {
+		const mod = await import("../index.ts");
+		const modAny = mod as Record<string, unknown>;
+		assert.strictEqual(
+			typeof modAny.beginSessionLoggerSession,
+			"undefined",
+			"beginSessionLoggerSession must be removed — use beginSession from pipeline.ts instead",
+		);
+	});
+
+	it("beginSession should still be importable from pipeline.ts (surviving function, no regression)", async () => {
+		const mod = await import("../pipeline.ts");
+		assert.strictEqual(typeof mod.beginSession, "function");
+	});
+});

--- a/.pi/extensions/session-logger/test/session-logger-gate.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-gate.test.mts
@@ -1,8 +1,8 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 
+import { beginSession } from "../pipeline.ts";
 import {
-	beginSessionLoggerSession,
 	createSessionLoggerGate,
 	getSessionLoggerState,
 	toggleSessionLoggerGate,
@@ -12,25 +12,25 @@ describe("session-logger gate", () => {
 	it("applies /session-logger off to the next session without disabling the current one", () => {
 		const gate = createSessionLoggerGate(true);
 
-		assert.strictEqual(beginSessionLoggerSession(gate), true);
+		assert.strictEqual(beginSession(gate), true);
 		assert.strictEqual(gate.sessionEnabled, true);
 
 		assert.strictEqual(toggleSessionLoggerGate(gate, "off"), false);
 		assert.strictEqual(gate.enabledForNextSession, false);
 		assert.strictEqual(gate.sessionEnabled, true);
 
-		assert.strictEqual(beginSessionLoggerSession(gate), false);
+		assert.strictEqual(beginSession(gate), false);
 		assert.strictEqual(gate.sessionEnabled, false);
 	});
 
 	it("re-enables logging only when a later session starts", () => {
 		const gate = createSessionLoggerGate(false);
 
-		assert.strictEqual(beginSessionLoggerSession(gate), false);
+		assert.strictEqual(beginSession(gate), false);
 		assert.strictEqual(toggleSessionLoggerGate(gate, "on"), true);
 		assert.strictEqual(gate.sessionEnabled, false);
 
-		assert.strictEqual(beginSessionLoggerSession(gate), true);
+		assert.strictEqual(beginSession(gate), true);
 		assert.strictEqual(gate.sessionEnabled, true);
 	});
 });
@@ -38,13 +38,13 @@ describe("session-logger gate", () => {
 describe("getSessionLoggerState", () => {
 	it("gate sessionEnabled=true → returns true", () => {
 		const gate = createSessionLoggerGate(true);
-		beginSessionLoggerSession(gate);
+		beginSession(gate);
 		assert.strictEqual(getSessionLoggerState(gate), true);
 	});
 
 	it("gate sessionEnabled=false → returns false", () => {
 		const gate = createSessionLoggerGate(false);
-		beginSessionLoggerSession(gate);
+		beginSession(gate);
 		assert.strictEqual(getSessionLoggerState(gate), false);
 	});
 
@@ -56,9 +56,9 @@ describe("getSessionLoggerState", () => {
 		assert.strictEqual(getSessionLoggerState(undefined), null);
 	});
 
-	it("toggle off then beginSessionLoggerSession — reflects sessionEnabled, not enabledForNextSession", () => {
+	it("toggle off then beginSession — reflects sessionEnabled, not enabledForNextSession", () => {
 		const gate = createSessionLoggerGate(true);
-		beginSessionLoggerSession(gate); // sessionEnabled = true
+		beginSession(gate); // sessionEnabled = true
 		toggleSessionLoggerGate(gate, "off"); // enabledForNextSession = false, sessionEnabled still true
 
 		// Before next session starts, getter reflects current sessionEnabled = true
@@ -67,14 +67,14 @@ describe("getSessionLoggerState", () => {
 		assert.strictEqual(gate.enabledForNextSession, false);
 
 		// Next session starts
-		beginSessionLoggerSession(gate); // sessionEnabled = enabledForNextSession = false
+		beginSession(gate); // sessionEnabled = enabledForNextSession = false
 		assert.strictEqual(getSessionLoggerState(gate), false);
 		assert.strictEqual(gate.sessionEnabled, false);
 	});
 
-	it("gate with uninitialized values (no beginSessionLoggerSession) — sessionEnabled matches initial", () => {
+	it("gate with uninitialized values (no beginSession called) — sessionEnabled matches initial", () => {
 		const gate = createSessionLoggerGate(true);
-		// No beginSessionLoggerSession called — sessionEnabled is already initialized
+		// No beginSession called — sessionEnabled is already initialized
 		assert.strictEqual(getSessionLoggerState(gate), true);
 	});
 });

--- a/.pi/extensions/session-logger/test/session-logger-toggle.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-toggle.test.mts
@@ -12,11 +12,8 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 
-import {
-	beginSessionLoggerSession,
-	createSessionLoggerGate,
-	toggleSessionLoggerGate,
-} from "../index.ts";
+import { beginSession } from "../pipeline.ts";
+import { createSessionLoggerGate, toggleSessionLoggerGate } from "../index.ts";
 
 // ---------------------------------------------------------------------------
 // Phase 1: Toggle args normalization
@@ -91,26 +88,26 @@ describe("toggleSessionLoggerGate — edge cases", () => {
 describe("toggleSessionLoggerGate — regression: existing gate lifecycle", () => {
 	it("start enabled -> toggle off -> next session disabled", () => {
 		const gate = createSessionLoggerGate(true);
-		assert.strictEqual(beginSessionLoggerSession(gate), true);
+		assert.strictEqual(beginSession(gate), true);
 		assert.strictEqual(gate.sessionEnabled, true);
 
 		assert.strictEqual(toggleSessionLoggerGate(gate, "off"), false);
 		assert.strictEqual(gate.enabledForNextSession, false);
 		assert.strictEqual(gate.sessionEnabled, true);
 
-		assert.strictEqual(beginSessionLoggerSession(gate), false);
+		assert.strictEqual(beginSession(gate), false);
 		assert.strictEqual(gate.sessionEnabled, false);
 	});
 
 	it("start disabled -> toggle on -> next session enabled", () => {
 		const gate = createSessionLoggerGate(false);
-		assert.strictEqual(beginSessionLoggerSession(gate), false);
+		assert.strictEqual(beginSession(gate), false);
 
 		assert.strictEqual(toggleSessionLoggerGate(gate, "on"), true);
 		assert.strictEqual(gate.enabledForNextSession, true);
 		assert.strictEqual(gate.sessionEnabled, false);
 
-		assert.strictEqual(beginSessionLoggerSession(gate), true);
+		assert.strictEqual(beginSession(gate), true);
 		assert.strictEqual(gate.sessionEnabled, true);
 	});
 });

--- a/.pi/extensions/session-logger/test/session-logger-wiring.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-wiring.test.mts
@@ -13,7 +13,6 @@ import { describe, it } from "node:test";
 import defaultExport, {
 	createSessionLoggerGate,
 	toggleSessionLoggerGate,
-	beginSessionLoggerSession,
 	getSessionLoggerState,
 	generateMissingReports,
 } from "../index.ts";
@@ -279,18 +278,6 @@ describe("index.ts — named exports", () => {
 		const gate = createSessionLoggerGate(true);
 		const result = toggleSessionLoggerGate(gate, "off");
 		assert.strictEqual(result, false);
-	});
-
-	it("beginSessionLoggerSession is a function and copies enabledForNextSession", () => {
-		assert.strictEqual(
-			typeof beginSessionLoggerSession,
-			"function",
-			"beginSessionLoggerSession should be a function",
-		);
-		const gate = createSessionLoggerGate();
-		const result = beginSessionLoggerSession(gate);
-		assert.strictEqual(result, true);
-		assert.strictEqual(gate.sessionEnabled, true);
 	});
 
 	it("getSessionLoggerState returns sessionEnabled when gate is provided", () => {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #909

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 52s | 90.1K | 18 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 40s | 19.7K | 14 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 1s | 22.7K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 51s | 67.5K | 58 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 3s | 19.7K | 14 | deepseek-v4-flash |

**Total:** 5 agents · 9m 28s · 219.6K tokens · 122 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/909
Closes #909