### PR TITLE
feat(#940): Bug: web-search - maxResults uses Type.Number() instead of Type.Integer()

### DIFF
--- a/.pi/extensions/web-search/index.ts
+++ b/.pi/extensions/web-search/index.ts
@@ -39,7 +39,7 @@ export default function webSearch(pi: ExtensionAPI): void {
 				description: "Search query (e.g. 'latest rust web framework 2026')",
 			}),
 			maxResults: Type.Optional(
-				Type.Number({
+				Type.Integer({
 					default: 10,
 					description: "Maximum number of search results (default 10)",
 				}),

--- a/.pi/extensions/web-search/test/index.test.ts
+++ b/.pi/extensions/web-search/test/index.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import os from "node:os";
 import type { ExecFn, ExecResult } from "../types.ts";
 import webSearch, { formatResults } from "../index.ts";
+import { Value } from "typebox/value";
 
 // ── Mock exec helpers ──
 
@@ -104,6 +105,31 @@ describe("web-search extension entry point", () => {
 		assert.ok(Array.isArray(tool.promptGuidelines));
 		assert.ok(tool.promptGuidelines.length > 0);
 		assert.ok(tool.promptGuidelines.every((g: any) => typeof g === "string"));
+	});
+});
+
+// ===========================================================================
+// Schema validation — maxResults type safety
+// ===========================================================================
+
+describe("maxResults schema validation", () => {
+	it("(D) maxResults schema rejects fractional values", () => {
+		const tool = registerWebSearch(mockExecReturns({ code: 0, stdout: "", stderr: "" }));
+		const maxResultsSchema = tool.parameters.properties.maxResults;
+		// Integer values pass
+		assert.ok(Value.Check(maxResultsSchema, 1));
+		assert.ok(Value.Check(maxResultsSchema, 10));
+		assert.ok(Value.Check(maxResultsSchema, 50));
+		// Fractional values fail
+		assert.equal(Value.Check(maxResultsSchema, 2.5), false);
+		assert.equal(Value.Check(maxResultsSchema, 0.1), false);
+		assert.equal(Value.Check(maxResultsSchema, -1.5), false);
+	});
+
+	it("(D) maxResults schema accepts the default value 10", () => {
+		const tool = registerWebSearch(mockExecReturns({ code: 0, stdout: "", stderr: "" }));
+		const maxResultsSchema = tool.parameters.properties.maxResults;
+		assert.ok(Value.Check(maxResultsSchema, 10));
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #940

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 14s | 9.3K | 1 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 13s | 22.3K | 25 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 57s | 14.8K | 11 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 17s | 20.1K | 16 | deepseek-v4-flash |

**Total:** 4 agents · 3m 42s · 66.5K tokens · 53 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/940
Closes #940