### PR TITLE
feat(#1133): Bug: tsc-checkpoint - watcher not invalidated when worktree changes

### DIFF
--- a/.pi/extensions/tsc-checkpoint/README.md
+++ b/.pi/extensions/tsc-checkpoint/README.md
@@ -99,8 +99,11 @@ flowchart TD
     D -- no --> E[Notify: skip]
     D -- yes --> F{Watcher exists?}
     F -- no --> G[new DiagnosticsWatcher]
+    F -- yes --> S{tsconfigPath matches watcher?}
+    S -- no --> T[watcher.stop]
+    T --> G
+    S -- yes --> I{Watcher running?}
     G --> H[watcher.start: ts.createWatchProgram]
-    F -- yes --> I{Watcher running?}
     I -- no --> H
     I -- yes --> J[watcher.getDiagnostics]
     H --> J
@@ -118,6 +121,7 @@ flowchart TD
 - **Incremental watch mode** — `ts.createWatchProgram()` runs in background. File changes trigger incremental re-check. Subsequent `/check` calls return cached diagnostics instantly.
 - **Error trending** — `getTrend()` compares current vs previous error count: `regressed` (more), `improved` (fewer), `stable` (same).
 - **Watcher lifecycle** — `watcher.stop()` on `session_shutdown` prevents file watcher leaks.
+- **Per-worktree watcher** — The watcher is keyed to the worktree's `tsconfig.json` path. Switching projects (different worktree path) invalidates the old watcher, stopping it and creating a fresh one for the new path. This prevents cross-project diagnostic contamination and leaked file watchers.
 - **Mode-adapted output** — TUI: markdown with clickable `file://` paths. JSON/RPC/Print: structured JSON.
 - **Trust gate** — Untrusted projects skip watcher creation. Prevents running `tsc` against unsafe project-local `tsconfig.json`.
 - **Backward-compatible exports** — All sub-module functions re-exported for supervisor pipeline.

--- a/.pi/extensions/tsc-checkpoint/index.ts
+++ b/.pi/extensions/tsc-checkpoint/index.ts
@@ -19,13 +19,10 @@ import { parseArgs } from "@earendil-works/pi-coding-agent";
 
 import type {
 	TscDiagnostic,
-	TscWatchOptions,
 	DiagnosticTrend,
-	TscCheckpointResult,
 } from "./types.ts";
 import type { TscWatchAdapter } from "./adapter.ts";
 import {
-	createDefaultAdapter,
 	diagnosticToTscDiagnostic,
 	resolveDiagnosticFilePath,
 } from "./adapter.ts";
@@ -45,15 +42,12 @@ void parseArgs;
 // Type re-exports
 export type {
 	TscDiagnostic,
-	TscWatchOptions,
 	DiagnosticTrend,
-	TscCheckpointResult,
 } from "./types.ts";
 export type { TscWatchAdapter } from "./adapter.ts";
 
 // Value re-exports
 export {
-	createDefaultAdapter,
 	diagnosticToTscDiagnostic,
 	resolveDiagnosticFilePath,
 } from "./adapter.ts";
@@ -111,8 +105,9 @@ export default function tscCheckpoint(pi: ExtensionAPI): void {
 				return;
 			}
 
-			// Create watcher lazily on first /check
-			if (!watcher) {
+			// Create watcher lazily on first /check, or recreate when worktree changes
+			if (!watcher || watcher.tsconfigPathValue !== tsconfigPath) {
+				watcher?.stop(); // stop old watcher before creating a new one for a different worktree
 				watcher = new DiagnosticsWatcher(tsconfigPath);
 			}
 

--- a/.pi/extensions/tsc-checkpoint/test/index.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/index.test.ts
@@ -7,6 +7,7 @@
  */
 
 import assert from "node:assert";
+import fs from "node:fs";
 import { describe, it } from "node:test";
 import { resolve } from "node:path";
 
@@ -111,8 +112,9 @@ function createCheckHandler(
 			return { messages, diagnostics: [] };
 		}
 
-		// Create watcher lazily
-		if (!watcherInstance) {
+		// Create watcher lazily, or recreate when worktree changes
+		if (!watcherInstance || watcherInstance.tsconfigPathValue !== tsconfigPath) {
+			watcherInstance?.stop(); // stop old watcher before creating a new one
 			const directAdapter = adapter ?? new MockAdapter();
 			watcherInstance = new DiagnosticsWatcher(tsconfigPath, undefined, directAdapter);
 		}
@@ -271,6 +273,114 @@ describe("Extension entry point (/check command)", () => {
 
 	it("formatDiagnostics with empty array returns empty string", () => {
 		assert.strictEqual(formatDiagnostics([]), "");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Worktree switch — watcher invalidation when worktree changes
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("worktree switch — watcher invalidation", () => {
+	it("checking same worktree twice does NOT call stop", async () => {
+		const adapter = new MockAdapter();
+		const { handleCheck } = createCheckHandler(adapter);
+
+		await handleCheck(process.cwd());
+		assert.strictEqual(adapter.startCalls, 1);
+		assert.strictEqual(adapter.stopCalls, 0);
+
+		await handleCheck(process.cwd());
+		// Still only 1 start, 0 stop — same worktree reuses watcher
+		assert.strictEqual(adapter.startCalls, 1);
+		assert.strictEqual(adapter.stopCalls, 0);
+	});
+
+	it("switching to different worktree stops old watcher and creates new one", async () => {
+		const adapter = new MockAdapter();
+		const { handleCheck } = createCheckHandler(adapter);
+
+		// First call in worktree A
+		await handleCheck(process.cwd());
+		const firstPath = adapter.lastStartPath;
+		assert.strictEqual(adapter.startCalls, 1);
+		assert.strictEqual(adapter.stopCalls, 0);
+
+		// Second call in different worktree B
+		const tmpDir = fs.mkdtempSync("tsc-test-");
+		try {
+			fs.writeFileSync(resolve(tmpDir, "tsconfig.json"), JSON.stringify({ compilerOptions: { noEmit: true } }));
+			const tsconfigPathB = resolve(tmpDir, "tsconfig.json");
+
+			await handleCheck(tmpDir);
+
+			// Old watcher was stopped, new watcher created for worktree B
+			assert.strictEqual(adapter.stopCalls, 1, "should stop old watcher");
+			assert.strictEqual(adapter.startCalls, 2, "should create new watcher");
+			assert.notStrictEqual(adapter.lastStartPath, firstPath, "should use new path");
+			assert.strictEqual(adapter.lastStartPath, tsconfigPathB, "new path matches worktree B");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("worktree switch with no tsconfig returns skip, old watcher unchanged", async () => {
+		const adapter = new MockAdapter();
+		const { handleCheck } = createCheckHandler(adapter);
+
+		// First call in worktree A creates watcher
+		await handleCheck(process.cwd());
+		assert.strictEqual(adapter.startCalls, 1);
+
+		// Second call in worktree with no tsconfig
+		const { handleCheck: handleCheckNoConfig } = createCheckHandler(adapter);
+		const tmpDir = fs.mkdtempSync("tsc-test-noconfig-");
+		try {
+			const result = await handleCheckNoConfig(tmpDir);
+			// Skip message returned
+			assert.ok(result.messages.some((m) => m.content.includes("No `tsconfig.json` found")));
+			// Old watcher unchanged — no stop/start
+			assert.strictEqual(adapter.stopCalls, 0, "should not stop");
+			assert.strictEqual(adapter.startCalls, 1, "should not start new watcher");
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("worktree switch with start failure sends error, no crash", async () => {
+		const adapter = new MockAdapter();
+		const { handleCheck } = createCheckHandler(adapter);
+
+		// First call creates watcher
+		await handleCheck(process.cwd());
+		assert.strictEqual(adapter.startCalls, 1);
+		assert.strictEqual(adapter.stopCalls, 0);
+
+		// Second call in worktree B — make start fail
+		adapter.setShouldFailStart(true);
+		const tmpDir = fs.mkdtempSync("tsc-test-startfail-");
+		try {
+			fs.writeFileSync(resolve(tmpDir, "tsconfig.json"), JSON.stringify({ compilerOptions: {} }));
+			const result = await handleCheck(tmpDir);
+
+			// Old watcher was stopped
+			assert.strictEqual(adapter.stopCalls, 1, "should stop old watcher");
+			// Second start attempted but failed
+			assert.strictEqual(adapter.startCalls, 2, "should attempt start");
+			// Error message sent
+			assert.ok(result.messages.some((m) => m.content.includes("Failed to start watcher")));
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("watcher identity key is tsconfigPathValue", () => {
+		const adapter = new MockAdapter();
+		const pathA = resolve(process.cwd(), "tsconfig.json");
+		const pathB = resolve("/other/project", "tsconfig.json");
+
+		const w = new DiagnosticsWatcher(pathA, undefined, adapter);
+		assert.strictEqual(w.tsconfigPathValue, pathA);
+		assert.notStrictEqual(w.tsconfigPathValue, pathB);
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1133

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| test-designer | ✓ SUCCESS | 1m 18s | 30.7K | 13 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 2s | 55.0K | 28 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 20s | 37.9K | 26 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 46s | 47.1K | 37 | minimax-m3 |

**Total:** 4 agents · 10m 26s · 170.7K tokens · 104 tool calls · 5 failed (5%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1133
Closes #1133

**Gate failures:**
- Dead Code Gate gate failed on run 2 — developer restarted