### PR TITLE
feat(#1130): [Feature] Warn when configured thinking level differs from effective level after clamping

### DIFF
--- a/.pi/extensions/supervisor/pipeline/execute-agent.ts
+++ b/.pi/extensions/supervisor/pipeline/execute-agent.ts
@@ -12,6 +12,7 @@ import { runAgentSubprocess } from "../agent/runner.ts";
 import { convertAgentRunToToolResult } from "../session/result.ts";
 import { validateAgentResult } from "./output.ts";
 import { replaySessionFile } from "./replay-session.ts";
+import { detectThinkingLevelMismatch } from "./thinking-mismatch.ts";
 
 // ─── executeAgent — primary subprocess execution ───────────────────
 // Signature unchanged for backward compatibility with handler.ts callers.
@@ -60,6 +61,24 @@ export async function executeAgent(
 	// ── 4. Replay session file for persistent chat message ───────
 	if (result.success) {
 		await replaySessionFile(sessionPath, pi, agentName);
+
+		// ── 4a. Detect thinking level mismatch ──────────────────
+		const mismatch = detectThinkingLevelMismatch(sessionPath, agent.config.thinking);
+		if (mismatch) {
+			const msg = `Agent '${agentName}' configured thinking=${mismatch.configured} but model clamps to ${mismatch.effective}. Running at thinking=${mismatch.effective}.`;
+			console.warn(`[${agentName}] Warning: ${msg}`);
+			pi.sendMessage({
+				customType: "supervisor",
+				content: `⚠️ ${msg}`,
+				display: true,
+				details: {
+					eventType: "thinking-mismatch",
+					agentName,
+					configured: mismatch.configured,
+					effective: mismatch.effective,
+				},
+			});
+		}
 	}
 
 	// ── 5. Send final result message ────────────────────────────

--- a/.pi/extensions/supervisor/pipeline/thinking-mismatch.ts
+++ b/.pi/extensions/supervisor/pipeline/thinking-mismatch.ts
@@ -1,0 +1,67 @@
+// ─── Thinking Level Mismatch Detection ────────────────────────────
+// Reads a session JSONL file and compares the configured thinking level
+// (from agent frontmatter) against the effective level recorded in the
+// session file after pi's clampThinkingLevel() clamping.
+//
+// Session file format: JSONL with entries of various types.
+// Thinking level is recorded as a "thinking_level_change" entry at session start.
+// See: node_modules/@earendil-works/pi-coding-agent/docs/session-format.md
+
+import { existsSync, readFileSync } from "node:fs";
+import {
+	parseSessionEntries,
+	type ThinkingLevelChangeEntry,
+} from "@earendil-works/pi-coding-agent";
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export interface ThinkingMismatch {
+	/** Configured thinking level from agent frontmatter (e.g. "medium") */
+	configured: string;
+	/** Effective thinking level from session after clamping (e.g. "high") */
+	effective: string;
+}
+
+// ─── Detection ─────────────────────────────────────────────────────
+
+/**
+ * Detect if the configured thinking level differs from the effective level
+ * recorded in the session file after pi's clamping logic.
+ *
+ * Returns null (no mismatch) when:
+ * - `sessionPath` is undefined or file doesn't exist
+ * - `configuredLevel` is undefined or empty
+ * - No `thinking_level_change` entry found in the session file
+ * - Levels match (no clamping occurred)
+ */
+export function detectThinkingLevelMismatch(
+	sessionPath: string | undefined,
+	configuredLevel: string | undefined,
+): ThinkingMismatch | null {
+	if (!sessionPath || !configuredLevel || !existsSync(sessionPath)) {
+		return null;
+	}
+
+	const content = readFileSync(sessionPath, "utf-8");
+	if (!content.trim()) return null;
+
+	const entries = parseSessionEntries(content);
+
+	// Find the first thinking_level_change entry — this records the effective
+	// level after clamping at session start, before any user messages.
+	for (const entry of entries) {
+		if (entry.type === "thinking_level_change") {
+			const tlc = entry as ThinkingLevelChangeEntry;
+			if (tlc.thinkingLevel && tlc.thinkingLevel !== configuredLevel) {
+				return {
+					configured: configuredLevel,
+					effective: tlc.thinkingLevel,
+				};
+			}
+			// Found the entry and levels match — no mismatch
+			return null;
+		}
+	}
+
+	return null;
+}

--- a/.pi/extensions/supervisor/test/pipeline/thinking-mismatch.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/thinking-mismatch.test.mts
@@ -1,0 +1,202 @@
+// ─── Tests: pipeline/thinking-mismatch.ts — detectThinkingLevelMismatch ─
+// Phase 0 + Phase 2: verifies that configured vs effective thinking level
+// mismatches are detected correctly from session JSONL files.
+
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ─── Import the module under test ──────────────────────────────────
+
+const { detectThinkingLevelMismatch } = await import(
+	"../../pipeline/thinking-mismatch.ts"
+);
+
+// ─── Helpers ───────────────────────────────────────────────────────
+
+function createTempDir(): string {
+	return mkdtempSync(join(tmpdir(), "thinking-mismatch-test-"));
+}
+
+function createSessionFile(dir: string, lines: string[]): string {
+	const filePath = join(dir, "session.jsonl");
+	writeFileSync(filePath, lines.join("\n") + "\n", "utf-8");
+	return filePath;
+}
+
+// ─── Fixtures ──────────────────────────────────────────────────────
+
+const SESSION_HEADER = JSON.stringify({
+	type: "session",
+	version: 3,
+	id: "test-session",
+	timestamp: new Date().toISOString(),
+	cwd: "/repo",
+});
+
+function thinkingChange(level: string, id = "tc-1"): string {
+	return JSON.stringify({
+		type: "thinking_level_change",
+		id,
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		thinkingLevel: level,
+	});
+}
+
+const USER_MESSAGE = JSON.stringify({
+	type: "message",
+	role: "user",
+	id: "msg-1",
+	parentId: null,
+	timestamp: new Date().toISOString(),
+	content: [{ type: "text", text: "Hello" }],
+});
+
+const MODEL_CHANGE = JSON.stringify({
+	type: "model_change",
+	id: "mc-1",
+	parentId: null,
+	timestamp: new Date().toISOString(),
+	provider: "anthropic",
+	modelId: "claude-sonnet-4-20250514",
+});
+
+// ═══════════════════════════════════════════════════════════════════
+// Tests
+// ═══════════════════════════════════════════════════════════════════
+
+await describe("detectThinkingLevelMismatch", async () => {
+	let tmpDir: string;
+
+	afterEach(() => {
+		if (tmpDir) {
+			try {
+				rmSync(tmpDir, { recursive: true, force: true });
+			} catch {
+				// cleanup best-effort
+			}
+		}
+	});
+
+	await it("returns null when sessionPath is undefined", async () => {
+		const result = detectThinkingLevelMismatch(undefined, "medium");
+		assert.equal(result, null);
+	});
+
+	await it("returns null when sessionPath file doesn't exist", async () => {
+		const result = detectThinkingLevelMismatch("/nonexistent/path.jsonl", "medium");
+		assert.equal(result, null);
+	});
+
+	await it("returns null when configuredLevel is undefined", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			thinkingChange("high"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, undefined);
+		assert.equal(result, null);
+	});
+
+	await it("returns null when configured level matches effective level", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			thinkingChange("high"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "high");
+		assert.equal(result, null);
+	});
+
+	await it("returns mismatch when configured level differs from effective level", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			thinkingChange("high"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.notEqual(result, null);
+		assert.equal(result!.configured, "medium");
+		assert.equal(result!.effective, "high");
+	});
+
+	await it("returns mismatch for medium → off clamping", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			thinkingChange("off"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.notEqual(result, null);
+		assert.equal(result!.configured, "medium");
+		assert.equal(result!.effective, "off");
+	});
+
+	await it("uses the first thinking_level_change entry (session start level)", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			thinkingChange("high", "tc-1"),
+			USER_MESSAGE,
+			// A second change mid-session — not relevant for start-level check
+			thinkingChange("xhigh", "tc-2"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.notEqual(result, null);
+		assert.equal(result!.configured, "medium");
+		assert.equal(result!.effective, "high");
+	});
+
+	await it("returns null when no thinking_level_change entry exists", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			MODEL_CHANGE,
+			USER_MESSAGE,
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.equal(result, null);
+	});
+
+	await it("returns null for empty session file", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, []);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.equal(result, null);
+	});
+
+	await it("handles session file with only a header (no thinking_level_change)", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [SESSION_HEADER]);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.equal(result, null);
+	});
+
+	await it("detects mismatch when effective level appears after model change", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			MODEL_CHANGE,
+			thinkingChange("xhigh"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "high");
+		assert.notEqual(result, null);
+		assert.equal(result!.configured, "high");
+		assert.equal(result!.effective, "xhigh");
+	});
+
+	await it("returns ThinkingMismatch with correct shape", async () => {
+		tmpDir = createTempDir();
+		const filePath = createSessionFile(tmpDir, [
+			SESSION_HEADER,
+			thinkingChange("off"),
+		]);
+		const result = detectThinkingLevelMismatch(filePath, "medium");
+		assert.notEqual(result, null);
+		assert.ok(typeof result!.configured === "string");
+		assert.ok(typeof result!.effective === "string");
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1130

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 27s | 57.6K | 19 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 2m 44s | 78.6K | 43 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 16s | 55.4K | 22 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 7m 0s | 75.3K | 39 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 30s | 51.5K | 27 | minimax-m3 |

**Total:** 5 agents · 15m 58s · 318.4K tokens · 150 tool calls · 11 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1130
Closes #1130