### PR TITLE
feat(#935): Supervisor pipeline summary: show failed tool call count

### DIFF
--- a/.pi/extensions/session-logger/index.ts
+++ b/.pi/extensions/session-logger/index.ts
@@ -25,6 +25,11 @@ export function createSessionLoggerGate(initiallyEnabled = true): SessionLoggerG
 	};
 }
 
+export function getSessionLoggerState(gate: SessionLoggerGate | null | undefined): boolean | null {
+	if (gate == null) return null;
+	return gate.sessionEnabled;
+}
+
 export function toggleSessionLoggerGate(gate: SessionLoggerGate, args?: string): boolean {
 	const normalized = args?.toLowerCase();
 	if (normalized === "on") gate.enabledForNextSession = true;

--- a/.pi/extensions/session-logger/test/session-logger-wiring.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-wiring.test.mts
@@ -301,8 +301,6 @@ describe("index.ts — named exports", () => {
 		assert.strictEqual(state, null);
 	});
 
-	});
-
 	it("generateMissingReports is a function (re-exported)", () => {
 		assert.strictEqual(
 			typeof generateMissingReports,

--- a/.pi/extensions/supervisor/agent/runner.ts
+++ b/.pi/extensions/supervisor/agent/runner.ts
@@ -33,6 +33,7 @@ export function createAgentRunState(
 ): AgentRunState {
 	return {
 		toolCount: 0,
+		failedToolCount: 0,
 		tokenCount: 0,
 		fullLog: [],
 		liveThinking: "",
@@ -395,6 +396,7 @@ export async function runAgentSubprocess(
 				success,
 				agentName,
 				toolCount: state.toolCount,
+				failedToolCount: state.failedToolCount ?? undefined,
 				tokenCount: state.tokenCount,
 				durationMs,
 				textOutput,
@@ -433,6 +435,7 @@ export async function runAgentSubprocess(
 				success: false,
 				agentName: agent.config.name,
 				toolCount: 0,
+				failedToolCount: undefined,
 				tokenCount: 0,
 				durationMs: Date.now() - startedAt,
 				textOutput: "",

--- a/.pi/extensions/supervisor/config/types.ts
+++ b/.pi/extensions/supervisor/config/types.ts
@@ -90,6 +90,8 @@ export interface AgentRunResult {
 	toolCount: number;
 	tokenCount: number;
 	durationMs: number;
+	/** Number of tool executions that ended with an error */
+	failedToolCount?: number;
 	/** Clean text output from the agent (no tool/emoji noise) */
 	textOutput: string;
 	/** Brief summary line: what the agent accomplished */
@@ -150,6 +152,8 @@ export interface AgentRunState {
 	budgetExceededReason?: string;
 	/** Max tool calls allowed (0 = unlimited, populated from config) */
 	maxToolCalls: number;
+	/** Number of tool executions that ended with an error */
+	failedToolCount?: number;
 	/** Max tokens allowed (0 = unlimited, populated from config) */
 	agentTokenBudget: number;
 	/** LLM prompt cache read tokens (from message usage) */
@@ -280,6 +284,8 @@ export interface PipelineAgentResult {
 	toolCount: number;
 	/** Model identifier from agent frontmatter, e.g. "anthropic/claude-sonnet-4-20250514" */
 	model?: string;
+	/** Number of tool executions that ended with an error */
+	failedToolCount?: number;
 	/** Error output from agent execution (stderr, crash diagnostics) */
 	errorOutput?: string;
 }

--- a/.pi/extensions/supervisor/event/handlers.ts
+++ b/.pi/extensions/supervisor/event/handlers.ts
@@ -73,6 +73,9 @@ export function handleToolExecutionEnd(
 	ev: NormalizedEvent & { kind: "tool_execution_end" },
 ): HandlerResult {
 	state.toolCount++;
+	if (ev.isError) {
+		state.failedToolCount = (state.failedToolCount ?? 0) + 1;
+	}
 	state.currentTool = undefined;
 	state.currentToolArgs = undefined;
 	state.phase = "idle";

--- a/.pi/extensions/supervisor/pipeline/output.ts
+++ b/.pi/extensions/supervisor/pipeline/output.ts
@@ -97,8 +97,15 @@ export function buildPipelineSummary(
 	const totalTokens = agentResults.reduce((sum, a) => sum + a.tokenCount, 0);
 	const totalDurationMs = agentResults.reduce((sum, a) => sum + a.durationMs, 0);
 	const totalToolCalls = agentResults.reduce((sum, a) => sum + a.toolCount, 0);
+	const totalFailedCalls = agentResults.reduce((sum, a) => sum + (a.failedToolCount ?? 0), 0);
+	const failedPercentage =
+		totalToolCalls > 0 ? ((totalFailedCalls / totalToolCalls) * 100).toFixed(0) : "0";
+	const failedSuffix =
+		totalFailedCalls > 0 || agentResults.some((a) => a.failedToolCount !== undefined)
+			? ` · ${totalFailedCalls} failed (${failedPercentage}%)`
+			: "";
 	lines.push(
-		`**Total:** ${agentResults.length} agents · ${formatDuration(totalDurationMs)} · ${formatTokens(totalTokens)} tokens · ${totalToolCalls} tool calls`,
+		`**Total:** ${agentResults.length} agents · ${formatDuration(totalDurationMs)} · ${formatTokens(totalTokens)} tokens · ${totalToolCalls} tool calls${failedSuffix}`,
 	);
 
 	// Issue link + auto-link PR to issue (cross-reference in GitHub UI)

--- a/.pi/extensions/supervisor/pipeline/stages.ts
+++ b/.pi/extensions/supervisor/pipeline/stages.ts
@@ -571,6 +571,7 @@ export function buildAgentResultEntry(
 		durationMs: result.durationMs,
 		tokenCount: result.tokenCount,
 		toolCount: result.toolCount,
+		failedToolCount: result.failedToolCount ?? undefined,
 		model,
 		errorOutput: result.errorOutput || undefined,
 	};

--- a/.pi/extensions/supervisor/session/result.ts
+++ b/.pi/extensions/supervisor/session/result.ts
@@ -191,6 +191,7 @@ export function buildAgentRunResult(
 		success,
 		agentName,
 		toolCount: state.toolCount,
+		failedToolCount: state.failedToolCount ?? undefined,
 		tokenCount: tokenCount + (state.cacheRead || 0) + (state.cacheWrite || 0),
 		durationMs,
 		textOutput,
@@ -237,6 +238,7 @@ export function convertToolResultToAgentRunResult(
 		success: d.success,
 		agentName: d.agentName,
 		toolCount: d.toolCalls.length,
+		failedToolCount: d.errorCount ?? undefined,
 		tokenCount:
 			(d.inputTokens || 0) + (d.outputTokens || 0) + (d.cacheRead || 0) + (d.cacheWrite || 0),
 		durationMs: d.durationMs,

--- a/.pi/extensions/supervisor/test/event-handlers.test.mts
+++ b/.pi/extensions/supervisor/test/event-handlers.test.mts
@@ -46,6 +46,7 @@ function createState(overrides?: Partial<AgentRunState>): AgentRunState {
 		currentTool: undefined,
 		currentToolArgs: undefined,
 		toolCount: 0,
+		failedToolCount: 0,
 		tokenCount: 0,
 		fullLog: [],
 		liveThinking: "",
@@ -205,6 +206,39 @@ describe("handleToolExecutionEnd", () => {
 		const state = createState();
 		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
 		assert.ok(state.fullLog.some((l) => l.includes("✗")));
+	});
+
+	it("increments failedToolCount when isError=true", () => {
+		const state = createState();
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
+		assert.equal(state.failedToolCount, 1);
+	});
+
+	it("does NOT increment failedToolCount when isError=false", () => {
+		const state = createState();
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "read", isError: false });
+		assert.equal(state.failedToolCount, 0);
+	});
+
+	it("increments toolCount regardless of isError (regression guard)", () => {
+		const state = createState({ toolCount: 3 });
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
+		assert.equal(state.toolCount, 4);
+	});
+
+	it("when failedToolCount initially undefined, after error it becomes 1", () => {
+		const state = createState({ failedToolCount: undefined as any });
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
+		assert.equal(state.failedToolCount, 1);
+	});
+
+	it("accumulates multiple errors across calls", () => {
+		const state = createState();
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "bash", isError: true });
+		handleToolExecutionEnd(state, { kind: "tool_execution_end", toolName: "read", isError: false });
+		assert.equal(state.failedToolCount, 2);
+		assert.equal(state.toolCount, 3);
 	});
 });
 

--- a/.pi/extensions/supervisor/test/output.test.mts
+++ b/.pi/extensions/supervisor/test/output.test.mts
@@ -621,3 +621,84 @@ describe("buildPipelineSummary — multi-developer-run (Phase 5)", () => {
 		assert.ok(output.includes("**Total:** 1 agents"), "total shows 1 agent");
 	});
 });
+
+// ─── Tests: buildPipelineSummary — failed tool call rendering ────
+
+describe("buildPipelineSummary — failed tool call rendering", () => {
+	const makeAgent = (
+		name: string,
+		status: PipelineAgentResult["status"],
+		tokens: number,
+		duration: number,
+		tools: number,
+		failed?: number,
+	): PipelineAgentResult => ({
+		agentName: name,
+		status,
+		tokenCount: tokens,
+		durationMs: duration,
+		toolCount: tools,
+		failedToolCount: failed,
+	});
+
+	it("shows · 2 failed (50%) when half of 4 tools failed across agents", () => {
+		const results = [
+			makeAgent("developer", "SUCCESS", 5000, 30000, 2, 1),
+			makeAgent("auditor", "SUCCESS", 2000, 15000, 2, 1),
+		];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(output.includes("· 2 failed (50%)"), "should show 2 failed (50%)");
+	});
+
+	it("shows · 0 failed (0%) when all agents have failedToolCount: 0", () => {
+		const results = [
+			makeAgent("developer", "SUCCESS", 5000, 30000, 10, 0),
+			makeAgent("auditor", "SUCCESS", 2000, 15000, 5, 0),
+		];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(output.includes("· 0 failed (0%)"), "should show 0 failed (0%)");
+	});
+
+	it("unchanged (no · N failed suffix) when all agents have undefined failedToolCount (backward compat)", () => {
+		const results = [makeAgent("developer", "SUCCESS", 5000, 30000, 10)];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(!output.includes("failed"), "should NOT include failed suffix when undefined");
+		assert.ok(output.includes("10 tool calls"), "original format preserved");
+	});
+
+	it("zero-division guard: when total tool calls = 0, percentage renders as 0 not NaN", () => {
+		const results = [makeAgent("developer", "SUCCESS", 0, 0, 0, 0)];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(output.includes("0 failed (0%)"), "should show 0% not NaN");
+	});
+
+	it("all calls failed: · 5 failed (100%) for 5/5 failed", () => {
+		const results = [
+			makeAgent("developer", "SUCCESS", 5000, 30000, 3, 3),
+			makeAgent("auditor", "SUCCESS", 2000, 15000, 2, 2),
+		];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(output.includes("· 5 failed (100%)"), "should show 5 failed (100%)");
+	});
+
+	it("sums failedToolCount across all agents correctly", () => {
+		const results = [
+			makeAgent("developer", "SUCCESS", 5000, 30000, 10, 1),
+			makeAgent("developer", "SUCCESS", 3000, 20000, 8, 3),
+			makeAgent("auditor", "SUCCESS", 2000, 15000, 5, 0),
+		];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(output.includes("· 4 failed"), "should sum to 4 failed across 3 agents");
+	});
+
+	it("existing total-line format preserved: agents count, duration, tokens, tool calls all present (regression guard)", () => {
+		const results = [makeAgent("developer", "SUCCESS", 5000, 30000, 10, 1)];
+		const output = buildPipelineSummary(results, "success", 42, "Test", defaultConfig);
+		assert.ok(output.includes("**Total:"), "Total line present");
+		assert.ok(output.includes("1 agents"), "agent count present");
+		assert.ok(output.includes("30s") || output.includes("0m 30s"), "duration present");
+		assert.ok(output.includes("5.0K tokens"), "tokens present");
+		assert.ok(output.includes("10 tool calls"), "tool calls present");
+		assert.ok(output.includes("· 1 failed"), "failed count present");
+	});
+});

--- a/.pi/extensions/supervisor/test/pipeline/stages.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/stages.test.mts
@@ -885,6 +885,26 @@ describe("buildAgentResultEntry()", () => {
 		const shortModel = (m?: string) => (m ? m.split("/").pop() || m : "—");
 		assert.equal(shortModel(entry.model), "—");
 	});
+
+	it("threads failedToolCount from result", () => {
+		const entry = buildAgentResultEntry({ ...baseResult, failedToolCount: 2 }, false);
+		assert.equal(entry.failedToolCount, 2);
+	});
+
+	it("failedToolCount is undefined when not present on result", () => {
+		const entry = buildAgentResultEntry(baseResult, false);
+		assert.equal(entry.failedToolCount, undefined);
+	});
+
+	it("existing fields unchanged when failedToolCount absent (regression guard)", () => {
+		const entry = buildAgentResultEntry(baseResult, false);
+		assert.equal(entry.status, "SUCCESS");
+		assert.equal(entry.agentName, "developer");
+		assert.equal(entry.toolCount, 10);
+		assert.equal(entry.tokenCount, 5000);
+		assert.equal(entry.durationMs, 30000);
+		assert.equal(entry.model, undefined);
+	});
 });
 
 // ─── Tests: handleBacklogTransition() ─────────────────────────────

--- a/.pi/extensions/supervisor/test/session-result.test.mts
+++ b/.pi/extensions/supervisor/test/session-result.test.mts
@@ -18,6 +18,7 @@ function createState(overrides?: Partial<AgentRunState>): AgentRunState {
 		currentTool: undefined,
 		currentToolArgs: undefined,
 		toolCount: 0,
+		failedToolCount: 0,
 		tokenCount: 0,
 		fullLog: [],
 		liveThinking: "",
@@ -399,6 +400,32 @@ describe("buildAgentRunResult — breakdown extraction", () => {
 	});
 });
 
+// ─── buildAgentRunResult — failedToolCount threading ─────────────
+
+describe("buildAgentRunResult — failedToolCount threading", () => {
+	it("maps state.failedToolCount to result.failedToolCount", () => {
+		const state = createState({ failedToolCount: 3 });
+		const result = buildAgentRunResult(state, "developer", true, 1000, []);
+		assert.equal(result.failedToolCount, 3);
+	});
+
+	it("when state has no failedToolCount (undefined), result.failedToolCount is undefined", () => {
+		const state = createState({ failedToolCount: undefined as any });
+		const result = buildAgentRunResult(state, "developer", true, 1000, []);
+		assert.equal(result.failedToolCount, undefined);
+	});
+
+	it("existing fields (toolCount, tokenCount, success) unchanged when failedToolCount absent (regression guard)", () => {
+		const state = createState({ toolCount: 7, tokenCount: 500 });
+		const result = buildAgentRunResult(state, "developer", true, 5000, []);
+		assert.equal(result.toolCount, 7);
+		assert.equal(result.tokenCount, 500);
+		assert.equal(result.success, true);
+		assert.equal(result.agentName, "developer");
+		assert.equal(result.failedToolCount, 0);
+	});
+});
+
 // ─── buildAgentRunResult — budgetExceeded propagation ─────────────
 
 describe("buildAgentRunResult — budgetExceeded propagation", () => {
@@ -480,6 +507,18 @@ describe("convertToolResultToAgentRunResult — budgetExceeded propagation", () 
 	it("d.budgetExceeded=false produces undefined (not false), unused field convention", () => {
 		const result = convertToolResultToAgentRunResult(makeToolResult({ budgetExceeded: false }));
 		assert.equal(result.budgetExceeded, undefined);
+	});
+
+	it("maps d.errorCount to result.failedToolCount", () => {
+		const tr = makeToolResult({ errorCount: 2 });
+		const result = convertToolResultToAgentRunResult(tr);
+		assert.equal(result.failedToolCount, 2);
+	});
+
+	it("when d.errorCount is undefined, result.failedToolCount is undefined", () => {
+		const tr = makeToolResult({ errorCount: undefined });
+		const result = convertToolResultToAgentRunResult(tr);
+		assert.equal(result.failedToolCount, undefined);
 	});
 
 	it("all other fields unchanged from current mapping — regression guard", () => {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #935

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 43s | 30.4K | 6 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 35s | 57.0K | 50 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 7m 23s | 50.2K | 29 | deepseek-v4-flash |

**Total:** 3 agents · 11m 42s · 137.5K tokens · 85 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/935
Closes #935

**Gate failures:**
- TypeScript Checkpoint gate failed on run 1 — developer restarted