### PR TITLE
feat(#1129): [Feature] Show subagent thinking level in supervisor widget + result message

### DIFF
--- a/.pi/extensions/supervisor/agent/runner.ts
+++ b/.pi/extensions/supervisor/agent/runner.ts
@@ -102,6 +102,7 @@ function createAgentRunState(
 	startedAt: number,
 	maxToolCalls?: number,
 	agentTokenBudget?: number,
+	thinkingLevel?: string,
 ): AgentRunState {
 	return {
 		toolCount: 0,
@@ -121,6 +122,7 @@ function createAgentRunState(
 		budgetExceededReason: undefined,
 		maxToolCalls: maxToolCalls ?? 0,
 		agentTokenBudget: agentTokenBudget ?? 0,
+		thinkingLevel: thinkingLevel?.trim() || undefined,
 	};
 }
 
@@ -182,7 +184,8 @@ export async function runAgentSubprocess(
 
 	const startedAt = Date.now();
 
-	const state = createAgentRunState(startedAt, maxToolCalls, agentTokenBudget);
+	const thinkingLevel = agent.config.thinking?.trim() || undefined;
+	const state = createAgentRunState(startedAt, maxToolCalls, agentTokenBudget, thinkingLevel);
 
 	log.info("agent-runner", `Subprocess spawn: ${agentName}`, {
 		pid: process.pid,
@@ -437,6 +440,7 @@ export async function runAgentSubprocess(
 				success,
 				agentName,
 				toolCount: state.toolCount,
+				thinkingLevel: state.thinkingLevel,
 				failedToolCount: state.failedToolCount ?? undefined,
 				tokenCount: state.tokenCount,
 				durationMs,

--- a/.pi/extensions/supervisor/config/types.ts
+++ b/.pi/extensions/supervisor/config/types.ts
@@ -118,6 +118,8 @@ export interface AgentRunResult {
 	cost?: number;
 	/** Number of LLM turns (assistant messages with usage) */
 	turnCount?: number;
+	/** Thinking level used by the agent (e.g. "off", "low", "medium", "high") */
+	thinkingLevel?: string;
 }
 
 // ─── AgentRunState: mutable state during agent execution ────────────
@@ -158,6 +160,8 @@ export interface AgentRunState {
 	cacheRead?: number;
 	/** LLM prompt cache write tokens (from message usage) */
 	cacheWrite?: number;
+	/** Thinking level used by the agent (e.g. "off", "low", "medium", "high") */
+	thinkingLevel?: string;
 }
 
 // ─── Message renderer details type ───────────────────────────────────
@@ -203,11 +207,13 @@ export interface SupervisorMessageDetails {
 	cost?: number;
 	/** Number of LLM turns (assistant messages with usage) */
 	turnCount?: number;
+	/** Thinking level used by the agent (e.g. "off", "low", "medium", "high") */
+	thinkingLevel?: string;
 }
 
 // ─── Dependency gate types ─────────────────────────────────────────
 
-export interface BlockerInfo {
+interface BlockerInfo {
 	number: number;
 	title: string;
 	type: "issue" | "pullrequest";
@@ -219,14 +225,14 @@ export interface DepsResult {
 	blockers: BlockerInfo[];
 }
 
-export interface GhBlockingIssue {
+interface GhBlockingIssue {
 	id: string;
 	number: number;
 	title: string;
 	state: string;
 }
 
-export interface GhTimelineNode {
+interface GhTimelineNode {
 	__typename: string;
 	blockingIssue?: GhBlockingIssue | null;
 }
@@ -299,13 +305,13 @@ export interface MergeResult {
 // All agents output the same structure; pipeline parses it deterministically.
 
 /** Supported action types — single vocabulary for all agents */
-export type AgentAction = "COMPLETE" | "APPROVED" | "REJECTED";
+type AgentAction = "COMPLETE" | "APPROVED" | "REJECTED";
 
 /** Severity levels for audit findings */
 export type FindingSeverity = "critical" | "warning" | "suggestion";
 
 /** Known audit dimensions */
-export type AuditDimension =
+type AuditDimension =
 	| "architecture-compliance"
 	| "ticket-fulfillment"
 	| "tests-passed"
@@ -363,7 +369,7 @@ export type ParseResult = AgentOutput | FailedParse;
 
 // ─── LSP Pre-Audit ──────────────────────────────────────────────────
 
-export interface LspPreAuditDecision {
+interface LspPreAuditDecision {
 	/** New status to transition to — "Audit" if proceeding, "Implementation" if blocking */
 	nextStatus: string;
 	/** Note to include in notification */

--- a/.pi/extensions/supervisor/lib/formatting.ts
+++ b/.pi/extensions/supervisor/lib/formatting.ts
@@ -255,3 +255,55 @@ export function isToolCallLine(line: string): boolean {
 
 	return false;
 }
+
+// ─── Thinking level helpers ─────────────────────────────────────────
+// Inline minimal version (no cross-extension import from context-info).
+// Matches the same mapping as context-info/formatting.ts for consistency.
+
+/** Map thinking level string to its unicode icon character */
+function thinkingIcon(level: string | undefined): string {
+	switch (level) {
+		case "off":
+			return "○";
+		case "minimal":
+			return "◐";
+		case "low":
+			return "◑";
+		case "medium":
+			return "◒";
+		case "high":
+			return "◓";
+		case "xhigh":
+			return "●";
+		default:
+			return "";
+	}
+}
+
+/** Map thinking level string to a TUI theme color name */
+export function thinkingColor(level: string | undefined): string {
+	switch (level) {
+		case "off":
+		case "minimal":
+			return "dim";
+		case "low":
+		case "medium":
+			return "muted";
+		case "high":
+		case "xhigh":
+			return "accent";
+		default:
+			return "dim";
+	}
+}
+
+/**
+ * Format thinking level as "◒ medium" or empty string if not set.
+ * Returns empty string for falsy/empty/unknown levels.
+ */
+export function thinkingLabel(level: string | undefined): string {
+	if (!level || !level.trim()) return "";
+	const icon = thinkingIcon(level);
+	if (!icon) return "";
+	return `${icon} ${level}`;
+}

--- a/.pi/extensions/supervisor/session/message-renderer.ts
+++ b/.pi/extensions/supervisor/session/message-renderer.ts
@@ -14,7 +14,7 @@ import {
 	truncateToWidth,
 	wrapTextWithAnsi,
 } from "@earendil-works/pi-tui";
-import { formatTokensInt, formatDuration, formatTokens, getTermWidth } from "../lib/formatting.ts";
+import { formatTokensInt, formatDuration, formatTokens, getTermWidth, thinkingLabel, thinkingColor } from "../lib/formatting.ts";
 import { renderTextLines, renderThinkingBlock } from "../lib/render-helpers.ts";
 import type { SubagentDetails, AgentToolResult } from "../subagent/types.ts";
 import { formatToolCall } from "../lib/formatting.ts";
@@ -50,6 +50,8 @@ function renderSubagentResultInline(
 
 	// ── Stats Parts (shared) ────────────────────────────────────
 	const statsParts: string[] = [];
+	const tl = thinkingLabel(details.thinkingLevel);
+	if (tl) statsParts.push(tl);
 	if (details.inputTokens > 0 || details.outputTokens > 0) {
 		const inStr = details.inputTokens > 0 ? formatTokens(details.inputTokens) : "0";
 		const outStr = details.outputTokens > 0 ? formatTokens(details.outputTokens) : "0";
@@ -154,6 +156,10 @@ function renderSubagentResultInline(
 	if (details.cacheRead > 0) footerParts.push(`R${formatTokens(details.cacheRead)}`);
 	if (details.cacheWrite > 0) footerParts.push(`W${formatTokens(details.cacheWrite)}`);
 	if (details.cost > 0) footerParts.push(`$${details.cost.toFixed(4)}`);
+	const thinkingLevelStr = thinkingLabel(details.thinkingLevel);
+	if (thinkingLevelStr) {
+		footerParts.push(theme.fg(thinkingColor(details.thinkingLevel), thinkingLevelStr));
+	}
 	if (details.model) {
 		const shortModel = details.model.split("/").pop() || details.model;
 		footerParts.push(shortModel);

--- a/.pi/extensions/supervisor/session/result.ts
+++ b/.pi/extensions/supervisor/session/result.ts
@@ -44,6 +44,7 @@ export function convertAgentRunToToolResult(
 			durationMs: result.durationMs,
 			toolCalls: [],
 			toolResults: [],
+			thinkingLevel: result.thinkingLevel,
 			taskPrompt: devTask || "",
 			budgetExceeded: result.budgetExceeded,
 			errorCount: result.failedToolCount ?? undefined,

--- a/.pi/extensions/supervisor/session/widget.ts
+++ b/.pi/extensions/supervisor/session/widget.ts
@@ -4,7 +4,7 @@
 
 import type { AgentRunState } from "../config/types.ts";
 import type { SubagentDetails } from "../subagent/types.ts";
-import { formatTokens, formatDuration } from "../lib/formatting.ts";
+import { formatTokens, formatDuration, thinkingLabel } from "../lib/formatting.ts";
 
 /**
  * Build widget lines from state. Pure function — no side effects.
@@ -24,6 +24,8 @@ export function buildWidgetLines(
 	const shortModel = model ? model.split("/").pop() || model : undefined;
 	const statsParts: string[] = [`subagent:${agentName}`];
 	if (shortModel) statsParts.push(`🧠 ${shortModel}`);
+	const tl = thinkingLabel(state.thinkingLevel);
+	if (tl) statsParts.push(tl);
 	if (state.tokenCount > 0) statsParts.push(`📊 ${formatTokens(state.tokenCount)} tokens`);
 	const cacheRead = state.cacheRead;
 	const cacheWrite = state.cacheWrite;
@@ -78,6 +80,7 @@ export function renderWidgetFromDetails(
 		contextInfoReceived: details.contextTokens !== undefined && details.contextWindow !== undefined,
 		currentTool: details.currentTool,
 		currentToolArgs: details.currentToolArgs,
+		thinkingLevel: details.thinkingLevel,
 		// Fields required by interface:
 		textOutputLines: [],
 		thinkingOutputLines: [],

--- a/.pi/extensions/supervisor/subagent/types.ts
+++ b/.pi/extensions/supervisor/subagent/types.ts
@@ -59,6 +59,8 @@ export interface SubagentDetails {
 	contextWindow?: number;
 	/** Session start timestamp (Date.now()) */
 	startedAt?: number;
+	/** Thinking level used by the agent (e.g. "off", "low", "medium", "high") */
+	thinkingLevel?: string;
 }
 
 /** Text content block for AgentToolResult */

--- a/.pi/extensions/supervisor/test/message-renderer.test.mts
+++ b/.pi/extensions/supervisor/test/message-renderer.test.mts
@@ -276,6 +276,72 @@ describe("expanded view (expanded=true) — _subagentResult path", () => {
 		const rawHeader = lines.find((l) => l.includes("Raw Output"));
 		assert.equal(rawHeader, undefined, "should NOT have Raw Output header");
 	});
+
+	it("collapsed view includes thinking level icon and name", () => {
+		const details = makeSubagentDetails({ thinkingLevel: "medium" });
+		const result = makeSubagentResult(details, { outputText: "output" });
+		const c = renderMessage(result, undefined, false) as Text;
+		const text = renderAndStrip(c).join(" ");
+		assert.ok(text.includes("◒"), "should show medium thinking icon");
+		assert.ok(text.includes("medium"), "should show thinking level name");
+	});
+
+	it("collapsed view omits thinking level when not set", () => {
+		const details = makeSubagentDetails({ thinkingLevel: undefined });
+		const result = makeSubagentResult(details, { outputText: "output" });
+		const c = renderMessage(result, undefined, false) as Text;
+		const text = renderAndStrip(c).join(" ");
+		assert.ok(!text.includes("◒"), "should not show thinking icon when undefined");
+	});
+
+	it("expanded view footer includes thinking level icon and name", () => {
+		const details = makeSubagentDetails({ thinkingLevel: "high" });
+		const result = makeSubagentResult(details, { outputText: "output" });
+		const c = renderMessage(result, undefined, true) as Container;
+		const lines = renderStripped(c);
+		const footerLine = lines.find((l) => l.includes("◓"));
+		assert.ok(footerLine, "expanded footer should show high thinking icon");
+		assert.ok(footerLine!.includes("high"), "expanded footer should show thinking name");
+	});
+
+	it("expanded view footer omits thinking level when not set", () => {
+		const details = makeSubagentDetails({ thinkingLevel: undefined });
+		const result = makeSubagentResult(details, { outputText: "output" });
+		const c = renderMessage(result, undefined, true) as Container;
+		const lines = renderStripped(c);
+		const hasThinkingLevelIcon = lines.some((l) => l.includes("◒") || l.includes("◓") || l.includes("○") || l.includes("◐") || l.includes("◑") || l.includes("●"));
+		assert.equal(hasThinkingLevelIcon, false, "should not show thinking icons when not set");
+	});
+
+	it("all thinking levels render expected icon in collapsed view", () => {
+		const iconMap: Record<string, string> = { off: "○", minimal: "◐", low: "◑", medium: "◒", high: "◓", xhigh: "●" };
+		for (const [level, icon] of Object.entries(iconMap)) {
+			const details = makeSubagentDetails({ thinkingLevel: level });
+			const result = makeSubagentResult(details, { outputText: "output" });
+			const c = renderMessage(result, undefined, false) as Text;
+			const text = renderAndStrip(c).join(" ");
+			assert.ok(text.includes(icon), `level '${level}' should show icon '${icon}'`);
+			assert.ok(text.includes(level), `level '${level}' should show name`);
+		}
+	});
+
+	it("thinking level appears in expanded view footer alongside other stats", () => {
+		const details = makeSubagentDetails({
+			thinkingLevel: "low",
+			turnCount: 5,
+			inputTokens: 100,
+			outputTokens: 200,
+			model: "test-model",
+			durationMs: 30000,
+		});
+		const result = makeSubagentResult(details, { outputText: "output" });
+		const c = renderMessage(result, undefined, true) as Container;
+		const lines = renderStripped(c);
+		const footerLine = lines.find((l) => l.includes("◑"));
+		assert.ok(footerLine, "footer should contain low thinking icon");
+		assert.ok(footerLine!.includes("5 turns"), "footer should still show turns");
+		assert.ok(footerLine!.includes("test-model"), "footer should still show model");
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════

--- a/.pi/extensions/supervisor/test/session/result.test.mts
+++ b/.pi/extensions/supervisor/test/session/result.test.mts
@@ -177,4 +177,24 @@ describe("convertAgentRunToToolResult — edge cases", () => {
 		const toolResult = convertAgentRunToToolResult(result);
 		assert.equal(toolResult.details.summaryLine, "");
 	});
+
+	it("thinkingLevel mapped from AgentRunResult to SubagentDetails", () => {
+		const result = makeRunResult({ thinkingLevel: "medium" });
+		const toolResult = convertAgentRunToToolResult(result);
+		assert.equal(toolResult.details.thinkingLevel, "medium");
+	});
+
+	it("thinkingLevel undefined → details.thinkingLevel undefined", () => {
+		const result = makeRunResult({});
+		const toolResult = convertAgentRunToToolResult(result);
+		assert.equal(toolResult.details.thinkingLevel, undefined);
+	});
+
+	it("thinkingLevel empty string → passed through as empty string", () => {
+		const result = makeRunResult({ thinkingLevel: "" });
+		const toolResult = convertAgentRunToToolResult(result);
+		// empty string is preserved (the result adapter passes it through)
+		// the display layer (thinkingLabel) will handle filtering
+		assert.equal(toolResult.details.thinkingLevel, "");
+	});
 });

--- a/.pi/extensions/supervisor/test/session/widget.test.mts
+++ b/.pi/extensions/supervisor/test/session/widget.test.mts
@@ -178,4 +178,42 @@ describe("renderWidgetFromDetails — simplified widget (footer only)", () => {
 		assert.ok(line.includes("📦"));
 		assert.ok(line.includes("1m") || line.includes("63") || line.includes("s"));
 	});
+
+	it("includes thinking level when set", () => {
+		const ctx = createMockCtx();
+		const details = makeDetails({ thinkingLevel: "medium" });
+		renderWidgetFromDetails(details, "developer", undefined, ctx, "agent-dev");
+		const line = widgetCalls[0].lines?.[0] ?? "";
+		assert.ok(line.includes("◒"), "should show thinking icon for medium");
+		assert.ok(line.includes("medium"), "should show thinking level name");
+	});
+
+	it("omits thinking level when undefined", () => {
+		const ctx = createMockCtx();
+		const details = makeDetails({ thinkingLevel: undefined });
+		renderWidgetFromDetails(details, "developer", undefined, ctx, "agent-dev");
+		const line = widgetCalls[0].lines?.[0] ?? "";
+		assert.ok(!line.includes("◒"), "should not show thinking icon when undefined");
+		assert.ok(!line.includes("medium"), "should not show thinking level when undefined");
+	});
+
+	it("omits thinking level when empty string", () => {
+		const ctx = createMockCtx();
+		const details = makeDetails({ thinkingLevel: "" });
+		renderWidgetFromDetails(details, "developer", undefined, ctx, "agent-dev");
+		const line = widgetCalls[0].lines?.[0] ?? "";
+		assert.ok(!line.includes("◒"), "should not show thinking icon for empty");
+	});
+
+	it("shows correct icon per level", () => {
+		const ctx = createMockCtx();
+		const iconMap: Record<string, string> = { off: "○", minimal: "◐", low: "◑", medium: "◒", high: "◓", xhigh: "●" };
+		for (const [level, icon] of Object.entries(iconMap)) {
+			widgetCalls = [];
+			const d = makeDetails({ thinkingLevel: level });
+			renderWidgetFromDetails(d, "dev", undefined, ctx, "agent-dev");
+			const line = widgetCalls[0].lines?.[0] ?? "";
+			assert.ok(line.includes(icon), `level '${level}' should show icon '${icon}'`);
+		}
+	});
 });

--- a/.pi/extensions/supervisor/test/terminal-widget.test.mts
+++ b/.pi/extensions/supervisor/test/terminal-widget.test.mts
@@ -182,4 +182,44 @@ describe("Simplified widget — footer only", () => {
 		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
 		assert.ok(!lines[0].includes("undefined"), "no 'undefined' in output");
 	});
+
+	it("includes thinking level icon and name when state has thinkingLevel", () => {
+		const state = createState({ thinkingLevel: "medium" });
+		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		assert.ok(lines[0].includes("◒ medium"), "should show '◒ medium' for medium thinking");
+	});
+
+	it("omits thinking level when state.thinkingLevel is undefined", () => {
+		const state = createState();
+		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		assert.ok(!lines[0].includes("◒"), "should not show thinking icon when undefined");
+		assert.ok(!lines[0].includes("medium"), "should not show thinking name when undefined");
+	});
+
+	it("omits thinking level for unknown level string", () => {
+		const state = createState({ thinkingLevel: "bogus" });
+		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		assert.ok(!lines[0].includes("bogus"), "should not show unknown thinking level");
+	});
+
+	it("thinking level appears after model in stats line", () => {
+		const state = createState({ thinkingLevel: "high", tokenCount: 1000, toolCount: 3, cacheRead: 0, cacheWrite: 0, startedAt: 0 });
+		const lines = buildWidgetLines(state, "dev", "some-model", undefined, 10000);
+		const line = lines[0];
+		const modelIdx = line.indexOf("some-model");
+		const thinkingIdx = line.indexOf("◓");
+		assert.ok(modelIdx >= 0, "should have model");
+		assert.ok(thinkingIdx >= 0, "should have thinking icon");
+		assert.ok(thinkingIdx > modelIdx, "thinking level should appear after model");
+	});
+
+	it("all levels render correct icon", () => {
+		const iconMap: Record<string, string> = { off: "○", minimal: "◐", low: "◑", medium: "◒", high: "◓", xhigh: "●" };
+		for (const [level, icon] of Object.entries(iconMap)) {
+			const state = createState({ thinkingLevel: level });
+			const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+			assert.ok(lines[0].includes(icon), `level '${level}' should show icon '${icon}'`);
+			assert.ok(lines[0].includes(level), `level '${level}' should show name`);
+		}
+	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1129

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 17s | 58.6K | 35 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 2m 24s | 49.2K | 48 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 7s | 68.1K | 31 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 55s | 106.6K | 79 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 45s | 45.4K | 49 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 6m 22s | 71.7K | 102 | minimax-m3 |

**Total:** 6 agents · 21m 50s · 399.6K tokens · 344 tool calls · 17 failed (5%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1129
Closes #1129

**Gate failures:**
- Dead Code Gate gate failed on run 5 — developer restarted