### PR TITLE
feat(#956): Tool call stats line: inconsistent token format — raw number vs K abbreviation

### DIFF
--- a/.pi/extensions/supervisor/lib/formatting.ts
+++ b/.pi/extensions/supervisor/lib/formatting.ts
@@ -11,6 +11,15 @@ export function formatTokens(n: number): string {
 	return String(n);
 }
 
+/** Integer-rounded, lowercase k/m token display for compact stats lines.
+ *  Values <1000 return raw number; values >=1e6 use lowercase `m`.
+ */
+export function formatTokensInt(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(0)}m`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(0)}k`;
+	return String(n);
+}
+
 export function formatDuration(ms: number): string {
 	if (ms < 1_000) return `${ms}ms`;
 	const sec = Math.round(ms / 1_000);

--- a/.pi/extensions/supervisor/session/message-renderer.ts
+++ b/.pi/extensions/supervisor/session/message-renderer.ts
@@ -12,7 +12,13 @@ import {
 	truncateToWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { formatTokens, formatDuration, getTermWidth, boldText } from "../lib/formatting.ts";
+import {
+	formatTokens,
+	formatTokensInt,
+	formatDuration,
+	getTermWidth,
+	boldText,
+} from "../lib/formatting.ts";
 import { renderTextLines, renderThinkingBlock } from "../lib/render-helpers.ts";
 import { renderSubagentResult } from "../subagent/renderer.ts";
 import type { SubagentDetails } from "../subagent/types.ts";
@@ -80,8 +86,7 @@ export function createMessageRenderer(pi: ExtensionAPI) {
 			if (tok !== undefined) {
 				const maxTok = toolCallResult.agentTokenBudget;
 				if (maxTok && maxTok > 0) {
-					const maxK = maxTok >= 1000 ? `${(maxTok / 1000).toFixed(0)}K` : String(maxTok);
-					statsParts.push(`${tok}/${maxK} tok`);
+					statsParts.push(`${formatTokensInt(tok)}/${formatTokensInt(maxTok)} tok`);
 				} else {
 					statsParts.push(`${tok} tok`);
 				}

--- a/.pi/extensions/supervisor/test/formatting.test.mts
+++ b/.pi/extensions/supervisor/test/formatting.test.mts
@@ -1,0 +1,59 @@
+/**
+ * Tests: formatting.ts — formatTokensInt helper (integer-rounded, lowercase k/m)
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/supervisor/test/formatting.test.mts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatTokensInt } from "../lib/formatting.ts";
+
+describe("formatTokensInt", () => {
+	// ── Sub-1000: raw number ────────────────────────────────────
+	it("0 returns '0'", () => {
+		assert.equal(formatTokensInt(0), "0");
+	});
+
+	it("500 returns '500'", () => {
+		assert.equal(formatTokensInt(500), "500");
+	});
+
+	it("999 returns '999'", () => {
+		assert.equal(formatTokensInt(999), "999");
+	});
+
+	// ── Thousands: integer-rounded, lowercase k ────────────────
+	it("1000 returns '1k'", () => {
+		assert.equal(formatTokensInt(1000), "1k");
+	});
+
+	it("1500 returns '2k' (rounds up)", () => {
+		assert.equal(formatTokensInt(1500), "2k");
+	});
+
+	it("5499 returns '5k' (rounding boundary)", () => {
+		assert.equal(formatTokensInt(5499), "5k");
+	});
+
+	it("5969 returns '6k' (matches bug report example)", () => {
+		assert.equal(formatTokensInt(5969), "6k");
+	});
+
+	it("300_000 returns '300k' (no decimal, no uppercase K)", () => {
+		assert.equal(formatTokensInt(300_000), "300k");
+	});
+
+	// ── Millions: integer-rounded, lowercase m ─────────────────
+	it("1_000_000 returns '1m'", () => {
+		assert.equal(formatTokensInt(1_000_000), "1m");
+	});
+
+	it("1_500_000 returns '2m' (million with rounding)", () => {
+		assert.equal(formatTokensInt(1_500_000), "2m");
+	});
+
+	it("2_500_000 returns '3m' (banker's rounding: 2.5 → toFixed(0) → '3')", () => {
+		assert.equal(formatTokensInt(2_500_000), "3m");
+	});
+});

--- a/.pi/extensions/supervisor/test/message-renderer.test.mts
+++ b/.pi/extensions/supervisor/test/message-renderer.test.mts
@@ -1072,3 +1072,158 @@ describe("expanded view — thinking styling", () => {
 		);
 	});
 });
+
+// ─── Phase 7: Tool call result — stats line formatting ──────────
+
+describe("tool call result — stats line formatting (formatTokensInt)", () => {
+	before(() => {
+		initTheme();
+	});
+
+	it("runningTokenCount=5969, agentTokenBudget=300000 → '6k/300k tok'", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			runningTokenCount: 5969,
+			agentTokenBudget: 300000,
+			isError: false,
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("tok"));
+		assert.ok(statsLine, `expected tok in stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("6k/300k tok"), `expected 6k/300k tok, got: ${statsLine}`);
+		assert.ok(!statsLine!.includes("5969"), "should NOT contain raw token count 5969");
+		assert.ok(!statsLine!.includes("300K"), "should NOT contain uppercase K");
+	});
+
+	it("runningTokenCount=500, agentTokenBudget=100000 → '500/100k tok'", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			runningTokenCount: 500,
+			agentTokenBudget: 100000,
+			isError: false,
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("tok"));
+		assert.ok(statsLine, `expected tok in stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("500/100k tok"), `expected 500/100k tok, got: ${statsLine}`);
+	});
+
+	it("runningTokenCount=1500, agentTokenBudget=1500 → '2k/2k tok'", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			runningTokenCount: 1500,
+			agentTokenBudget: 1500,
+			isError: false,
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("tok"));
+		assert.ok(statsLine, `expected tok in stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("2k/2k tok"), `expected 2k/2k tok, got: ${statsLine}`);
+	});
+
+	it("runningTokenCount=undefined → no tok segment in stats line", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			agentTokenBudget: 100000,
+			isError: false,
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		const hasTok = lines.some((l) => l.includes("tok"));
+		assert.equal(hasTok, false, "should NOT have tok segment when runningTokenCount is undefined");
+	});
+
+	it("runningTokenCount=500, agentTokenBudget=0 → '500 tok' (no budget when 0)", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			runningTokenCount: 500,
+			agentTokenBudget: 0,
+			isError: false,
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("tok"));
+		assert.ok(statsLine, `expected tok in stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("500 tok"), `expected "500 tok", got: ${statsLine}`);
+	});
+
+	it("runningTokenCount=1000, agentTokenBudget=undefined → '1000 tok' (no budget when missing)", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			runningTokenCount: 1000,
+			isError: false,
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		const statsLine = lines.find((l) => l.includes("tok"));
+		assert.ok(statsLine, `expected tok in stats, got: ${JSON.stringify(lines)}`);
+		assert.ok(statsLine!.includes("1000 tok"), `expected "1000 tok", got: ${statsLine}`);
+	});
+
+	it("regression: other tool call render sections (header, tools, duration, thinking) unchanged", () => {
+		const pi = {} as any;
+		const renderer = createMessageRenderer(pi);
+		const message = makeToolCallMessage({
+			name: "bash",
+			args: "ls",
+			toolIndex: "#1",
+			toolDurationMs: 1234,
+			runningToolCount: 2,
+			maxToolCalls: 10,
+			runningTokenCount: 5969,
+			agentTokenBudget: 300000,
+			isError: false,
+			resultText: "file1.txt",
+			thinking: "I ran ls",
+		});
+		const c = renderer(message, {}, mockTheme) as Container;
+		const lines = renderAndStrip(c);
+		// Header, tools, duration, thinking all present
+		assert.ok(
+			lines.some((l) => l.includes("bash")),
+			"should have tool name in header",
+		);
+		assert.ok(
+			lines.some((l) => l.includes("2/10 tools")),
+			"should have tool count",
+		);
+		assert.ok(
+			lines.some((l) => l.includes("1.2s")),
+			"should have duration",
+		);
+		assert.ok(
+			lines.some((l) => l.includes("file1.txt")),
+			"should have resultText",
+		);
+		assert.ok(
+			lines.some((l) => l.includes("I ran ls")),
+			"should have thinking content",
+		);
+		// Token line uses formatTokensInt
+		assert.ok(
+			lines.some((l) => l.includes("6k/300k tok")),
+			"token line should be formatted with formatTokensInt",
+		);
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #956

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 20s | 40.9K | 34 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 35s | 26.2K | 11 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 13s | 25.2K | 30 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 16s | 53.3K | 24 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 42s | 41.7K | 18 | deepseek-v4-flash |

**Total:** 5 agents · 9m 6s · 187.4K tokens · 117 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/956
Closes #956