### PR TITLE
feat(#1142): [Bug] Subagent tool calls missing from session metadata toolStats

### DIFF
--- a/.pi/extensions/session-logger/renderer.ts
+++ b/.pi/extensions/session-logger/renderer.ts
@@ -34,6 +34,10 @@ export interface ParsedSessionStats {
 	thinkingChanges: Array<{ time: string; level: string }>;
 	compactions: number;
 	toolStats: Record<string, { calls: number; errors: number; totalDurationMs: number }>;
+	subagentToolStats?: Record<
+		string,
+		Record<string, { calls: number; errors: number; totalDurationMs: number }>
+	>;
 	fileModifications: Array<{ action: string; path: string; timestamp: string; size?: number }>;
 	perTurnTokens: Array<{
 		turnIndex: number;
@@ -200,6 +204,10 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 	let totalCost = 0;
 	let compactions = 0;
 	const toolCounts: Record<string, { calls: number; errors: number; totalDurationMs: number }> = {};
+	const subagentToolStats: Record<
+		string,
+		Record<string, { calls: number; errors: number; totalDurationMs: number }>
+	> = {};
 	const fileMods: Array<{ action: string; path: string; timestamp: string; size?: number }> = [];
 
 	// Per-turn tracking — uses shared PerTurnState from per-turn.ts
@@ -269,9 +277,48 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 			} else if (role === "assistant" && turnState.currentTurnIndex < 0) {
 				turnState.currentTurnIndex = 0;
 			}
+		} else if (entry.type === "custom") {
+			// Extract subagent tool calls from supervisor custom messages
+			const details = entry.details as Record<string, unknown> | undefined;
+			if (
+				entry.customType === "supervisor" &&
+				details?.eventType === "tool-complete" &&
+				details?.toolName &&
+				typeof details.toolName === "string"
+			) {
+				const toolName = details.toolName;
+				const isError = !!details.isError;
+				const durationMs =
+					typeof details.toolDurationMs === "number" ? details.toolDurationMs : 0;
+				const agentName =
+					details?.agentName && typeof details.agentName === "string"
+						? details.agentName
+						: "?";
+
+				// Merge into flat toolStats
+				if (!toolCounts[toolName])
+					toolCounts[toolName] = { calls: 0, errors: 0, totalDurationMs: 0 };
+				toolCounts[toolName].calls++;
+				if (isError) toolCounts[toolName].errors++;
+				toolCounts[toolName].totalDurationMs += durationMs;
+
+				// Build per-agent breakdown
+				if (!subagentToolStats[agentName]) subagentToolStats[agentName] = {};
+				if (!subagentToolStats[agentName][toolName])
+					subagentToolStats[agentName][toolName] = {
+						calls: 0,
+						errors: 0,
+						totalDurationMs: 0,
+					};
+				subagentToolStats[agentName][toolName].calls++;
+				if (isError) subagentToolStats[agentName][toolName].errors++;
+				subagentToolStats[agentName][toolName].totalDurationMs += durationMs;
+			}
 		}
 	}
 	flushTurn(turnState);
+
+	const hasSubagentTools = Object.keys(subagentToolStats).length > 0;
 
 	return {
 		sessionId: header.id ?? "?",
@@ -292,6 +339,7 @@ export function parseSessionStats(filepath: string): ParsedSessionStats | null {
 		thinkingChanges,
 		compactions,
 		toolStats: toolCounts,
+		subagentToolStats: hasSubagentTools ? subagentToolStats : undefined,
 		fileModifications: fileMods,
 		perTurnTokens: turnState.perTurnTokens,
 	};
@@ -385,6 +433,18 @@ export function renderSessionToMarkdown(
 			if (!toolCounts[tn]) toolCounts[tn] = { calls: 0, errors: 0 };
 			toolCounts[tn].calls++;
 			if (l.message.isError) toolCounts[tn].errors++;
+		}
+		// Include subagent tool-complete entries
+		if (
+			l.type === "custom" &&
+			l.customType === "supervisor" &&
+			l.details?.eventType === "tool-complete" &&
+			l.details?.toolName
+		) {
+			const tn = l.details.toolName;
+			if (!toolCounts[tn]) toolCounts[tn] = { calls: 0, errors: 0 };
+			toolCounts[tn].calls++;
+			if (l.details.isError) toolCounts[tn].errors++;
 		}
 	}
 

