### PR TITLE
feat(#1036): ICA: Extension-path resolver twins

### DIFF
--- a/.pi/extensions/supervisor/agent/runner.ts
+++ b/.pi/extensions/supervisor/agent/runner.ts
@@ -9,7 +9,6 @@
 import type { AgentRunResult, AgentRunState, ParsedAgent } from "../config/types.ts";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { spawn } from "node:child_process";
-import { resolve as resolvePath } from "node:path";
 import { resolveTools, resolveExtensionPaths, resolveSkillPaths } from "../lib/extensions.ts";
 import { formatDuration, extractSummaryLine } from "../lib/formatting.ts";
 import { DEFAULT_AGENT_TIMEOUT_MS } from "../config/config.ts";
@@ -194,20 +193,7 @@ export async function runAgentSubprocess(
 	const tools = resolveTools(rawTools, agent.config.extensions, effectiveCwd);
 	const model = agent.config.model || "";
 	const bareExtPaths = resolveExtensionPaths(agent.config.extensions, effectiveCwd);
-	const extFlags: string[] = [];
-	const CONTEXT_INFO_PATH = resolvePath(effectiveCwd, ".pi/extensions/context-info.ts");
-	if (bareExtPaths.length === 0) {
-		// No extensions resolved → just context-info
-		extFlags.push("--extension", CONTEXT_INFO_PATH);
-	} else {
-		for (const p of bareExtPaths) {
-			extFlags.push("--extension", p);
-		}
-		// Auto-inject context-info (dedup if already present in any path)
-		if (!bareExtPaths.some((p: string) => p.includes("context-info.ts"))) {
-			extFlags.push("--extension", CONTEXT_INFO_PATH);
-		}
-	}
+	const extFlags = bareExtPaths.flatMap((p) => ["--extension", p]);
 	const skillPaths = resolveSkillPaths(agent.config.skills, effectiveCwd);
 
 	const args: string[] = [

--- a/.pi/extensions/supervisor/agent/runner.ts
+++ b/.pi/extensions/supervisor/agent/runner.ts
@@ -9,7 +9,8 @@
 import type { AgentRunResult, AgentRunState, ParsedAgent } from "../config/types.ts";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import { spawn } from "node:child_process";
-import { resolveTools, resolveExtensions, resolveSkillPaths } from "../lib/extensions.ts";
+import { resolve as resolvePath } from "node:path";
+import { resolveTools, resolveExtensionPaths, resolveSkillPaths } from "../lib/extensions.ts";
 import { formatDuration, extractSummaryLine } from "../lib/formatting.ts";
 import { DEFAULT_AGENT_TIMEOUT_MS } from "../config/config.ts";
 import {
@@ -192,7 +193,21 @@ export async function runAgentSubprocess(
 	const rawTools = agent.config.tools || "read,bash,write,edit";
 	const tools = resolveTools(rawTools, agent.config.extensions, effectiveCwd);
 	const model = agent.config.model || "";
-	const extFlags = resolveExtensions(agent.config.extensions);
+	const bareExtPaths = resolveExtensionPaths(agent.config.extensions, effectiveCwd);
+	const extFlags: string[] = [];
+	const CONTEXT_INFO_PATH = resolvePath(effectiveCwd, ".pi/extensions/context-info.ts");
+	if (bareExtPaths.length === 0) {
+		// No extensions resolved → just context-info
+		extFlags.push("--extension", CONTEXT_INFO_PATH);
+	} else {
+		for (const p of bareExtPaths) {
+			extFlags.push("--extension", p);
+		}
+		// Auto-inject context-info (dedup if already present in any path)
+		if (!bareExtPaths.some((p: string) => p.includes("context-info.ts"))) {
+			extFlags.push("--extension", CONTEXT_INFO_PATH);
+		}
+	}
 	const skillPaths = resolveSkillPaths(agent.config.skills, effectiveCwd);
 
 	const args: string[] = [

--- a/.pi/extensions/supervisor/lib/extensions.ts
+++ b/.pi/extensions/supervisor/lib/extensions.ts
@@ -5,24 +5,18 @@
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 
-// ─── Extension flag resolution ──────────────────────────────────────
+// ─── Extension path resolution ──────────────────────────────────────
 
 /**
- * Resolve the extensions CLI flags for a given agent frontmatter.
- * - If extensions field is present and non-empty, split, trim, filter out
- *   "supervisor" (case-insensitive), and return `--extension <path>` flags.
- * - If extensions field is missing or empty, return no extensions.
- * - Context-info is NOT auto-injected — it's a TUI extension (footer, widgets,
- *   telemetry) that adds noise to stderr in --mode json subprocess agents.
- *   Reason: pi's takeOverStdout() redirects process.stdout.write → stderr
- *   in non-interactive modes, so any console.log from extensions ends up
- *   in stderr where the supervisor captures it as error output.
- *   Agents that want context-info must declare it explicitly.
+ * Internal version of resolveExtensionPaths that accepts a custom existsSync
+ * function for testing. Public API wraps this with real existsSync.
  */
-export function resolveExtensions(extensionsRaw: string | undefined): string[] {
-	if (!extensionsRaw || !extensionsRaw.trim()) {
-		return [];
-	}
+export function resolveExtensionPathsWithFs(
+	extensionsRaw: string | undefined,
+	cwd: string,
+	existsSyncFn: (path: string) => boolean,
+): string[] {
+	if (!extensionsRaw || !extensionsRaw.trim()) return [];
 
 	const extensions = extensionsRaw
 		.split(",")
@@ -30,26 +24,36 @@ export function resolveExtensions(extensionsRaw: string | undefined): string[] {
 		.filter((s) => s.length > 0)
 		.filter((s) => s.toLowerCase() !== "supervisor");
 
-	if (extensions.length === 0) {
-		return [];
-	}
-
-	const result: string[] = [];
+	const paths: string[] = [];
 	for (const ext of extensions) {
 		// Try single-file extension first, then directory-based
-		const filePath = resolvePath(process.cwd(), `.pi/extensions/${ext}.ts`);
-		const dirPath = resolvePath(process.cwd(), `.pi/extensions/${ext}/index.ts`);
-		if (existsSync(filePath)) {
-			result.push("--extension", filePath);
-		} else if (existsSync(dirPath)) {
-			result.push("--extension", dirPath);
+		const filePath = resolvePath(cwd, `.pi/extensions/${ext}.ts`);
+		const dirPath = resolvePath(cwd, `.pi/extensions/${ext}/index.ts`);
+		if (existsSyncFn(filePath)) {
+			paths.push(filePath);
+		} else if (existsSyncFn(dirPath)) {
+			paths.push(dirPath);
 		} else {
 			// Default to single-file path (will fail at runtime, but preserves existing behavior)
-			result.push("--extension", filePath);
+			paths.push(filePath);
 		}
 	}
 
-	return result;
+	return paths;
+}
+
+/**
+ * Resolve extension names from agent frontmatter to absolute file paths
+ * suitable for DefaultResourceLoader.additionalExtensionPaths.
+ * Returns array of absolute file paths (not CLI flags).
+ *
+ * Use resolveExtensionPathsWithFs for testing with a mock existsSync.
+ *
+ * Context-info is NOT auto-injected — it's the caller's responsibility
+ * to append it if needed (see agent/runner.ts for CLI flag formatting).
+ */
+export function resolveExtensionPaths(extensionsRaw: string | undefined, cwd?: string): string[] {
+	return resolveExtensionPathsWithFs(extensionsRaw, cwd ?? process.cwd(), existsSync);
 }
 
 // ─── Skill path resolution ───────────────────────────────────────────
@@ -180,43 +184,6 @@ export function discoverExtensionTools(cwd?: string): Map<string, string[]> {
 }
 
 // ─── Tool merging ──────────────────────────────────────────────────
-
-/**
- * Merge agent-declared tools with tools from agent's extensions.
- * Returns a comma-separated string for --tools flag.
- */
-/**
- * Resolve extension names from agent frontmatter to absolute file paths
- * suitable for DefaultResourceLoader.additionalExtensionPaths.
- * Returns array of absolute file paths (not CLI flags).
- */
-export function resolveExtensionPaths(extensionsRaw: string | undefined, cwd?: string): string[] {
-	if (!extensionsRaw || !extensionsRaw.trim()) return [];
-
-	const baseCwd = cwd || process.cwd();
-
-	const extensions = extensionsRaw
-		.split(",")
-		.map((s) => s.trim())
-		.filter((s) => s.length > 0)
-		.filter((s) => s.toLowerCase() !== "supervisor");
-
-	const paths: string[] = [];
-	for (const ext of extensions) {
-		const filePath = resolvePath(baseCwd, `.pi/extensions/${ext}.ts`);
-		const dirPath = resolvePath(baseCwd, `.pi/extensions/${ext}/index.ts`);
-		if (existsSync(filePath)) {
-			paths.push(filePath);
-		} else if (existsSync(dirPath)) {
-			paths.push(dirPath);
-		} else {
-			// Default to single-file path (will fail at runtime, but preserves existing behavior)
-			paths.push(filePath);
-		}
-	}
-
-	return paths;
-}
 
 /**
  * Merge agent-declared tools with tools from agent's extensions.

--- a/.pi/extensions/supervisor/lib/extensions.ts
+++ b/.pi/extensions/supervisor/lib/extensions.ts
@@ -43,14 +43,11 @@ export function resolveExtensionPathsWithFs(
 }
 
 /**
- * Resolve extension names from agent frontmatter to absolute file paths
- * suitable for DefaultResourceLoader.additionalExtensionPaths.
- * Returns array of absolute file paths (not CLI flags).
+ * Resolve extension names from agent frontmatter to absolute file paths.
+ * Returns bare absolute paths (not CLI flags). Callers format flags
+ * as needed (e.g., flatMap to "--extension" flags).
  *
  * Use resolveExtensionPathsWithFs for testing with a mock existsSync.
- *
- * Context-info is NOT auto-injected — it's the caller's responsibility
- * to append it if needed (see agent/runner.ts for CLI flag formatting).
  */
 export function resolveExtensionPaths(extensionsRaw: string | undefined, cwd?: string): string[] {
 	return resolveExtensionPathsWithFs(extensionsRaw, cwd ?? process.cwd(), existsSync);

--- a/.pi/extensions/supervisor/test/config-lib-refactor.test.mts
+++ b/.pi/extensions/supervisor/test/config-lib-refactor.test.mts
@@ -20,7 +20,12 @@ import assert from "node:assert/strict";
 // These have dedicated test files, but we re-test imports here for
 // belt-and-suspenders coverage.
 
-import { resolveTools, resolveExtensions, resolveSkillPaths } from "../lib/extensions.ts";
+import {
+	resolveTools,
+	resolveExtensionPaths,
+	resolveExtensionPathsWithFs,
+	resolveSkillPaths,
+} from "../lib/extensions.ts";
 import {
 	getDebugLogger,
 	setDebugLogger,
@@ -104,8 +109,12 @@ describe("config→lib refactor — moved lib/ files", () => {
 		assert.equal(typeof resolveTools, "function");
 	});
 
-	it("lib/extensions.ts exports resolveExtensions", () => {
-		assert.equal(typeof resolveExtensions, "function");
+	it("lib/extensions.ts exports resolveExtensionPaths", () => {
+		assert.equal(typeof resolveExtensionPaths, "function");
+	});
+
+	it("lib/extensions.ts exports resolveExtensionPathsWithFs", () => {
+		assert.equal(typeof resolveExtensionPathsWithFs, "function");
 	});
 
 	it("lib/extensions.ts exports resolveSkillPaths", () => {

--- a/.pi/extensions/supervisor/test/supervisor-extensions-dir.test.mts
+++ b/.pi/extensions/supervisor/test/supervisor-extensions-dir.test.mts
@@ -1,135 +1,79 @@
 /**
  * Tests for directory-aware extension resolution in supervisor/extensions.ts
  *
- * Phase 5: resolveExtensions checks if .pi/extensions/{ext} is a directory;
- * emits {ext}/index.ts instead of {ext}.ts. discoverExtensionTools reads
- * index.ts from subdirectories.
+ * Replaces the old duplicate-based tests with direct calls to the real
+ * resolveExtensionPathsWithFs function using an in-memory Map<string, boolean>
+ * as the fake existsSync. No temp directories, no process.chdir.
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/supervisor/test/supervisor-extensions-dir.test.mts
  */
 
 import assert from "node:assert";
-import { describe, it, beforeEach, afterEach } from "node:test";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-
-// ---------------------------------------------------------------------------
-// We duplicate the updated resolveExtensions logic for pure-unit testing,
-// matching the updated production code in supervisor/extensions.ts
-// ---------------------------------------------------------------------------
-
-import { existsSync, statSync, readFileSync, readdirSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { describe, it } from "node:test";
 
-const CONTEXT_INFO_EXTENSION = ".pi/extensions/context-info.ts";
+import { resolveExtensionPathsWithFs } from "../lib/extensions.ts";
 
-function resolveExtensions(extensionsRaw: string | undefined): string[] {
-	if (!extensionsRaw || !extensionsRaw.trim()) {
-		return ["--extension", CONTEXT_INFO_EXTENSION];
-	}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-	const extensions = extensionsRaw
-		.split(",")
-		.map((s) => s.trim())
-		.filter((s) => s.length > 0)
-		.filter((s) => s.toLowerCase() !== "supervisor");
+const BASE_CWD = "/test/cwd";
 
-	const result: string[] = [];
-	for (const ext of extensions) {
-		const tsPath = `.pi/extensions/${ext}.ts`;
-		const dirPath = `.pi/extensions/${ext}`;
-		const dirIndexPath = `${dirPath}/index.ts`;
-		const fullDirPath = resolvePath(process.cwd(), dirPath);
-		if (existsSync(fullDirPath) && statSync(fullDirPath).isDirectory()) {
-			result.push("--extension", dirIndexPath);
-		} else {
-			result.push("--extension", tsPath);
-		}
-	}
+function fakeExists(existing: Map<string, boolean>): (path: string) => boolean {
+	return (path: string) => existing.get(path) === true;
+}
 
-	// Auto-inject context-info (deduplicated)
-	const hasContextInfo = result.some(
-		(r) => r === CONTEXT_INFO_EXTENSION || r.endsWith("/context-info.ts"),
-	);
-	if (!hasContextInfo) {
-		result.push("--extension", CONTEXT_INFO_EXTENSION);
-	}
+function extPath(name: string): string {
+	return resolvePath(BASE_CWD, `.pi/extensions/${name}.ts`);
+}
 
-	return result;
+function extDirPath(name: string): string {
+	return resolvePath(BASE_CWD, `.pi/extensions/${name}/index.ts`);
 }
 
 // ---------------------------------------------------------------------------
-// Test helpers for temp directory structure
+// Tests — directory-aware resolution
 // ---------------------------------------------------------------------------
 
-let origCwd: string;
-
-beforeEach(() => {
-	origCwd = process.cwd();
-});
-
-afterEach(() => {
-	process.chdir(origCwd);
-});
-
-function setupFixture() {
-	const tmpDir = mkdtempSync(join(tmpdir(), "ext-dir-test-"));
-	const extDir = join(tmpDir, ".pi", "extensions");
-
-	// Create directory-based extension: caveman/index.ts
-	const cavemanDir = join(extDir, "caveman");
-	mkdirSync(cavemanDir, { recursive: true });
-	writeFileSync(
-		join(cavemanDir, "index.ts"),
-		`export default function caveman(pi: any) { pi.registerTool({ name: "caveman-tool", handler: () => {} }); }`,
-		"utf8",
-	);
-
-	// Create file-based extension: ask-user.ts
-	writeFileSync(
-		join(extDir, "ask-user.ts"),
-		`export default function askUser(pi: any) { pi.registerTool({ name: "ask-user-tool", handler: () => {} }); }`,
-		"utf8",
-	);
-
-	process.chdir(tmpDir);
-	return tmpDir;
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
-describe("resolveExtensions — directory-aware resolution", () => {
-	it("caveman when directory -> resolves to caveman/index.ts", () => {
-		const tmpDir = setupFixture();
-		const result = resolveExtensions("caveman");
+describe("resolveExtensionPathsWithFs — directory-aware resolution", () => {
+	it("caveman when directory exists → resolves to caveman/index.ts", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extDirPath("caveman"), true);
+		const result = resolveExtensionPathsWithFs("caveman", BASE_CWD, fakeExists(existing));
 		assert.ok(
 			result.some((r) => r.includes("caveman/index.ts")),
 			`Expected caveman/index.ts in result, got: ${JSON.stringify(result)}`,
 		);
 	});
 
-	it("ask-user when file (not dir) -> resolves to ask-user.ts", () => {
-		const tmpDir = setupFixture();
-		const result = resolveExtensions("ask-user");
+	it("ask-user when file exists (not dir) → resolves to ask-user.ts", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("ask-user"), true);
+		const result = resolveExtensionPathsWithFs("ask-user", BASE_CWD, fakeExists(existing));
 		assert.ok(
 			result.some((r) => r.includes("ask-user.ts") && !r.includes("index.ts")),
 			`Expected ask-user.ts in result, got: ${JSON.stringify(result)}`,
 		);
 	});
 
-	it("nonexistent when neither file nor dir -> falls back to .ts path", () => {
-		const tmpDir = setupFixture();
-		const result = resolveExtensions("nonexistent");
+	it("nonexistent when neither file nor dir → falls back to .ts path", () => {
+		const result = resolveExtensionPathsWithFs("nonexistent", BASE_CWD, fakeExists(new Map()));
 		assert.ok(
 			result.some((r) => r.includes("nonexistent.ts")),
 			`Expected nonexistent.ts fallback, got: ${JSON.stringify(result)}`,
 		);
 	});
 
-	it("caveman,supervisor -> supervisor filtered, caveman resolves to index.ts", () => {
-		const tmpDir = setupFixture();
-		const result = resolveExtensions("caveman,supervisor");
+	it("caveman,supervisor → supervisor filtered, caveman resolves to index.ts", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extDirPath("caveman"), true);
+		const result = resolveExtensionPathsWithFs(
+			"caveman,supervisor",
+			BASE_CWD,
+			fakeExists(existing),
+		);
 		assert.ok(
 			result.some((r) => r.includes("caveman/index.ts")),
 			`Expected caveman/index.ts, got: ${JSON.stringify(result)}`,
@@ -137,22 +81,43 @@ describe("resolveExtensions — directory-aware resolution", () => {
 		assert.ok(!result.some((r) => r.includes("supervisor")));
 	});
 
-	it("empty string returns []-with-context-info", () => {
-		const result = resolveExtensions("");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("empty string → []", () => {
+		const result = resolveExtensionPathsWithFs("", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
 	});
 
-	it("undefined returns []-with-context-info", () => {
-		const result = resolveExtensions(undefined);
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("undefined → []", () => {
+		const result = resolveExtensionPathsWithFs(undefined, BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
 	});
 
-	it("scrapling still resolves to scrapling.ts (unchanged file-based)", () => {
-		const tmpDir = setupFixture();
-		const result = resolveExtensions("scrapling");
+	it("scrapling when neither file nor dir → falls back to scrapling.ts", () => {
+		const result = resolveExtensionPathsWithFs("scrapling", BASE_CWD, fakeExists(new Map()));
 		assert.ok(
 			result.some((r) => r.includes("scrapling.ts")),
 			`Expected scrapling.ts, got: ${JSON.stringify(result)}`,
 		);
+	});
+
+	it("directory-based extension with additional single-file → priority: file wins", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("caveman"), true);
+		existing.set(extDirPath("caveman"), true);
+		const result = resolveExtensionPathsWithFs("caveman", BASE_CWD, fakeExists(existing));
+		// File path takes priority over directory index
+		assert.ok(
+			result.some((r) => r.includes("caveman.ts") && !r.includes("index.ts")),
+			`Expected caveman.ts (file priority), got: ${JSON.stringify(result)}`,
+		);
+	});
+
+	it("mixed extensions: one directory, one file → both resolved in order", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extDirPath("caveman"), true);
+		existing.set(extPath("mcp"), true);
+		const result = resolveExtensionPathsWithFs("caveman,mcp", BASE_CWD, fakeExists(existing));
+		assert.strictEqual(result.length, 2);
+		assert.ok(result[0]!.includes("caveman/index.ts"));
+		assert.ok(result[1]!.includes("mcp.ts"));
 	});
 });

--- a/.pi/extensions/supervisor/test/supervisor-extensions.test.mts
+++ b/.pi/extensions/supervisor/test/supervisor-extensions.test.mts
@@ -1,364 +1,311 @@
 /**
- * Tests for resolveExtensions() — per-agent extension resolution logic
- * from .pi/extensions/supervisor.ts
+ * Tests for resolveExtensionPathsWithFs() — per-agent extension path resolution
+ * with injected existsSync seam, and runner CLI formatting (flatMap + context-info).
  *
  * Run with:
  *   node --experimental-strip-types --test .pi/extensions/supervisor/test/supervisor-extensions.test.mts
  */
 
 import assert from "node:assert";
-import { existsSync, readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import { describe, it } from "node:test";
-import { parseAgentFile } from "../agent/loader.ts";
+
+import { resolveExtensionPathsWithFs, resolveExtensionPaths } from "../lib/extensions.ts";
 
 // ---------------------------------------------------------------------------
-// resolveExtensions — duplicated from supervisor.ts for pure-unit testing
-// (supervisor.ts has unresolvable runtime imports in test context)
+// Helpers
 // ---------------------------------------------------------------------------
 
-function resolveExtensions(extensionsRaw: string | undefined): string[] {
-	const base: string[] = [];
-	if (!extensionsRaw || !extensionsRaw.trim()) {
-		base.push("--extension", ".pi/extensions/context-info.ts");
-		return base;
-	}
+/**
+ * Create a fake existsSync function backed by a Map<string, boolean>.
+ * The Map is keyed by absolute paths.
+ */
+function fakeExists(existing: Map<string, boolean>): (path: string) => boolean {
+	return (path: string) => existing.get(path) === true;
+}
 
-	const extensions = extensionsRaw
-		.split(",")
-		.map((s) => s.trim())
-		.filter((s) => s.length > 0)
-		.filter((s) => s.toLowerCase() !== "supervisor");
+/**
+ * A known absolute base directory for tests.
+ * We use a path that avoids assumptions about the test runner's CWD.
+ */
+const BASE_CWD = "/test/cwd";
 
-	if (extensions.length === 0) {
-		base.push("--extension", ".pi/extensions/context-info.ts");
-		return base;
-	}
+/**
+ * Build an absolute extension path under BASE_CWD.
+ */
+function extPath(name: string): string {
+	return resolvePath(BASE_CWD, `.pi/extensions/${name}.ts`);
+}
 
-	for (const ext of extensions) {
-		// Try single-file extension first, then directory-based
-		const filePath = `.pi/extensions/${ext}.ts`;
-		const dirPath = `.pi/extensions/${ext}/index.ts`;
-		if (existsSync(dirPath)) {
-			base.push("--extension", dirPath);
-		} else {
-			base.push("--extension", filePath);
-		}
-	}
-
-	if (!extensions.includes("context-info")) {
-		base.push("--extension", ".pi/extensions/context-info.ts");
-	}
-
-	return base;
+/**
+ * Build an absolute directory-based extension index path under BASE_CWD.
+ */
+function extDirPath(name: string): string {
+	return resolvePath(BASE_CWD, `.pi/extensions/${name}/index.ts`);
 }
 
 // ---------------------------------------------------------------------------
-// Tests — AgentFrontmatter type (frontmatter key flows through)
+// Phase 1: resolveExtensionPathsWithFs — core resolver with injected seam
 // ---------------------------------------------------------------------------
 
-describe("AgentFrontmatter extensions field", () => {
-	it("1.1: parses extensions: 'mcp,browser' + context-info", () => {
-		const result = resolveExtensions("mcp,browser");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
+describe("resolveExtensionPathsWithFs — empty/undefined/missing input", () => {
+	it("undefined extensions → []", () => {
+		const result = resolveExtensionPathsWithFs(undefined, BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
 	});
 
-	it("1.2: undefined extensions → context-info auto-injected", () => {
-		const result = resolveExtensions(undefined);
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("empty string → []", () => {
+		const result = resolveExtensionPathsWithFs("", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
 	});
 
-	it("1.3: empty string extensions → context-info auto-injected", () => {
-		const result = resolveExtensions("");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("whitespace-only → []", () => {
+		const result = resolveExtensionPathsWithFs("   ", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
+	});
+
+	it("supervisor → [] (filtered out)", () => {
+		const result = resolveExtensionPathsWithFs("supervisor", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
+	});
+
+	it("SUPERVISOR → [] (case-insensitive filter)", () => {
+		const result = resolveExtensionPathsWithFs("SUPERVISOR", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
+	});
+
+	it("Supervisor → [] (mixed-case filter)", () => {
+		const result = resolveExtensionPathsWithFs("Supervisor", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, []);
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Tests — runAgent() Extension Resolution Logic
-// ---------------------------------------------------------------------------
-
-describe("runAgent() extension resolution", () => {
-	it("2.1: agent has extensions 'mcp,browser' → --extension per flag + context-info", () => {
-		const result = resolveExtensions("mcp,browser");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
+describe("resolveExtensionPathsWithFs — single-file resolution", () => {
+	it("single-file extension exists → returns [absFilePath]", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		const result = resolveExtensionPathsWithFs("mcp", BASE_CWD, fakeExists(existing));
+		assert.deepStrictEqual(result, [extPath("mcp")]);
 	});
 
-	it("2.2: agent has extensions 'supervisor,mcp' → supervisor filtered out, context-info added", () => {
-		const result = resolveExtensions("supervisor,mcp");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
+	it("directory-based extension exists → returns [absDirIndexPath]", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extDirPath("caveman"), true);
+		const result = resolveExtensionPathsWithFs("caveman", BASE_CWD, fakeExists(existing));
+		assert.deepStrictEqual(result, [extDirPath("caveman")]);
 	});
 
-	it("2.3: only supervisor → context-info auto-injected", () => {
-		const result = resolveExtensions("supervisor");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("file takes priority over directory when both exist", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		existing.set(extDirPath("mcp"), true);
+		const result = resolveExtensionPathsWithFs("mcp", BASE_CWD, fakeExists(existing));
+		assert.deepStrictEqual(result, [extPath("mcp")]);
 	});
 
-	it("2.4: no extensions field (undefined) → context-info auto-injected", () => {
-		const result = resolveExtensions(undefined);
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
-	});
-
-	it("2.5: empty string → context-info auto-injected", () => {
-		const result = resolveExtensions("");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
-	});
-
-	it("2.6: whitespace around names → trimmed + context-info added", () => {
-		const result = resolveExtensions("  mcp  ,  browser  ");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
-	});
-
-	it("2.7: mixed case — passes original case to CLI, supervisor check is case-insensitive + context-info", () => {
-		const result = resolveExtensions("MCP,Browser,Supervisor");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/MCP.ts",
-			"--extension",
-			".pi/extensions/Browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
-	});
-
-	it("2.8: supervisor in middle of list → filtered out, order preserved + context-info", () => {
-		const result = resolveExtensions("mcp,supervisor,browser");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
+	it("neither file nor dir exists → returns default file path (fallback)", () => {
+		const result = resolveExtensionPathsWithFs("unknown", BASE_CWD, fakeExists(new Map()));
+		assert.deepStrictEqual(result, [extPath("unknown")]);
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Tests — Supervisor Auto-Exclusion (Case-Insensitive)
-// ---------------------------------------------------------------------------
-
-describe("supervisor auto-exclusion (case-insensitive)", () => {
-	it("3.1: exclude lowercase 'supervisor' + context-info added", () => {
-		const result = resolveExtensions("mcp,supervisor,browser");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
+describe("resolveExtensionPathsWithFs — mixed multi-ext resolution", () => {
+	it("one single-file, one directory, one missing → three paths in order", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		existing.set(extDirPath("caveman"), true);
+		const result = resolveExtensionPathsWithFs(
+			"mcp,caveman,unknown",
+			BASE_CWD,
+			fakeExists(existing),
+		);
+		assert.deepStrictEqual(result, [extPath("mcp"), extDirPath("caveman"), extPath("unknown")]);
 	});
 
-	it("3.2: exclude uppercase 'SUPERVISOR' + context-info added", () => {
-		const result = resolveExtensions("mcp,SUPERVISOR,browser");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
+	it("supervisor in middle → filtered out, order preserved", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		existing.set(extPath("browser"), true);
+		const result = resolveExtensionPathsWithFs(
+			"mcp,supervisor,browser",
+			BASE_CWD,
+			fakeExists(existing),
+		);
+		assert.deepStrictEqual(result, [extPath("mcp"), extPath("browser")]);
 	});
 
-	it("3.3: exclude mixed-case 'Supervisor' → context-info auto-injected", () => {
-		const result = resolveExtensions("Supervisor");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("cwd controls base directory → all paths start with given cwd", () => {
+		const customCwd = "/custom/cwd";
+		const existing = new Map<string, boolean>();
+		existing.set(resolvePath(customCwd, ".pi/extensions/mcp.ts"), true);
+		const result = resolveExtensionPathsWithFs("mcp", customCwd, fakeExists(existing));
+		assert.ok(result[0]!.startsWith(customCwd));
 	});
 
-	it("3.4: no supervisor in list → passes through + context-info added", () => {
-		const result = resolveExtensions("mcp,browser");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/browser.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
-	});
-
-	it("3.5: only supervisor in list → context-info auto-injected", () => {
-		const result = resolveExtensions("supervisor");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("existsSyncFn called with exact absolute paths", () => {
+		const calledPaths: string[] = [];
+		const trackingExists = (p: string) => {
+			calledPaths.push(p);
+			return false;
+		};
+		resolveExtensionPathsWithFs("test-ext", BASE_CWD, trackingExists);
+		assert.strictEqual(calledPaths.length, 2);
+		assert.ok(calledPaths.includes(extPath("test-ext")));
+		assert.ok(calledPaths.includes(extDirPath("test-ext")));
 	});
 });
 
-// ---------------------------------------------------------------------------
-// Tests — Edge Cases
-// ---------------------------------------------------------------------------
-
-describe("edge cases", () => {
-	it("5.1: only commas → context-info auto-injected", () => {
-		const result = resolveExtensions(",,,,");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
-	});
-
-	it("5.2: 50+ extensions → handles long lists + context-info", () => {
-		const extensions = Array.from({ length: 55 }, (_, i) => `ext-${i}`).join(",");
-		const result = resolveExtensions(extensions);
-		assert.strictEqual(result[0], "--extension");
-		assert.strictEqual(result.length, 112); // 55 pairs + context-info pair
-	});
-
-	it("5.3: extension names with hyphens or dots → pass through + context-info", () => {
-		const result = resolveExtensions("my-custom-tool,my.tool");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/my-custom-tool.ts",
-			"--extension",
-			".pi/extensions/my.tool.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
-	});
-
-	it("5.4: whitespace-only string → context-info auto-injected", () => {
-		const result = resolveExtensions("   ");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
-	});
-
-	it("caveman,scrapling (PS requirement) + context-info", () => {
-		const result = resolveExtensions("caveman,scrapling");
-		// Both caveman and scrapling are directory-based -> resolve to /index.ts
-		assert.ok(result.some((r) => r.includes("caveman/index.ts")));
-		assert.ok(result.some((r) => r.includes("scrapling/index.ts")));
-		assert.ok(result.some((r) => r.includes("context-info.ts")));
-	});
-
-	it("supervisor with caveman → supervisor excluded, context-info added", () => {
-		const result = resolveExtensions("supervisor,caveman,scrapling");
-		assert.ok(result.some((r) => r.includes("caveman/index.ts")));
-		assert.ok(result.some((r) => r.includes("scrapling/index.ts")));
-		assert.ok(result.some((r) => r.includes("context-info.ts")));
-	});
-
-	it("single extension (not supervisor) + context-info", () => {
-		const result = resolveExtensions("mcp");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			".pi/extensions/mcp.ts",
-			"--extension",
-			".pi/extensions/context-info.ts",
-		]);
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Integration test — verify existing agent .md files parse extensions field
-// ---------------------------------------------------------------------------
-
-describe("production agent files — extensions field", () => {
-	const agents = [
-		{
-			name: "architect",
-			expected: "agent-harness,caveman,piignore,ripgrep-search,scrapling,structural-analyzer",
-		},
-		{
-			name: "test-designer",
-			expected: "agent-harness,caveman,piignore,ripgrep-search,scrapling,structural-analyzer",
-		},
-		{
-			name: "developer",
-			expected:
-				"agent-harness,caveman,format-on-save,piignore,ripgrep-search,scrapling,tsc-checkpoint,structural-analyzer,worktree-sandbox",
-		},
-		{
-			name: "auditor",
-			expected:
-				"agent-harness,caveman,piignore,ripgrep-search,scrapling,structural-analyzer,worktree-sandbox",
-		},
-	];
-
-	for (const agent of agents) {
-		it(`${agent.name}.md has extensions field matching expected`, () => {
-			const { config } = parseAgentFile(`.pi/extensions/supervisor/agents/${agent.name}.md`);
-			assert.strictEqual(config.extensions, agent.expected);
-		});
-	}
-
-	it("supervisor.md does NOT exist (supervisor never loads in subagents)", () => {
-		let exists = false;
-		try {
-			readFileSync(".pi/extensions/supervisor/agents/supervisor.md");
-			exists = true;
-		} catch {
-			/* expected */
+describe("resolveExtensionPathsWithFs — boundary cases", () => {
+	it("55 extensions all resolve", () => {
+		const existing = new Map<string, boolean>();
+		const names: string[] = [];
+		for (let i = 0; i < 55; i++) {
+			const name = `ext-${i}`;
+			names.push(name);
+			existing.set(extPath(name), true);
 		}
-		assert.strictEqual(exists, false);
+		const result = resolveExtensionPathsWithFs(names.join(","), BASE_CWD, fakeExists(existing));
+		assert.strictEqual(result.length, 55);
+	});
+
+	it("extension names with hyphens and dots pass through", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("my-custom-tool"), true);
+		existing.set(extPath("my.tool"), true);
+		const result = resolveExtensionPathsWithFs(
+			"my-custom-tool,my.tool",
+			BASE_CWD,
+			fakeExists(existing),
+		);
+		assert.strictEqual(result.length, 2);
+		assert.ok(result[0]!.includes("my-custom-tool"));
+		assert.ok(result[1]!.includes("my.tool"));
+	});
+
+	it("whitespace around names trimmed", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		existing.set(extPath("browser"), true);
+		const result = resolveExtensionPathsWithFs(
+			"  mcp  ,  browser  ",
+			BASE_CWD,
+			fakeExists(existing),
+		);
+		assert.deepStrictEqual(result, [extPath("mcp"), extPath("browser")]);
 	});
 });
 
-describe("production agents resolve without supervisor in output", () => {
-	for (const name of ["architect", "test-designer", "developer", "auditor"]) {
-		it(`${name} extensions resolve without supervisor, with context-info`, () => {
-			const { config } = parseAgentFile(`.pi/extensions/supervisor/agents/${name}.md`);
-			const result = resolveExtensions(config.extensions);
-			// Must not contain --no-extensions (should have --extension flags)
-			assert.notStrictEqual(result[0], "--no-extensions");
-			// Must not contain "supervisor" in any path
-			assert.ok(!result.some((s) => s.toLowerCase().includes("supervisor")));
-			// Must contain context-info
-			assert.ok(result.some((s) => s.includes("context-info.ts")));
-		});
+// ---------------------------------------------------------------------------
+// Phase 1b: resolveExtensionPaths — public wrapper smoketest
+// ---------------------------------------------------------------------------
+
+describe("resolveExtensionPaths — public wrapper", () => {
+	it("called without 3rd arg uses real existsSync and process.cwd()", () => {
+		// This is a smoketest — it calls the real function with a known extension
+		// name that should exist in the real filesystem (supervisor extension itself).
+		const result = resolveExtensionPaths("supervisor");
+		// supervisor is always filtered out, so result should be empty
+		assert.deepStrictEqual(result, []);
+	});
+
+	it("with explicit cwd produces paths under that cwd", () => {
+		const result = resolveExtensionPaths("unknown-test-ext", BASE_CWD);
+		assert.strictEqual(result.length, 1);
+		assert.ok(result[0]!.startsWith(BASE_CWD));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2: Runner CLI formatting (flatMap + context-info injection)
+// Tests the transformation that agent/runner.ts applies to bare paths.
+// These are unit tests for the formatting logic, isolated from the resolver.
+// ---------------------------------------------------------------------------
+
+/**
+ * Simulates the runner's formatting logic: bare paths → --extension flags +
+ * context-info auto-injection (dedup).
+ */
+function formatExtensionFlags(barePaths: string[], contextInfoPath: string): string[] {
+	const flags: string[] = [];
+	if (barePaths.length === 0) {
+		flags.push("--extension", contextInfoPath);
+	} else {
+		for (const p of barePaths) {
+			flags.push("--extension", p);
+		}
+		const hasContextInfo = barePaths.some((p) => p.includes("context-info.ts"));
+		if (!hasContextInfo) {
+			flags.push("--extension", contextInfoPath);
+		}
 	}
+	return flags;
+}
+
+describe("runner CLI formatting — flatMap", () => {
+	it("bare paths → --extension flags in order", () => {
+		const result = formatExtensionFlags(
+			["/a/mcp.ts", "/b/browser.ts"],
+			"/abs/path/to/context-info.ts",
+		);
+		assert.deepStrictEqual(result, [
+			"--extension",
+			"/a/mcp.ts",
+			"--extension",
+			"/b/browser.ts",
+			"--extension",
+			"/abs/path/to/context-info.ts",
+		]);
+	});
+
+	it("empty array → only context-info", () => {
+		const result = formatExtensionFlags([], "/abs/path/to/context-info.ts");
+		assert.deepStrictEqual(result, ["--extension", "/abs/path/to/context-info.ts"]);
+	});
+
+	it("single path + context-info appended correctly", () => {
+		const result = formatExtensionFlags(["/a/mcp.ts"], "/context-info/context-info.ts");
+		assert.deepStrictEqual(result, [
+			"--extension",
+			"/a/mcp.ts",
+			"--extension",
+			"/context-info/context-info.ts",
+		]);
+	});
 });
 
-// ---------------------------------------------------------------------------
-// Tests — context-info extension auto-injection (Phase 3a)
-// ---------------------------------------------------------------------------
-
-describe("context-info extension auto-injection", () => {
-	it("P3.1: no extensions → includes context-info path", () => {
-		const result = resolveExtensions(undefined);
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+describe("runner CLI formatting — context-info dedup", () => {
+	it("context-info NOT in paths → appended", () => {
+		const result = formatExtensionFlags(["/a/mcp.ts"], "/ci/context-info.ts");
+		assert.ok(result.includes("/ci/context-info.ts"));
 	});
 
-	it("P3.2: other extensions → appends context-info (directory-based paths)", () => {
-		const result = resolveExtensions("caveman,scrapling");
-		// Both caveman and scrapling are directory-based -> resolve to /index.ts
-		assert.ok(result.some((r) => r.includes("caveman/index.ts")));
-		assert.ok(result.some((r) => r.includes("scrapling/index.ts")));
-		assert.ok(result.some((r) => r.includes("context-info.ts")));
-	});
-
-	it("P3.3: context-info already in list → no duplication", () => {
-		const result = resolveExtensions("caveman,context-info");
+	it("context-info already in paths → no duplicate", () => {
+		const result = formatExtensionFlags(
+			["/a/mcp.ts", "/ci/context-info.ts"],
+			"/ci/context-info.ts",
+		);
 		const contextInfoCount = result.filter(
-			(s) => s.includes("context-info") && !s.includes("--extension"),
+			(s) => s.includes("context-info.ts") && !s.includes("--extension"),
 		).length;
 		assert.strictEqual(contextInfoCount, 1);
 	});
 
-	it("P3.4: supervisor filtered out, context-info auto-added", () => {
-		const result = resolveExtensions("supervisor");
-		assert.deepStrictEqual(result, ["--extension", ".pi/extensions/context-info.ts"]);
+	it("no resolved paths → only context-info", () => {
+		const result = formatExtensionFlags([], "/abs/path/to/context-info.ts");
+		assert.deepStrictEqual(result, ["--extension", "/abs/path/to/context-info.ts"]);
+	});
+
+	it("resolveExtensionPaths returns bare paths → runner produces flags + context-info", () => {
+		// Integrate: this simulates what runner.ts does end-to-end
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		const barePaths = resolveExtensionPathsWithFs("mcp", BASE_CWD, fakeExists(existing));
+		const result = formatExtensionFlags(barePaths, extPath("context-info"));
+		assert.deepStrictEqual(result, [
+			"--extension",
+			extPath("mcp"),
+			"--extension",
+			extPath("context-info"),
+		]);
 	});
 });

--- a/.pi/extensions/supervisor/test/supervisor-extensions.test.mts
+++ b/.pi/extensions/supervisor/test/supervisor-extensions.test.mts
@@ -1,6 +1,6 @@
 /**
  * Tests for resolveExtensionPathsWithFs() — per-agent extension path resolution
- * with injected existsSync seam, and runner CLI formatting (flatMap + context-info).
+ * with injected existsSync seam, and runner CLI formatting (flatMap).
  *
  * Run with:
  *   node --experimental-strip-types --test .pi/extensions/supervisor/test/supervisor-extensions.test.mts
@@ -216,96 +216,60 @@ describe("resolveExtensionPaths — public wrapper", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Phase 2: Runner CLI formatting (flatMap + context-info injection)
-// Tests the transformation that agent/runner.ts applies to bare paths.
-// These are unit tests for the formatting logic, isolated from the resolver.
+// Phase 2: Runner CLI formatting — flatMap on bare paths
+// agent/runner.ts applies: bareExtPaths.flatMap(p => ["--extension", p])
+// These tests verify the flatMap transformation directly.
 // ---------------------------------------------------------------------------
 
-/**
- * Simulates the runner's formatting logic: bare paths → --extension flags +
- * context-info auto-injection (dedup).
- */
-function formatExtensionFlags(barePaths: string[], contextInfoPath: string): string[] {
-	const flags: string[] = [];
-	if (barePaths.length === 0) {
-		flags.push("--extension", contextInfoPath);
-	} else {
-		for (const p of barePaths) {
-			flags.push("--extension", p);
-		}
-		const hasContextInfo = barePaths.some((p) => p.includes("context-info.ts"));
-		if (!hasContextInfo) {
-			flags.push("--extension", contextInfoPath);
-		}
-	}
-	return flags;
-}
-
-describe("runner CLI formatting — flatMap", () => {
+describe("runner CLI formatting — flatMap on bare paths", () => {
 	it("bare paths → --extension flags in order", () => {
-		const result = formatExtensionFlags(
-			["/a/mcp.ts", "/b/browser.ts"],
-			"/abs/path/to/context-info.ts",
-		);
-		assert.deepStrictEqual(result, [
-			"--extension",
-			"/a/mcp.ts",
-			"--extension",
-			"/b/browser.ts",
-			"--extension",
-			"/abs/path/to/context-info.ts",
-		]);
-	});
-
-	it("empty array → only context-info", () => {
-		const result = formatExtensionFlags([], "/abs/path/to/context-info.ts");
-		assert.deepStrictEqual(result, ["--extension", "/abs/path/to/context-info.ts"]);
-	});
-
-	it("single path + context-info appended correctly", () => {
-		const result = formatExtensionFlags(["/a/mcp.ts"], "/context-info/context-info.ts");
-		assert.deepStrictEqual(result, [
-			"--extension",
-			"/a/mcp.ts",
-			"--extension",
-			"/context-info/context-info.ts",
-		]);
-	});
-});
-
-describe("runner CLI formatting — context-info dedup", () => {
-	it("context-info NOT in paths → appended", () => {
-		const result = formatExtensionFlags(["/a/mcp.ts"], "/ci/context-info.ts");
-		assert.ok(result.includes("/ci/context-info.ts"));
-	});
-
-	it("context-info already in paths → no duplicate", () => {
-		const result = formatExtensionFlags(
-			["/a/mcp.ts", "/ci/context-info.ts"],
-			"/ci/context-info.ts",
-		);
-		const contextInfoCount = result.filter(
-			(s) => s.includes("context-info.ts") && !s.includes("--extension"),
-		).length;
-		assert.strictEqual(contextInfoCount, 1);
-	});
-
-	it("no resolved paths → only context-info", () => {
-		const result = formatExtensionFlags([], "/abs/path/to/context-info.ts");
-		assert.deepStrictEqual(result, ["--extension", "/abs/path/to/context-info.ts"]);
-	});
-
-	it("resolveExtensionPaths returns bare paths → runner produces flags + context-info", () => {
-		// Integrate: this simulates what runner.ts does end-to-end
 		const existing = new Map<string, boolean>();
 		existing.set(extPath("mcp"), true);
-		const barePaths = resolveExtensionPathsWithFs("mcp", BASE_CWD, fakeExists(existing));
-		const result = formatExtensionFlags(barePaths, extPath("context-info"));
-		assert.deepStrictEqual(result, [
+		existing.set(extPath("browser"), true);
+		const barePaths = resolveExtensionPathsWithFs("mcp,browser", BASE_CWD, fakeExists(existing));
+		const flags = barePaths.flatMap((p) => ["--extension", p]);
+		assert.deepStrictEqual(flags, [
 			"--extension",
 			extPath("mcp"),
 			"--extension",
-			extPath("context-info"),
+			extPath("browser"),
 		]);
+	});
+
+	it("empty bare paths → empty flags", () => {
+		const barePaths = resolveExtensionPathsWithFs(undefined, BASE_CWD, fakeExists(new Map()));
+		const flags = barePaths.flatMap((p) => ["--extension", p]);
+		assert.deepStrictEqual(flags, []);
+	});
+
+	it("single path → two-element flag array", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("mcp"), true);
+		const barePaths = resolveExtensionPathsWithFs("mcp", BASE_CWD, fakeExists(existing));
+		const flags = barePaths.flatMap((p) => ["--extension", p]);
+		assert.deepStrictEqual(flags, ["--extension", extPath("mcp")]);
+	});
+
+	it("no resolved paths (supervisor only) → empty flags", () => {
+		const barePaths = resolveExtensionPathsWithFs("supervisor", BASE_CWD, fakeExists(new Map()));
+		const flags = barePaths.flatMap((p) => ["--extension", p]);
+		assert.deepStrictEqual(flags, []);
+	});
+
+	it("extensions with hyphens and dots format correctly as flags", () => {
+		const existing = new Map<string, boolean>();
+		existing.set(extPath("my-custom-tool"), true);
+		existing.set(extPath("my.tool"), true);
+		const barePaths = resolveExtensionPathsWithFs(
+			"my-custom-tool,my.tool",
+			BASE_CWD,
+			fakeExists(existing),
+		);
+		const flags = barePaths.flatMap((p) => ["--extension", p]);
+		assert.strictEqual(flags.length, 4);
+		assert.strictEqual(flags[0], "--extension");
+		assert.ok(flags[1]!.includes("my-custom-tool"));
+		assert.strictEqual(flags[2], "--extension");
+		assert.ok(flags[3]!.includes("my.tool"));
 	});
 });

--- a/.pi/extensions/supervisor/test/supervisor-in-process.test.mts
+++ b/.pi/extensions/supervisor/test/supervisor-in-process.test.mts
@@ -147,77 +147,66 @@ describe("buildToolList()", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Phase 2b: extensions.ts — resolveExtensionPaths
+// Phase 2b: extensions.ts — resolveExtensionPaths (via injected seam)
 // ---------------------------------------------------------------------------
 
-import { existsSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { resolveExtensionPathsWithFs } from "../lib/extensions.ts";
 
-// Duplicated from extensions.ts for unit testing (same pattern as other tests)
-function resolveExtensionPaths(extensionsRaw: string | undefined, cwd?: string): string[] {
-	if (!extensionsRaw || !extensionsRaw.trim()) return [];
-
-	const baseCwd = cwd || process.cwd();
-
-	const extensions = extensionsRaw
-		.split(",")
-		.map((s) => s.trim())
-		.filter((s) => s.length > 0)
-		.filter((s) => s.toLowerCase() !== "supervisor");
-
-	const paths: string[] = [];
-	for (const ext of extensions) {
-		const filePath = resolvePath(baseCwd, `.pi/extensions/${ext}.ts`);
-		const dirPath = resolvePath(baseCwd, `.pi/extensions/${ext}/index.ts`);
-		if (existsSync(filePath)) {
-			paths.push(filePath);
-		} else if (existsSync(dirPath)) {
-			paths.push(dirPath);
-		} else {
-			paths.push(filePath);
-		}
-	}
-
-	return paths;
+/**
+ * Create a fake existsSync backed by a Map<string, boolean>.
+ */
+function fakeExists(existing: Map<string, boolean>): (path: string) => boolean {
+	return (path: string) => existing.get(path) === true;
 }
 
-describe("resolveExtensionPaths()", () => {
+describe("resolveExtensionPaths — via injected seam", () => {
 	it("2.12: empty extensions → empty array", () => {
-		const result = resolveExtensionPaths(undefined, "/tmp");
+		const result = resolveExtensionPathsWithFs(undefined, "/test/cwd", fakeExists(new Map()));
 		assert.deepStrictEqual(result, []);
 	});
 
 	it("2.13: empty string extensions → empty array", () => {
-		const result = resolveExtensionPaths("", "/tmp");
+		const result = resolveExtensionPathsWithFs("", "/test/cwd", fakeExists(new Map()));
 		assert.deepStrictEqual(result, []);
 	});
 
 	it("2.14: supervisor filtered out → empty array", () => {
-		const result = resolveExtensionPaths("supervisor", "/tmp");
+		const result = resolveExtensionPathsWithFs("supervisor", "/test/cwd", fakeExists(new Map()));
 		assert.deepStrictEqual(result, []);
 	});
 
 	it("2.15: whitespace-only → empty array", () => {
-		const result = resolveExtensionPaths("   ", "/tmp");
+		const result = resolveExtensionPathsWithFs("   ", "/test/cwd", fakeExists(new Map()));
 		assert.deepStrictEqual(result, []);
 	});
 
 	it("2.16: non-existent extension returns default path", () => {
-		const result = resolveExtensionPaths("nonexistent", "/tmp");
+		const result = resolveExtensionPathsWithFs("nonexistent", "/test/cwd", fakeExists(new Map()));
 		assert.strictEqual(result.length, 1);
 		assert.ok(result[0]!.endsWith(".pi/extensions/nonexistent.ts"));
-		assert.ok(result[0]!.startsWith("/tmp/"));
+		assert.ok(result[0]!.startsWith("/test/cwd/"));
 	});
 
 	it("2.17: supervisor filtered from multi-ext list, others remain", () => {
-		const result = resolveExtensionPaths("supervisor,mcp,browser", "/tmp");
+		const existing = new Map<string, boolean>();
+		existing.set(resolvePath("/test/cwd", ".pi/extensions/mcp.ts"), true);
+		existing.set(resolvePath("/test/cwd", ".pi/extensions/browser.ts"), true);
+		const result = resolveExtensionPathsWithFs(
+			"supervisor,mcp,browser",
+			"/test/cwd",
+			fakeExists(existing),
+		);
 		assert.strictEqual(result.length, 2);
 		assert.ok(result[0]!.endsWith(".pi/extensions/mcp.ts"));
 		assert.ok(result[1]!.endsWith(".pi/extensions/browser.ts"));
 	});
 
 	it("2.18: multiple extensions all resolved", () => {
-		const result = resolveExtensionPaths("mcp,browser", "/tmp");
+		const existing = new Map<string, boolean>();
+		existing.set(resolvePath("/test/cwd", ".pi/extensions/mcp.ts"), true);
+		existing.set(resolvePath("/test/cwd", ".pi/extensions/browser.ts"), true);
+		const result = resolveExtensionPathsWithFs("mcp,browser", "/test/cwd", fakeExists(existing));
 		assert.strictEqual(result.length, 2);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1036

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 35s | 34.9K | 24 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 46s | 19.4K | 11 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 2s | 29.4K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 37s | 89.0K | 47 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 8m 14s | 60.0K | 65 | minimax-m3 |
| developer | ✓ SUCCESS | 2m 59s | 64.6K | 25 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 13s | 34.3K | 28 | minimax-m3 |

**Total:** 7 agents · 23m 25s · 331.7K tokens · 214 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1036
Closes #1036