### PR TITLE
feat(#1096): Bug: session-advice - no-batch inflated consecutive call count from tool_result entries

### DIFF
--- a/.pi/extensions/session-advice/test/identical-args.test.ts
+++ b/.pi/extensions/session-advice/test/identical-args.test.ts
@@ -13,6 +13,7 @@ import {
 	makeSession,
 	identicalBashEntry,
 	identicalStructuralSearchEntry,
+	toolCallPair,
 } from "./session-test-helpers.ts";
 
 describe("detectIdenticalArgs", () => {
@@ -123,6 +124,19 @@ describe("detectIdenticalArgs", () => {
 			{ type: "tool_use", toolName: undefined, args: undefined, text: "", turnIndex: 0 } as any,
 		]);
 		assert.ok(Array.isArray(detectIdenticalArgs(data)), "should return array without crashing");
+	});
+
+	it("3 identical calls with interleaved tool_result entries → count not inflated (#1096)", () => {
+		// toolCallPair sets args: {} on tool_result — latent inflation vector
+		const data = makeSession([
+			...toolCallPair("read", 0, { path: "/a.ts" }),
+			...toolCallPair("read", 1, { path: "/a.ts" }),
+			...toolCallPair("read", 2, { path: "/a.ts" }),
+		]);
+		const signals = detectIdenticalArgs(data);
+		// Should detect 3 tool_use entries with identical args (path: "/a.ts")
+		assert.strictEqual(signals.length, 1, "should produce one identical-args signal");
+		assert.ok(signals[0].occurrences >= 2, "occurrences should be >= 2");
 	});
 
 	it("empty session → 0 signals", () => {

--- a/.pi/extensions/session-advice/test/no-batch.test.ts
+++ b/.pi/extensions/session-advice/test/no-batch.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 import { detectNoBatch } from "../waste-signals/no-batch.ts";
-import { makeSession, readEntry } from "./session-test-helpers.ts";
+import { makeSession, readEntry, toolCallPair } from "./session-test-helpers.ts";
 
 describe("detectNoBatch", () => {
 	it("3 consecutive read calls across turns 0,1,2 → 1 no-batch signal", () => {
@@ -79,6 +79,21 @@ describe("detectNoBatch", () => {
 		]);
 		assert.strictEqual(detectNoBatch(data).length, 1);
 		assert.strictEqual(detectNoBatch(data)[0].context.toolName, "read");
+	});
+
+	it("3 consecutive reads with interleaved tool_result entries → count is 3 not 6 (#1096)", () => {
+		const data = makeSession([
+			...toolCallPair("read", 0, { path: "/a.ts" }),
+			...toolCallPair("read", 1, { path: "/b.ts" }),
+			...toolCallPair("read", 2, { path: "/c.ts" }),
+		]);
+		const signals = detectNoBatch(data);
+		assert.strictEqual(signals.length, 1, "should flag 3 consecutive calls");
+		assert.match(
+			signals[0].details[0],
+			/`read` called 3x consecutively/,
+			"detail should say 3x, not 6x",
+		);
 	});
 
 	it("empty session → 0 signals", () => {

--- a/.pi/extensions/session-advice/waste-signals/_guards.ts
+++ b/.pi/extensions/session-advice/waste-signals/_guards.ts
@@ -1,0 +1,29 @@
+/**
+ * _guards.ts — Type guards for SessionEntry discriminated union
+ *
+ * Prevents the recurring bug class (#431, #1096) of filtering by
+ * `e.toolName` without checking `e.type === "tool_use"`, which
+ * inflates counts by including tool_result entries.
+ *
+ * Domain layer: zero pi dependencies, zero I/O.
+ */
+
+import type { SessionEntry } from "../types.ts";
+
+/**
+ * Narrow SessionEntry to tool_use with a defined toolName.
+ * Use in filters where you want only actual tool-call entries.
+ */
+export function isToolUse(e: SessionEntry): e is SessionEntry & { type: "tool_use"; toolName: string } {
+	return e.type === "tool_use" && !!e.toolName;
+}
+
+/**
+ * Narrow SessionEntry to tool_use with toolName and args.
+ * Use in filters that need both toolName and args (e.g. identical-args).
+ */
+export function isToolUseWithArgs(
+	e: SessionEntry,
+): e is SessionEntry & { type: "tool_use"; toolName: string; args: Record<string, unknown> } {
+	return e.type === "tool_use" && !!e.toolName && !!e.args;
+}

--- a/.pi/extensions/session-advice/waste-signals/identical-args.ts
+++ b/.pi/extensions/session-advice/waste-signals/identical-args.ts
@@ -7,6 +7,7 @@
 
 import type { SessionData, WasteSignal } from "../types.ts";
 import { sumTokenCost, sumDollarCost } from "../token-utils.ts";
+import { isToolUseWithArgs } from "./_guards.ts";
 
 /**
  * Detect identical tool calls with matching args within a sliding window.
@@ -14,7 +15,7 @@ import { sumTokenCost, sumDollarCost } from "../token-utils.ts";
 export function detectIdenticalArgs(data: SessionData): WasteSignal[] {
 	const results: WasteSignal[] = [];
 	const calls = data.entries
-		.filter((e) => e.toolName && e.args)
+		.filter(isToolUseWithArgs)
 		.map((e) => ({
 			key: `${e.toolName}|${JSON.stringify(e.args)}`,
 			toolName: e.toolName!,

--- a/.pi/extensions/session-advice/waste-signals/no-batch.ts
+++ b/.pi/extensions/session-advice/waste-signals/no-batch.ts
@@ -7,6 +7,7 @@
 
 import type { SessionData, WasteSignal } from "../types.ts";
 import { sumTokenCost } from "../token-utils.ts";
+import { isToolUse } from "./_guards.ts";
 
 /**
  * Detect consecutive same-tool calls spread across multiple turns.
@@ -14,7 +15,7 @@ import { sumTokenCost } from "../token-utils.ts";
  */
 export function detectNoBatch(data: SessionData): WasteSignal[] {
 	const results: WasteSignal[] = [];
-	const tools = data.entries.filter((e) => e.toolName);
+	const tools = data.entries.filter(isToolUse);
 
 	let runStart = 0;
 	for (let i = 1; i <= tools.length; i++) {

--- a/.pi/extensions/session-advice/waste-signals/turn-inefficiency.ts
+++ b/.pi/extensions/session-advice/waste-signals/turn-inefficiency.ts
@@ -14,6 +14,7 @@
 import { isBashSearchOrRead } from "../../lib/bash-query.ts";
 import type { SessionData, WasteSignal, SessionEntry } from "../types.ts";
 import { getEntryPath, sumTokenCost, sumDollarCost } from "../token-utils.ts";
+import { isToolUse } from "./_guards.ts";
 
 /** Tools that perform codebase/external discovery (not waste). */
 const DISCOVERY_TOOLS = new Set([
@@ -79,7 +80,7 @@ export function detectTurnInefficiency(data: SessionData): WasteSignal[] {
 		}
 
 		// Count tool_use entries as tool calls (Bug 3: count calls, not all entries)
-		const toolCalls = entries.filter((e) => e.type === "tool_use" && e.toolName);
+		const toolCalls = entries.filter(isToolUse);
 		if (toolCalls.length < 15) {
 			// Accumulate reads even if below threshold
 			const readsThisTurn = readFilesPerTurn.get(turnIndex);


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1096

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| test-designer | ✓ SUCCESS | 1m 27s | 25.3K | 23 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 51s | 44.0K | 29 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 24s | 34.4K | 42 | minimax-m3 |

**Total:** 3 agents · 6m 42s · 103.8K tokens · 94 tool calls · 4 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1096
Closes #1096