--- a/.pi/extensions/session-logger/report.ts
+++ b/.pi/extensions/session-logger/report.ts
@@ -61,6 +61,7 @@ export function buildMetadata(
 		thinkingChanges: parsed.thinkingChanges,
 		perTurnTokens: parsed.perTurnTokens,
 		toolStats,
+		subagentToolStats: parsed.subagentToolStats,
 		fileModifications: parsed.fileModifications,
 	};
 }

--- a/.pi/extensions/session-logger/test/report.test.mts
+++ b/.pi/extensions/session-logger/test/report.test.mts
@@ -341,4 +341,70 @@ describe("buildMetadata() — pure function unit tests", () => {
 	it("buildMetadata is a function (exported from report.ts)", () => {
 		assert.strictEqual(typeof buildMetadata, "function", "buildMetadata should be a function");
 	});
+
+	it("buildMetadata returns metadata with subagentToolStats set from parsed stats when present", () => {
+		const subagentStats = {
+			researcher: {
+				read: { calls: 3, errors: 1, totalDurationMs: 500 },
+				web_search: { calls: 2, errors: 0, totalDurationMs: 300 },
+			},
+			developer: {
+				bash: { calls: 5, errors: 0, totalDurationMs: 1000 },
+			},
+		};
+		const parsed = makeParsed({ subagentToolStats: subagentStats });
+		const meta = buildMetadata(parsed);
+
+		assert.ok(meta.subagentToolStats, "subagentToolStats should be present");
+		assert.deepStrictEqual(meta.subagentToolStats, subagentStats, "should match parsed stats");
+	});
+
+	it("buildMetadata returns metadata without subagentToolStats when parsed has none (non-supervisor session)", () => {
+		const parsed = makeParsed(); // no subagentToolStats
+		const meta = buildMetadata(parsed);
+
+		assert.strictEqual(meta.subagentToolStats, undefined, "subagentToolStats should be undefined");
+	});
+
+	it("snapshot timing merge does NOT affect subagentToolStats — unmodified passthrough", () => {
+		const subagentStats = {
+			researcher: {
+				read: { calls: 3, errors: 1, totalDurationMs: 500 },
+			},
+		};
+		const parsed = makeParsed({
+			subagentToolStats: subagentStats,
+			toolStats: { read: { calls: 1, errors: 0, totalDurationMs: 0 } },
+		});
+		const execs = [makeToolExecution("read", { durationMs: 150 })];
+		const snapshot = makeSnapshot(execs);
+		const meta = buildMetadata(parsed, snapshot);
+
+		// subagentToolStats unchanged
+		assert.deepStrictEqual(
+			meta.subagentToolStats,
+			subagentStats,
+			"subagentToolStats unchanged after snapshot merge",
+		);
+		// toolStats still merged as before
+		assert.strictEqual(meta.toolStats!.read.totalDurationMs, 150, "toolStats duration from snapshot");
+	});
+
+	it("overrides (sessionName, mode) do not affect subagentToolStats", () => {
+		const subagentStats = {
+			researcher: {
+				read: { calls: 1, errors: 0, totalDurationMs: 100 },
+			},
+		};
+		const parsed = makeParsed({ subagentToolStats: subagentStats });
+		const meta = buildMetadata(parsed, undefined, { sessionName: "test", mode: "tui" });
+
+		assert.strictEqual(meta.name, "test");
+		assert.strictEqual(meta.mode, "tui");
+		assert.deepStrictEqual(
+			meta.subagentToolStats,
+			subagentStats,
+			"subagentToolStats unchanged by overrides",
+		);
+	});
 });

