### PR TITLE
feat(#1039): ICA: Deprecated tsc formatter twin

### DIFF
--- a/.pi/extensions/lib/tsc-types.ts
+++ b/.pi/extensions/lib/tsc-types.ts
@@ -1,11 +1,11 @@
 /**
- * tsc-types.ts — Shared TypeScript type-check types and formatter.
+ * tsc-types.ts — Shared TypeScript type-check types.
  *
  * Extracted from tsc-checkpoint/index.ts. Decision logic migrated to
  * supervisor/checks/audit-gate-decision.ts.
  * to eliminate the cross-extension direct import from supervisor → tsc-checkpoint.
  *
- * Layer: domain — zero pi dependencies. Pure types + one pure format function.
+ * Layer: domain — zero pi dependencies. Pure types only.
  */
 
 // ── Types ──

--- a/.pi/extensions/tsc-checkpoint/format.ts
+++ b/.pi/extensions/tsc-checkpoint/format.ts
@@ -16,16 +16,44 @@ export function formatTrend(trend: DiagnosticTrend): string {
 }
 
 /**
- * Format diagnostics as clickable file paths with line numbers.
+ * Format diagnostics as grouped, sorted, developer-readable output.
+ *
+ * Groups diagnostics by file, sorts files alphabetically, sorts
+ * diagnostics by line then column within each file.
+ * Truncates individual messages longer than 500 characters.
+ * Returns empty string for null, undefined, or empty input.
+ *
+ * Format per line: `file, Line N: [Error] message (code)`
  */
 export function formatDiagnostics(diagnostics: TscDiagnostic[]): string {
-	if (diagnostics.length === 0) return "";
-	return diagnostics
-		.map((d) => {
+	if (!diagnostics || diagnostics.length === 0) return "";
+
+	// Group by file (use `file` field for relative paths)
+	const byFile = new Map<string, TscDiagnostic[]>();
+	for (const d of diagnostics) {
+		const list = byFile.get(d.file) || [];
+		list.push(d);
+		byFile.set(d.file, list);
+	}
+
+	const blocks: string[] = [];
+	const files = [...byFile.keys()].sort();
+	for (const file of files) {
+		const diags = byFile.get(file)!;
+		diags.sort((a, b) => (a.line !== b.line ? a.line - b.line : a.column - b.column));
+
+		const lines: string[] = [];
+		for (const d of diags) {
+			let msg = d.message;
+			if (msg.length > 500) msg = msg.slice(0, 497) + "...";
 			const codePart = d.code ? ` (${d.code})` : "";
-			return `${d.filePath}, Line ${d.line}: [${d.severity}] ${d.message}${codePart}`;
-		})
-		.join("\n");
+			lines.push(`${d.file}, Line ${d.line}: [${d.severity}] ${msg}${codePart}`);
+		}
+		if (blocks.length > 0) blocks.push("");
+		blocks.push(lines.join("\n"));
+	}
+
+	return blocks.join("\n");
 }
 
 /**

--- a/.pi/extensions/tsc-checkpoint/test/format.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/format.test.ts
@@ -57,7 +57,7 @@ describe("formatTrend", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("formatDiagnostics", () => {
-	it("formats non-empty diagnostics with filePath, line, severity, message, code", () => {
+	it("formats single diagnostic with code", () => {
 		const diags: TscDiagnostic[] = [
 			{
 				file: "src/app.ts",
@@ -70,12 +70,10 @@ describe("formatDiagnostics", () => {
 			},
 		];
 		const result = formatDiagnostics(diags);
-		assert.ok(result.includes("/project/src/app.ts"));
-		assert.ok(result.includes("Line 10"));
-		assert.ok(result.includes("(TS2322)"));
+		assert.strictEqual(result, "src/app.ts, Line 10: [Error] Type error (TS2322)");
 	});
 
-	it("formats with code undefined → no code suffix", () => {
+	it("formats single diagnostic without code → no code suffix", () => {
 		const diags: TscDiagnostic[] = [
 			{
 				file: "src/app.ts",
@@ -87,40 +85,125 @@ describe("formatDiagnostics", () => {
 			},
 		];
 		const result = formatDiagnostics(diags);
-		assert.ok(result.includes("No code error"));
-		assert.ok(!result.includes("(TS"));
+		assert.strictEqual(result, "src/app.ts, Line 5: [Error] No code error");
 	});
 
 	it("returns empty string for empty array", () => {
 		assert.strictEqual(formatDiagnostics([]), "");
 	});
 
-	it("formats multiple diagnostics separated by newline", () => {
+	it("returns empty string for null/undefined", () => {
+		assert.strictEqual(formatDiagnostics(null as unknown as TscDiagnostic[]), "");
+		assert.strictEqual(formatDiagnostics(undefined as unknown as TscDiagnostic[]), "");
+	});
+
+	it("truncates message longer than 500 characters", () => {
+		const longMsg = "x".repeat(600);
 		const diags: TscDiagnostic[] = [
 			{
-				file: "a.ts",
+				file: "src/a.ts",
 				line: 1,
 				column: 1,
 				severity: "Error",
-				message: "err1",
+				message: longMsg,
 				code: "TS1000",
-				filePath: "/a.ts",
+				filePath: "/project/src/a.ts",
+			},
+		];
+		const result = formatDiagnostics(diags);
+		const prefix = "src/a.ts, Line 1: [Error] ";
+		const suffix = " (TS1000)";
+		// Message part between prefix and code suffix: 497 chars + "..." = 500 chars
+		const msgPart = result.slice(prefix.length, -suffix.length);
+		assert.strictEqual(msgPart.length, 500, "message part should be 497 truncated chars + '...'");
+		assert.ok(msgPart.endsWith("..."), "message should contain truncation ellipsis");
+		// Verify the full 600-char message is NOT present
+		assert.ok(
+			!result.includes("x".repeat(498)),
+			"result should not contain the full 600-char string",
+		);
+	});
+
+	it("groups diagnostics by file, sorts files alphabetically and diagnostics by line/col", () => {
+		const diags: TscDiagnostic[] = [
+			{
+				file: "src/b.ts",
+				line: 5,
+				column: 10,
+				severity: "Error",
+				message: "err b1",
+				code: "TS1000",
+				filePath: "/project/src/b.ts",
 			},
 			{
-				file: "b.ts",
-				line: 2,
+				file: "src/a.ts",
+				line: 3,
+				column: 5,
+				severity: "Error",
+				message: "err a1",
+				code: "TS2000",
+				filePath: "/project/src/a.ts",
+			},
+			{
+				file: "src/a.ts",
+				line: 1,
 				column: 2,
 				severity: "Error",
-				message: "err2",
-				code: "TS2000",
-				filePath: "/b.ts",
+				message: "err a0",
+				code: "TS3000",
+				filePath: "/project/src/a.ts",
 			},
 		];
 		const result = formatDiagnostics(diags);
 		const lines = result.split("\n");
+
+		// a.ts should come first (alphabetically), with line 1 before line 3
+		const a0Idx = lines.findIndex((l) => l.includes("err a0"));
+		const a1Idx = lines.findIndex((l) => l.includes("err a1"));
+		const bIdx = lines.findIndex((l) => l.includes("err b1"));
+
+		assert.ok(a0Idx >= 0, "err a0 should be present");
+		assert.ok(a1Idx >= 0, "err a1 should be present");
+		assert.ok(bIdx >= 0, "err b1 should be present");
+
+		// a.ts lines should come before b.ts
+		assert.ok(a0Idx < bIdx, "a.ts should come before b.ts");
+		assert.ok(a1Idx < bIdx, "a.ts second error should come before b.ts");
+		// Within a.ts, line 1 should come before line 3
+		assert.ok(a0Idx < a1Idx, "line 1 should come before line 3 within a.ts");
+
+		// Blank-line separator between file groups
+		const blankIdx = lines.findIndex((l) => l === "");
+		assert.ok(blankIdx >= 0, "should have blank-line separator between file groups");
+		assert.ok(blankIdx > a1Idx, "blank line should be after a.ts errors");
+		assert.ok(blankIdx < bIdx, "blank line should be before b.ts errors");
+	});
+
+	it("sorts multiple diagnostics within same file by line then column", () => {
+		const diags: TscDiagnostic[] = [
+			{
+				file: "a.ts",
+				line: 3,
+				column: 5,
+				severity: "Error",
+				message: "second",
+				filePath: "/abs/a.ts",
+			},
+			{
+				file: "a.ts",
+				line: 1,
+				column: 10,
+				severity: "Error",
+				message: "first",
+				filePath: "/abs/a.ts",
+			},
+		];
+		const result = formatDiagnostics(diags);
+		const lines = result.split("\n");
+		assert.ok(lines[0]!.includes("first"), "line 1 should come before line 3");
+		assert.ok(lines[1]!.includes("second"), "line 3 should come after line 1");
+		// Only two lines, no blank line separator since it's one file
 		assert.strictEqual(lines.length, 2);
-		assert.ok(lines[0]!.includes("TS1000"));
-		assert.ok(lines[1]!.includes("TS2000"));
 	});
 });
 

--- a/.pi/extensions/tsc-checkpoint/test/index.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/index.test.ts
@@ -251,7 +251,7 @@ describe("Extension entry point (/check command)", () => {
 		assert.strictEqual(filePath, resolve(tsconfigDir, "src/app.ts"));
 	});
 
-	it("formatDiagnostics produces clickable paths", () => {
+	it("formatDiagnostics emits relative file paths", () => {
 		const diags: TscDiagnostic[] = [
 			{
 				file: "src/app.ts",
@@ -264,7 +264,7 @@ describe("Extension entry point (/check command)", () => {
 			},
 		];
 		const formatted = formatDiagnostics(diags);
-		assert.ok(formatted.includes("/project/src/app.ts"));
+		assert.ok(formatted.includes("src/app.ts"));
 		assert.ok(formatted.includes("Line 10"));
 		assert.ok(formatted.includes("(TS2322)"));
 	});
@@ -496,7 +496,7 @@ describe("Trust gate (isProjectTrusted)", () => {
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("Mode-adapted output (/check with ctx.mode)", () => {
-	it("TUI mode sends markdown with clickable file paths", async () => {
+	it("TUI mode sends markdown with relative file paths", async () => {
 		const adapter = new MockAdapter();
 		const { handleCheck } = createCheckHandler(adapter, {
 			isProjectTrusted: true,
@@ -523,7 +523,7 @@ describe("Mode-adapted output (/check with ctx.mode)", () => {
 		// Find the error message
 		const errorMsg = result.messages.find((m) => m.content.includes("Type Error(s) Found"));
 		assert.ok(errorMsg, "Should have error message in TUI mode");
-		assert.ok(errorMsg!.content.includes("/project/src/app.ts"));
+		assert.ok(errorMsg!.content.includes("src/app.ts"));
 		assert.ok(errorMsg!.content.includes("Line 10"));
 		assert.ok(errorMsg!.content.includes("(TS2322)"));
 	});

--- a/docs/extensions/tsc-checkpoint.md
+++ b/docs/extensions/tsc-checkpoint.md
@@ -28,7 +28,7 @@ Wraps TypeScript watch compiler API in an incremental diagnostic cache:
 ├── watcher.ts    # DiagnosticsWatcher: createWatchProgram, getDiagnostics, getTrend, stop
 ├── adapter.ts    # TscWatchAdapter: createDefaultAdapter, diagnosticToTscDiagnostic, resolveDiagnosticFilePath
 ├── checkpoint.ts # runTscCheckpoint: orchestrated checkpoint for supervisor pipeline
-├── format.ts     # formatDiagnostics, formatDiagnosticsJson, formatTscDiagnostics, formatTrend
+├── format.ts     # formatDiagnostics, formatDiagnosticsJson, formatTrend
 ├── types.ts      # TscDiagnostic, TscWatchOptions, DiagnosticTrend, TscCheckpointResult
 └── test/         # Watcher + formatter tests
 ```
@@ -68,7 +68,7 @@ flowchart TD
 - **Watcher lifecycle** — `watcher.stop()` called on `session_shutdown`. Prevents file watcher leaks (TypeScript's watch program holds fs watchers on the project dir).
 - **Mode-adapted output** — TUI: markdown with clickable `file://` paths. JSON/RPC/Print: structured JSON `{ type: "tsc-checkpoint", files: [{path, issues}] }`.
 - **Trust gate** — Untrusted projects skip watcher creation. Prevents running `tsc` against potentially unsafe project-local `tsconfig.json` configurations.
-- **Backward-compatible exports** — All sub-module functions re-exported for supervisor pipeline imports. `formatTscDiagnostics` marked deprecated in favor of `formatDiagnostics`.
+- **Backward-compatible exports** — All sub-module functions re-exported for supervisor pipeline imports.
 
 ### DiagnosticsWatcher Internals
 

--- a/docs/extensions/tsc-checkpoint.md
+++ b/docs/extensions/tsc-checkpoint.md
@@ -51,7 +51,7 @@ flowchart TD
     J --> K[watcher.getTrend: compare vs previous]
     K --> L{diagnostics.length > 0?}
     L -- no --> M[Notify: ✓ No type errors]
-    L -- yes --> N[formatDiagnostics: markdown with clickable paths]
+    L -- yes --> N[formatDiagnostics: markdown with relative file paths]
     N --> O[Notify: N errors + trend direction]
     
     J -.-> P[On file change: ts updater diagnostics]


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1039

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 1m 7s | 30.8K | 13 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 4m 20s | 47.0K | 61 | minimax-m3 |
| developer | ✓ SUCCESS | 1m 26s | 36.7K | 20 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 7m 5s | 29.6K | 43 | minimax-m3 |

**Total:** 4 agents · 13m 58s · 144.1K tokens · 137 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1039
Closes #1039