### PR TITLE
feat(#1094): Bug: session-advice - identical-args false positive from tool_result entries

### DIFF
--- a/.pi/extensions/session-advice/test/identical-args.test.ts
+++ b/.pi/extensions/session-advice/test/identical-args.test.ts
@@ -13,6 +13,7 @@ import {
 	makeSession,
 	identicalBashEntry,
 	identicalStructuralSearchEntry,
+	toolCallPair,
 } from "./session-test-helpers.ts";
 
 describe("detectIdenticalArgs", () => {
@@ -127,6 +128,29 @@ describe("detectIdenticalArgs", () => {
 
 	it("empty session → 0 signals", () => {
 		assert.strictEqual(detectIdenticalArgs(makeSession([])).length, 0);
+	});
+
+	it("regression: tool_result pairs with empty args → 0 signals", () => {
+		const pairs = [
+			...toolCallPair("read", 0, { path: "/a.ts" }),
+			...toolCallPair("read", 1, { path: "/b.ts" }),
+			...toolCallPair("read", 2, { path: "/c.ts" }),
+		];
+		const data = makeSession(pairs);
+		assert.strictEqual(detectIdenticalArgs(data).length, 0);
+	});
+
+	it("regression: mixed tool_use + tool_result — real identical calls still detected", () => {
+		const entries = [
+			identicalBashEntry("ls", 0),
+			...toolCallPair("bash", 1),
+			identicalBashEntry("ls", 0),
+			...toolCallPair("bash", 1),
+			identicalBashEntry("ls", 0),
+			...toolCallPair("bash", 1),
+		];
+		const data = makeSession(entries);
+		assert.strictEqual(detectIdenticalArgs(data).length, 1);
 	});
 
 	it("6 identical calls → 2 separate signals (no dedup within individual detector)", () => {

--- a/.pi/extensions/session-advice/waste-signals/identical-args.ts
+++ b/.pi/extensions/session-advice/waste-signals/identical-args.ts
@@ -14,7 +14,7 @@ import { sumTokenCost, sumDollarCost } from "../token-utils.ts";
 export function detectIdenticalArgs(data: SessionData): WasteSignal[] {
 	const results: WasteSignal[] = [];
 	const calls = data.entries
-		.filter((e) => e.toolName && e.args)
+		.filter((e) => e.type === "tool_use" && e.toolName && e.args)
 		.map((e) => ({
 			key: `${e.toolName}|${JSON.stringify(e.args)}`,
 			toolName: e.toolName!,


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1094

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 1m 17s | 18.9K | 16 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 48s | 21.7K | 31 | minimax-m3 |

**Total:** 2 agents · 3m 5s · 40.6K tokens · 47 tool calls · 2 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1094
Closes #1094