--- a/.pi/extensions/session-logger/test/session-logger-renderer.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-renderer.test.mts
@@ -773,3 +773,463 @@ describe("renderSessionToMarkdown — header name/mode overrides", () => {
 		assert.ok(md.includes("| **Input tokens** |"), "Input tokens row present");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// parseSessionStats — subagent tool calls from supervisor custom entries
+// ---------------------------------------------------------------------------
+
+describe("parseSessionStats — subagent tool calls from supervisor custom entries", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-logger-subagent-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeJsonl(entries: Record<string, unknown>[]): string {
+		const filepath = path.join(tmpDir, "test-session.jsonl");
+		const header = {
+			type: "session",
+			id: "test-session-subagent",
+			timestamp: "2025-06-01T10:00:00Z",
+			cwd: "/tmp",
+			version: 1,
+		};
+		const lines = [header, ...entries].map((e) => JSON.stringify(e)).join("\n") + "\n";
+		fs.writeFileSync(filepath, lines, "utf-8");
+		return filepath;
+	}
+
+	it("merges subagent tool calls into toolStats alongside native toolResult counts", () => {
+		const filepath = writeJsonl([
+			// Native toolResult
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "read",
+					isError: false,
+					content: [{ type: "text", text: "content" }],
+				},
+			},
+			// Subagent tool-complete
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "read",
+					agentName: "researcher",
+					isError: false,
+					toolDurationMs: 500,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.toolStats.read.calls, 2, "2 read calls total (1 native + 1 subagent)");
+	});
+
+	it("extracts per-agent subagentToolStats breakdown", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "read",
+					agentName: "researcher",
+					isError: false,
+					toolDurationMs: 200,
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: false,
+					toolDurationMs: 300,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.ok(parsed.subagentToolStats, "should have subagentToolStats");
+		assert.strictEqual(
+			parsed.subagentToolStats!["researcher"]["read"].calls,
+			1,
+			"researcher has 1 read call",
+		);
+		assert.strictEqual(
+			parsed.subagentToolStats!["developer"]["bash"].calls,
+			1,
+			"developer has 1 bash call",
+		);
+	});
+
+	it("subagent tool-complete with isError increments error count", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: true,
+					toolDurationMs: 100,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.toolStats.bash.errors, 1, "1 error in flat toolStats");
+		assert.strictEqual(
+			parsed.subagentToolStats!["developer"]["bash"].errors,
+			1,
+			"1 error in per-agent breakdown",
+		);
+	});
+
+	it("supervisor entry with missing toolName (malformed) silently skipped", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					// no toolName
+					agentName: "researcher",
+					isError: false,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(Object.keys(parsed.toolStats).length, 0, "no tools extracted");
+	});
+
+	it("supervisor entry with missing agentName uses ? as agent key", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					// no agentName
+					isError: false,
+					toolDurationMs: 100,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.ok(parsed.subagentToolStats, "should have subagentToolStats");
+		assert.strictEqual(parsed.subagentToolStats!["?"]["bash"].calls, 1, "uses ? as agent key");
+	});
+
+	it("non-tool-complete eventType (tool-start, thinking) ignored", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-start",
+					toolName: "read",
+					agentName: "researcher",
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "thinking",
+					content: "hmm",
+					agentName: "researcher",
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(Object.keys(parsed.toolStats).length, 0, "no tools from non-tool-complete events");
+	});
+
+	it("customType other than supervisor with eventType tool-complete ignored", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "other-plugin",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "other",
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(Object.keys(parsed.toolStats).length, 0, "non-supervisor custom ignored");
+	});
+
+	it("merged: 2 native bash + 2 subagent bash = 4 total in toolStats.bash.calls", () => {
+		const filepath = writeJsonl([
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "bash",
+					isError: false,
+					content: [{ type: "text", text: "ok" }],
+				},
+			},
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "bash",
+					isError: false,
+					content: [{ type: "text", text: "ok2" }],
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: false,
+					toolDurationMs: 100,
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: true,
+					toolDurationMs: 200,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.toolStats.bash.calls, 4, "4 bash calls total");
+		assert.strictEqual(parsed.toolStats.bash.errors, 1, "1 bash error total");
+		assert.strictEqual(
+			parsed.toolStats.bash.totalDurationMs,
+			300,
+			"300ms total duration from subagent entries",
+		);
+	});
+
+	it("toolDurationMs from subagent details used for totalDurationMs", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "read",
+					agentName: "researcher",
+					isError: false,
+					toolDurationMs: 1500,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.toolStats.read.totalDurationMs, 1500, "duration from details used");
+	});
+
+	it("empty session with no supervisor entries returns subagentToolStats undefined", () => {
+		const filepath = writeJsonl([]);
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.subagentToolStats, undefined, "subagentToolStats undefined for empty");
+	});
+
+	it("multiple agents each contribute distinct entries", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "read",
+					agentName: "researcher",
+					isError: false,
+					toolDurationMs: 100,
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: false,
+					toolDurationMs: 200,
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: true,
+					toolDurationMs: 300,
+				},
+			},
+		]);
+
+		const parsed = parseSessionStats(filepath);
+		assert.ok(parsed, "should parse");
+		assert.strictEqual(parsed.subagentToolStats!["researcher"]["read"].calls, 1);
+		assert.strictEqual(parsed.subagentToolStats!["developer"]["bash"].calls, 2);
+		assert.strictEqual(parsed.subagentToolStats!["developer"]["bash"].errors, 1);
+		assert.strictEqual(parsed.subagentToolStats!["developer"]["bash"].totalDurationMs, 500);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// renderSessionToMarkdown — subagent tool calls in Tool Usage table
+// ---------------------------------------------------------------------------
+
+describe("renderSessionToMarkdown — subagent tool calls in Tool Usage table", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-logger-renderer-sub-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeJsonl(entries: Record<string, unknown>[]): string {
+		const filepath = path.join(tmpDir, "test-session.jsonl");
+		const header = {
+			type: "session",
+			id: "test-session-sub",
+			timestamp: "2025-06-01T10:00:00Z",
+			cwd: "/tmp",
+			version: 1,
+		};
+		const lines = [header, ...entries].map((e) => JSON.stringify(e)).join("\n") + "\n";
+		fs.writeFileSync(filepath, lines, "utf-8");
+		return filepath;
+	}
+
+	it("Tool Usage table includes tools from supervisor tool-complete entries", () => {
+		const filepath = writeJsonl([
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "read",
+					isError: false,
+					content: [{ type: "text", text: "content" }],
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: false,
+				},
+			},
+		]);
+
+		const md = renderSessionToMarkdown(filepath);
+		assert.ok(md.includes("## Tool Usage"), "Tool Usage section present");
+		assert.ok(md.includes("read"), "includes native tool read");
+		assert.ok(md.includes("bash"), "includes subagent tool bash");
+		// Both should appear in table rows
+		assert.ok(md.includes("| \`read\` | 1 |"), "read row with 1 call");
+		assert.ok(md.includes("| \`bash\` | 1 |"), "bash row with 1 call");
+	});
+
+	it("tool counts from subagent entries aggregated into same table rows when tool names match", () => {
+		const filepath = writeJsonl([
+			{
+				type: "message",
+				message: {
+					role: "toolResult",
+					toolName: "bash",
+					isError: false,
+					content: [{ type: "text", text: "ok" }],
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "bash",
+					agentName: "developer",
+					isError: true,
+				},
+			},
+		]);
+
+		const md = renderSessionToMarkdown(filepath);
+		assert.ok(md.includes("| \`bash\` | 2 | 1 |"), "bash aggregated: 2 calls, 1 error");
+	});
+
+	it("session with ONLY supervisor tool-complete entries and zero native toolResult entries renders correctly", () => {
+		const filepath = writeJsonl([
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "web_search",
+					agentName: "researcher",
+					isError: false,
+				},
+			},
+			{
+				type: "custom",
+				customType: "supervisor",
+				details: {
+					eventType: "tool-complete",
+					toolName: "read",
+					agentName: "researcher",
+					isError: false,
+				},
+			},
+		]);
+
+		const md = renderSessionToMarkdown(filepath);
+		assert.ok(md.includes("## Tool Usage"), "Tool Usage section present");
+		assert.ok(md.includes("web_search"), "includes web_search");
+		assert.ok(md.includes("read"), "includes read");
+		assert.ok(md.includes("| \`read\` | 1 |"), "read row with 1 call");
+		assert.ok(md.includes("| \`web_search\` | 1 |"), "web_search row with 1 call");
+	});
+});

