### PR TITLE
feat(#1066): [Bug] structural-analyzer: uses 'ast-grep scan --pattern' but ast-grep 0.43 requires 'ast-grep run --pattern'

### DIFF
--- a/.pi/extensions/structural-analyzer/README.md
+++ b/.pi/extensions/structural-analyzer/README.md
@@ -25,7 +25,7 @@
 2. If language omitted, the extension auto-detects from project config files in scope (tsconfig.json → typescript, pyproject.toml → python, go.mod → go, Cargo.toml → rust, sgconfig.yml → languageGlobs). Defaults to `ts`.
 3. The extension validates the pattern — rejects text-only patterns (redirects to `ripgrep_search`)
 4. Checks the result cache — if the same (pattern, language, cwd) was searched before, returns cached result immediately
-5. Runs `ast-grep scan --pattern <pattern> --json=stream --lang <language>`
+5. Runs `ast-grep run --pattern <pattern> --json=stream --lang <language>`
 6. Parses NDJSON output into structured `SgMatch[]` results
 7. If >100 matches, returns truncated summary with total count; otherwise returns full results
 8. Caches the result for subsequent calls
@@ -103,7 +103,7 @@ flowchart LR
     B -- valid --> D[cache.ts: check key]
     D -- hit --> E[Return cached result]
     D -- miss --> F[await getSgBinary]
-    F --> G[exec ast-grep scan --json=stream]
+    F --> G[exec ast-grep run --json=stream]
     G --> H[parser.ts: interpret exit code]
     H -- error --> I[Throw Error with stderr]
     H -- success --> J[cache.ts: setCache]

--- a/.pi/extensions/structural-analyzer/index.ts
+++ b/.pi/extensions/structural-analyzer/index.ts
@@ -151,7 +151,7 @@ export default function structuralAnalyzer(pi: ExtensionAPI): void {
 
 			// Get binary (lazy init, cached for subsequent calls)
 			const binary = await getSgBinary();
-			const args = ["scan", "--pattern", pattern, "--json=stream", "--lang", language];
+			const args = ["run", "--pattern", pattern, "--json=stream", "--lang", language];
 
 			const result = await pi.exec(binary, args, {
 				cwd: ctx.cwd,

--- a/.pi/extensions/structural-analyzer/test/index.test.mts
+++ b/.pi/extensions/structural-analyzer/test/index.test.mts
@@ -175,7 +175,7 @@ describe("structuralAnalyzer extension wiring", () => {
 			execOverride: async (cmd: string, args: string[]) => {
 				if (args.includes("--version"))
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					scanCallCount++;
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
 				}
@@ -195,7 +195,7 @@ describe("structuralAnalyzer extension wiring", () => {
 			execOverride: async (cmd: string, args: string[]) => {
 				if (args.includes("--version"))
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					scanCallCount++;
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
 				}
@@ -216,7 +216,7 @@ describe("structuralAnalyzer extension wiring", () => {
 				if (args.includes("--version"))
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { stdout: "", stderr: "", code: 1, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					scanCallCount++;
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
 				}
@@ -238,7 +238,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { stdout: "", stderr: "", code: 1, killed: false };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					scanCallCount++;
 					return { stdout: "", stderr: "unknown language", code: 1, killed: false };
 				}
@@ -292,7 +292,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { code: 1, stdout: "" };
 				}
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					const langIdx = args.indexOf("--lang");
 					if (langIdx >= 0) usedLanguage = args[langIdx + 1];
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
@@ -314,7 +314,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					const langIdx = args.indexOf("--lang");
 					if (langIdx >= 0) usedLanguage = args[langIdx + 1];
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
@@ -336,7 +336,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" }; // no files exist
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					const langIdx = args.indexOf("--lang");
 					if (langIdx >= 0) usedLanguage = args[langIdx + 1];
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
@@ -365,7 +365,7 @@ describe("structuralAnalyzer extension wiring", () => {
 				if (cmd === "cat") {
 					return { code: 0, stdout: "languageGlobs:\n  rust: '*.rs'\n" };
 				}
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					const langIdx = args.indexOf("--lang");
 					if (langIdx >= 0) usedLanguage = args[langIdx + 1];
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
@@ -389,7 +389,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") return { stdout: manyMatches, stderr: "", code: 0, killed: false };
+				if (args[0] === "run") return { stdout: manyMatches, stderr: "", code: 0, killed: false };
 				return { stdout: "", stderr: "", code: 0, killed: false };
 			},
 		});
@@ -413,7 +413,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") return { stdout: fiveMatches, stderr: "", code: 0, killed: false };
+				if (args[0] === "run") return { stdout: fiveMatches, stderr: "", code: 0, killed: false };
 				return { stdout: "", stderr: "", code: 0, killed: false };
 			},
 		});
@@ -435,7 +435,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan")
+				if (args[0] === "run")
 					return { stdout: hundredMatches, stderr: "", code: 0, killed: false };
 				return { stdout: "", stderr: "", code: 0, killed: false };
 			},
@@ -458,7 +458,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") return { stdout: matches, stderr: "", code: 0, killed: false };
+				if (args[0] === "run") return { stdout: matches, stderr: "", code: 0, killed: false };
 				return { stdout: "", stderr: "", code: 0, killed: false };
 			},
 		});
