### PR TITLE
feat(#981): ripgrep-search: auto-correct file path passed as 'directory' parameter

### DIFF
--- a/.pi/extensions/ripgrep-search/index.ts
+++ b/.pi/extensions/ripgrep-search/index.ts
@@ -9,7 +9,7 @@ import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { mkdtemp, rm, stat, readdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { RgResult, SearchConfig } from "./types.ts";
@@ -78,7 +78,19 @@ export async function verifyDirectory(cwd: string, directory: string): Promise<s
 	}
 	try {
 		const dirStat = await stat(resolvedDir);
-		if (!dirStat.isDirectory()) throw new Error(`"${directory}" is a file, not a directory.`);
+		if (!dirStat.isDirectory()) {
+			const parentDir = dirname(resolvedDir);
+			const relDir = parentDir === resolvedCwd ? "." : relative(resolvedCwd, parentDir);
+			console.warn(
+				`[ripgrep_search] Path "${directory}" is a file, searching parent directory "${relDir}" instead.`,
+			);
+			if (parentDir !== resolvedCwd && !parentDir.startsWith(resolvedCwd + "/")) {
+				throw new Error(
+					`Directory traversal detected: parent directory of "${directory}" resolves outside project root.`,
+				);
+			}
+			return parentDir;
+		}
 		return resolvedDir;
 	} catch (err: unknown) {
 		const nodeErr = err as { code?: string };

--- a/.pi/extensions/ripgrep-search/test/ripgrep-search.test.mts
+++ b/.pi/extensions/ripgrep-search/test/ripgrep-search.test.mts
@@ -855,21 +855,23 @@ describe("verifyDirectory", () => {
 			}
 		});
 
-		it("ENOTDIR: file path throws Error with 'is a file'", async () => {
+		it("auto-corrects file path to parent directory", async () => {
 			const dir = setupTmpDir();
 			try {
 				writeFileSync(join(dir, "afile.txt"), "content");
-				await assert.rejects(verifyDirectory(dir, "afile.txt"), /is a file/);
+				const result = await verifyDirectory(dir, "afile.txt");
+				assert.equal(result, dir);
 			} finally {
 				cleanupTmpDir(dir);
 			}
 		});
 
-		it("ENOTDIR: file via relative path throws Error with 'is a file'", async () => {
+		it("auto-corrects file via relative path to parent directory", async () => {
 			const dir = setupTmpDir();
 			try {
 				writeFileSync(join(dir, "bfile.txt"), "content");
-				await assert.rejects(verifyDirectory(dir, "./bfile.txt"), /is a file/);
+				const result = await verifyDirectory(dir, "./bfile.txt");
+				assert.equal(result, dir);
 			} finally {
 				cleanupTmpDir(dir);
 			}

--- a/.pi/extensions/supervisor/event/session-events.ts
+++ b/.pi/extensions/supervisor/event/session-events.ts
@@ -73,7 +73,7 @@ export function processSessionEvent(
  * | grep | `grep /pattern/ in /dir` |
  * | ls | `ls /path` |
  * | find | `find /path` |
- * | ripgrep_search | `grep /pattern/` (same as grep) |
+ * | ripgrep_search | `rg "query" in dir` |
  * | others | `toolName: {"key":"val"}` (JSON preview, ≤80 chars) |
  */
 export function formatToolCall(toolName: string, args?: Record<string, unknown> | null): string {
@@ -125,8 +125,7 @@ export function formatToolCall(toolName: string, args?: Record<string, unknown> 
 			return "edit";
 		}
 
-		case "grep":
-		case "ripgrep_search": {
+		case "grep": {
 			const pattern = a.pattern;
 			const path = a.path;
 			let result = "grep";
@@ -135,6 +134,19 @@ export function formatToolCall(toolName: string, args?: Record<string, unknown> 
 			}
 			if (typeof path === "string" && path) {
 				result += ` in ${path}`;
+			}
+			return result;
+		}
+
+		case "ripgrep_search": {
+			const query = a.query;
+			const directory = a.directory;
+			let result = "rg";
+			if (typeof query === "string" && query) {
+				result += ` "${query}"`;
+			}
+			if (typeof directory === "string" && directory) {
+				result += ` in ${directory}`;
 			}
 			return result;
 		}
@@ -178,6 +190,19 @@ export function isToolCallLine(line: string): boolean {
 	// Bash format: starts with "$ " or is bare "$"
 	if (line.startsWith("$ ") || line === "$") return true;
 
+	// Bare known tool name (no args)
+	if (
+		line === "edit" ||
+		line === "find" ||
+		line === "grep" ||
+		line === "ls" ||
+		line === "read" ||
+		line === "rg" ||
+		line === "write"
+	) {
+		return true;
+	}
+
 	// Tool-name-prefixed formats: "read ...", "write ...", etc.
 	// Match the first word against known tool names followed by a space
 	const spaceIdx = line.indexOf(" ");
@@ -185,12 +210,13 @@ export function isToolCallLine(line: string): boolean {
 		const firstWord = line.slice(0, spaceIdx);
 		// Known short tool names (no colon)
 		if (
-			firstWord === "read" ||
-			firstWord === "write" ||
 			firstWord === "edit" ||
+			firstWord === "find" ||
 			firstWord === "grep" ||
 			firstWord === "ls" ||
-			firstWord === "find"
+			firstWord === "read" ||
+			firstWord === "rg" ||
+			firstWord === "write"
 		) {
 			return true;
 		}

--- a/.pi/extensions/supervisor/test/format-tool-call.test.mts
+++ b/.pi/extensions/supervisor/test/format-tool-call.test.mts
@@ -112,16 +112,24 @@ describe("formatToolCall()", () => {
 		assert.equal(formatToolCall("find", {}), "find");
 	});
 
-	// ripgrep_search → grep format
-	it('formats ripgrep_search as grep: "grep /TODO/"', () => {
-		assert.equal(formatToolCall("ripgrep_search", { pattern: "TODO" }), "grep /TODO/");
+	// ripgrep_search
+	it('formats ripgrep_search: "rg \"TODO\" in /src"', () => {
+		assert.equal(
+			formatToolCall("ripgrep_search", { query: "TODO", directory: "/src" }),
+			'rg "TODO" in /src',
+		);
 	});
 
-	it('formats ripgrep_search with path: "grep /TODO/ in /src"', () => {
-		assert.equal(
-			formatToolCall("ripgrep_search", { pattern: "TODO", path: "/src" }),
-			"grep /TODO/ in /src",
-		);
+	it('formats ripgrep_search with query only: "rg \"TODO\""', () => {
+		assert.equal(formatToolCall("ripgrep_search", { query: "TODO" }), 'rg "TODO"');
+	});
+
+	it('formats ripgrep_search with directory only: "rg in /src"', () => {
+		assert.equal(formatToolCall("ripgrep_search", { directory: "/src" }), "rg in /src");
+	});
+
+	it('formats ripgrep_search with no args: "rg"', () => {
+		assert.equal(formatToolCall("ripgrep_search", {}), "rg");
 	});
 
 	// web_search — fallback format
@@ -200,6 +208,14 @@ describe("isToolCallLine()", () => {
 
 	it('returns true for "find /src"', () => {
 		assert.equal(isToolCallLine("find /src"), true);
+	});
+
+	it('returns true for "rg \"TODO\" in /src"', () => {
+		assert.equal(isToolCallLine('rg "TODO" in /src'), true);
+	});
+
+	it('returns true for "rg"', () => {
+		assert.equal(isToolCallLine("rg"), true);
 	});
 
 	it('returns true for fallback format like "web_search: {...}"', () => {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #981

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 7s | 33.2K | 25 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 25s | 24.8K | 19 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 13s | 35.5K | 30 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 8s | 36.5K | 35 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 19s | 37.4K | 14 | deepseek-v4-flash |

**Total:** 5 agents · 11m 12s · 167.4K tokens · 123 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/981
Closes #981