--- a/.pi/extensions/session-logger/types.ts
+++ b/.pi/extensions/session-logger/types.ts
@@ -36,6 +36,18 @@ export interface Metadata {
 			totalDurationMs: number;
 		}
 	>;
+	/** Per-agent breakdown of subagent tool calls from supervisor pipeline runs */
+	subagentToolStats?: Record<
+		string,
+		Record<
+			string,
+			{
+				calls: number;
+				errors: number;
+				totalDurationMs: number;
+			}
+		>
+	>;
 	/** File modifications tracked during session */
 	fileModifications?: Array<{
 		action: string;

--- a/.pi/extensions/supervisor/agent/runner.ts
+++ b/.pi/extensions/supervisor/agent/runner.ts
@@ -313,6 +313,7 @@ export async function runAgentSubprocess(
 									display: true,
 									details: {
 										eventType: "tool-complete",
+										agentName,
 										toolName,
 										args: pendingToolFormattedArgs,
 										isError: pendingToolIsError,

--- a/.pi/extensions/supervisor/test/agent-runner-subprocess.test.mts
+++ b/.pi/extensions/supervisor/test/agent-runner-subprocess.test.mts
@@ -838,4 +838,247 @@ if (hasMockModule) {
 			assert.ok(result.output.includes("message_update"), "raw output should contain JSON lines");
 		});
 	});