@@ -600,7 +600,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					return { stdout: "", stderr: "unknown language", code: 1, killed: false };
 				}
 				return { stdout: "", stderr: "", code: 0, killed: false };
@@ -621,7 +621,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					return { stdout: "", stderr: "Permission denied", code: 126, killed: false };
 				}
 				return { stdout: "", stderr: "", code: 0, killed: false };
@@ -642,7 +642,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					return { stdout: "", stderr: "some error", code: 2, killed: false };
 				}
 				return { stdout: "", stderr: "", code: 0, killed: false };
@@ -660,7 +660,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					return { stdout: "", stderr: "", code: 1, killed: false };
 				}
 				return { stdout: "", stderr: "", code: 0, killed: false };
@@ -681,7 +681,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					scanCallCount++;
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
 				}
@@ -703,7 +703,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					scanCallCount++;
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
 				}
@@ -725,7 +725,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					passedSignal = opts?.signal;
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };
 				}
@@ -763,7 +763,7 @@ describe("structuralAnalyzer extension wiring", () => {
 					return { stdout: "ast-grep 0.42.2", stderr: "", code: 0, killed: false };
 				if (cmd === "test") return { code: 1, stdout: "" };
 				if (cmd === "cat") return { stdout: "", stderr: "", code: 0, killed: false };
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					passedSignal = opts?.signal;
 					// Reject if signal already aborted — verify it's forwarded correctly
 					if (opts?.signal?.aborted) throw new Error("AbortError");
@@ -795,7 +795,7 @@ describe("structuralAnalyzer extension wiring", () => {
 				if (cmd === "cat") {
 					return { code: 0, stdout: "languageGlobs:\n  rust: '*.rs'\n" };
 				}
-				if (args[0] === "scan") {
+				if (args[0] === "run") {
 					const langIdx = args.indexOf("--lang");
 					if (langIdx >= 0) usedLanguage = args[langIdx + 1];
 					return { stdout: TWO_MATCHES, stderr: "", code: 0, killed: false };

--- a/docs/extensions/structural-analyzer.md
+++ b/docs/extensions/structural-analyzer.md
@@ -42,7 +42,7 @@ flowchart LR
     B -- valid --> D[cache.ts: check key]
     D -- hit --> E[Return cached result]
     D -- miss --> F[await getSgBinary]
-    F --> G[exec ast-grep scan --json=stream]
+    F --> G[exec ast-grep run --json=stream]
     G --> H[parser.ts: interpret exit code]
     H -- error --> I[Throw Error with stderr]
     H -- success --> J[cache.ts: setCache]


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1066

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 2m 34s | 45.4K | 42 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 22s | 20.0K | 22 | minimax-m3 |

**Total:** 2 agents · 3m 57s · 65.4K tokens · 64 tool calls
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1066
Closes #1066