### PR TITLE
feat(#943): Bug: lsp-auditor - extractModifiedFiles path check rejects valid filenames with '..'

### DIFF
--- a/.pi/extensions/lsp-auditor/file-discovery.ts
+++ b/.pi/extensions/lsp-auditor/file-discovery.ts
@@ -27,8 +27,8 @@ export function extractModifiedFiles(gitDiffOutput: string, _worktreePath: strin
 		if (!file) continue;
 
 		const resolved = file.replace(/^(\.\/)+/, "");
-		// Path traversal prevention
-		if (resolved.includes("..")) continue;
+		// Path traversal prevention — block only ".." as path component
+		if (/\.\.(\/|$)/.test(resolved)) continue;
 		if (resolved.startsWith("/")) continue;
 
 		files.push(resolved);

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
@@ -335,8 +335,21 @@ describe("extractModifiedFiles", () => {
 		assert.deepStrictEqual(extractModifiedFiles("", "/tmp/worktree"), []);
 	});
 
-	it("path with .. → filtered out", () => {
+	it("path traversal pattern ../ → filtered out", () => {
 		const result = extractModifiedFiles("src/../etc/passwd\nvalid.ts", "/tmp/worktree");
+		assert.deepStrictEqual(result, ["valid.ts"]);
+	});
+
+	it("valid ..-bearing filenames are NOT filtered", () => {
+		const result = extractModifiedFiles(
+			"release..notes.ts\n..bar.ts\nfoo..bar/baz.ts",
+			"/tmp/worktree",
+		);
+		assert.deepStrictEqual(result, ["release..notes.ts", "..bar.ts", "foo..bar/baz.ts"]);
+	});
+
+	it("trailing .. at end of line → filtered out (traversal risk)", () => {
+		const result = extractModifiedFiles("foo/bar..\nvalid.ts", "/tmp/worktree");
 		assert.deepStrictEqual(result, ["valid.ts"]);
 	});
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #943

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 10s | 56.9K | 35 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 31s | 14.1K | 9 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 44s | 19.5K | 5 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 52s | 23.3K | 13 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 58s | 23.9K | 9 | deepseek-v4-flash |

**Total:** 5 agents · 5m 15s · 137.6K tokens · 71 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/943
Closes #943