+
+	describe("runAgentSubprocess — agentName on tool-complete", () => {
+		it("tool-complete details include agentName matching the agent name", async () => {
+			resetMock();
+			const sendMessageCalls: any[] = [];
+			const mockPi = { sendMessage: (msg: any) => sendMessageCalls.push(msg) };
+
+			currentMockOpts = {
+				stdoutLines: [
+					JSON.stringify({
+						type: "tool_execution_start",
+						toolName: "read",
+						args: { path: "/tmp/x.ts" },
+					}),
+					JSON.stringify({ type: "tool_execution_end", toolName: "read", isError: false }),
+					JSON.stringify({
+						type: "message_end",
+						message: {
+							role: "toolResult",
+							toolName: "read",
+							content: [{ type: "text", text: "file content" }],
+						},
+					}),
+					JSON.stringify({
+						type: "message_end",
+						message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+					}),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
+
+			const { runAgentSubprocess } = await import("../agent/runner.ts");
+			const resultPromise = runAgentSubprocess(
+				mockAgent as any,
+				"test task",
+				mockCtx,
+				5000,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPi as any,
+			);
+			emitMockEvents();
+			await resultPromise;
+
+			const toolCompleteMsgs = sendMessageCalls.filter(
+				(m: any) => m.details?.eventType === "tool-complete",
+			);
+			assert.ok(toolCompleteMsgs.length >= 1, "should have tool-complete messages");
+			for (const msg of toolCompleteMsgs) {
+				assert.equal(
+					msg.details.agentName,
+					"test-agent",
+					"tool-complete details should include agentName",
+				);
+			}
+		});
+
+		it("tool-complete details contain agentName even when no prior tool-start was emitted", async () => {
+			resetMock();
+			const sendMessageCalls: any[] = [];
+			const mockPi = { sendMessage: (msg: any) => sendMessageCalls.push(msg) };
+
+			currentMockOpts = {
+				stdoutLines: [
+					// No tool_execution_start — tool-complete from toolResult only
+					JSON.stringify({
+						type: "message_end",
+						message: {
+							role: "toolResult",
+							toolName: "bash",
+							content: [{ type: "text", text: "result" }],
+						},
+					}),
+					JSON.stringify({
+						type: "message_end",
+						message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+					}),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
+
+			const { runAgentSubprocess } = await import("../agent/runner.ts");
+			const resultPromise = runAgentSubprocess(
+				mockAgent as any,
+				"test task",
+				mockCtx,
+				5000,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPi as any,
+			);
+			emitMockEvents();
+			await resultPromise;
+
+			const toolCompleteMsgs = sendMessageCalls.filter(
+				(m: any) => m.details?.eventType === "tool-complete",
+			);
+			assert.ok(toolCompleteMsgs.length >= 1, "should have tool-complete messages");
+			for (const msg of toolCompleteMsgs) {
+				assert.equal(
+					msg.details.agentName,
+					"test-agent",
+					"tool-complete details should include agentName even without prior tool-start",
+				);
+			}
+		});
+
+		it("agentName value matches the agent name from config — consistent with tool-start", async () => {
+			resetMock();
+			const sendMessageCalls: any[] = [];
+			const mockPi = { sendMessage: (msg: any) => sendMessageCalls.push(msg) };
+
+			currentMockOpts = {
+				stdoutLines: [
+					JSON.stringify({
+						type: "tool_execution_start",
+						toolName: "bash",
+						args: { command: "ls" },
+					}),
+					JSON.stringify({ type: "tool_execution_end", toolName: "bash", isError: false }),
+					JSON.stringify({
+						type: "message_end",
+						message: {
+							role: "toolResult",
+							toolName: "bash",
+							content: [{ type: "text", text: "result" }],
+						},
+					}),
+					JSON.stringify({
+						type: "message_end",
+						message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+					}),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
+
+			const { runAgentSubprocess } = await import("../agent/runner.ts");
+			const resultPromise = runAgentSubprocess(
+				mockAgent as any,
+				"test task",
+				mockCtx,
+				5000,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPi as any,
+			);
+			emitMockEvents();
+			await resultPromise;
+
+			const toolStartMsgs = sendMessageCalls.filter(
+				(m: any) => m.details?.eventType === "tool-start",
+			);
+			const toolCompleteMsgs = sendMessageCalls.filter(
+				(m: any) => m.details?.eventType === "tool-complete",
+			);
+
+			assert.ok(toolStartMsgs.length >= 1, "should have tool-start messages");
+			assert.ok(toolCompleteMsgs.length >= 1, "should have tool-complete messages");
+
+			// Both events should reference the same agent name
+			for (const msg of toolStartMsgs) {
+				assert.equal(
+					msg.details.agentName,
+					"test-agent",
+					"tool-start agentName should match config name",
+				);
+			}
+			for (const msg of toolCompleteMsgs) {
+				assert.equal(
+					msg.details.agentName,
+					"test-agent",
+					"tool-complete agentName should match config name",
+				);
+			}
+		});
+
+		it("existing tool-start event details still include agentName (no regression)", async () => {
+			resetMock();
+			const sendMessageCalls: any[] = [];
+			const mockPi = { sendMessage: (msg: any) => sendMessageCalls.push(msg) };
+
+			currentMockOpts = {
+				stdoutLines: [
+					JSON.stringify({
+						type: "tool_execution_start",
+						toolName: "edit",
+						args: { path: "/tmp/a.ts" },
+					}),
+					JSON.stringify({ type: "tool_execution_end", toolName: "edit", isError: false }),
+					JSON.stringify({
+						type: "message_end",
+						message: {
+							role: "toolResult",
+							toolName: "edit",
+							content: [{ type: "text", text: "applied" }],
+						},
+					}),
+					JSON.stringify({
+						type: "message_end",
+						message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+					}),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
+
+			const { runAgentSubprocess } = await import("../agent/runner.ts");
+			const resultPromise = runAgentSubprocess(
+				mockAgent as any,
+				"test task",
+				mockCtx,
+				5000,
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				mockPi as any,
+			);
+			emitMockEvents();
+			await resultPromise;
+
+			const toolStartMsgs = sendMessageCalls.filter(
+				(m: any) => m.details?.eventType === "tool-start",
+			);
+			assert.ok(toolStartMsgs.length >= 1, "should have tool-start messages");
+			// tool-start already has agentName before this change — verify it's still there
+			for (const msg of toolStartMsgs) {
+				assert.ok(
+					msg.details.agentName !== undefined,
+					"tool-start should still have agentName",
+				);
+			}
+		});
+	});
 }


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1142

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 47s | 59.2K | 38 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 57s | 27.1K | 18 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 18s | 38.6K | 29 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 55s | 82.3K | 43 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 24s | 41.7K | 44 | minimax-m3 |

**Total:** 5 agents · 10m 22s · 248.9K tokens · 172 tool calls · 7 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1142
Closes #1142