### PR TITLE
feat(#1161): Bug: context-info - session_shutdown calls stopTimer instead of dispose, leaving disposed=false

### DIFF
--- a/.pi/extensions/context-info/footer-state.ts
+++ b/.pi/extensions/context-info/footer-state.ts
@@ -129,6 +129,7 @@ export class FooterState {
 	// ── Tool call tracking ────────────────────────────────────────
 
 	addToolCall(): void {
+		if (this.disposed) return;
 		this.footerConfig.toolCallCount.value++;
 		this.callInstallFooter();
 	}

--- a/.pi/extensions/context-info/index.ts
+++ b/.pi/extensions/context-info/index.ts
@@ -234,7 +234,7 @@ export default function contextInfo(pi: ExtensionAPI): void {
 				ctx.ui.setFooter(undefined);
 				ctx.ui.setStatus("contextUsage", undefined);
 			}
-			state.stopTimer();
+			state.dispose();
 			return;
 		}
 
@@ -315,7 +315,7 @@ export default function contextInfo(pi: ExtensionAPI): void {
 	});
 
 	pi.on("thinking_level_select", async (event, ctx: ExtensionContext) => {
-		if (!state) return;
+		if (!state || state.disposed) return;
 		state.footerConfig.thinkingLevel = event.level;
 		if (state.config) {
 			state.callInstallFooter();
@@ -323,7 +323,7 @@ export default function contextInfo(pi: ExtensionAPI): void {
 	});
 
 	pi.on("model_select", async (event, ctx: ExtensionContext) => {
-		if (!state) return;
+		if (!state || state.disposed) return;
 		const cw = event.model?.contextWindow;
 		if (typeof cw === "number" && cw > 0) {
 			state.footerConfig.lastContextWindow.value = cw;
@@ -339,14 +339,14 @@ export default function contextInfo(pi: ExtensionAPI): void {
 	});
 
 	pi.on("turn_end", async (_event, ctx: ExtensionContext) => {
-		if (!state || !state.config) return;
+		if (!state || state.disposed || !state.config) return;
 		// Re-read session name (in case setSessionName was called mid-session)
 		state.footerConfig.sessionName = pi.getSessionName();
 		state.callInstallFooter();
 	});
 
 	pi.on("message_end", async (event, ctx: ExtensionContext) => {
-		if (!state) return;
+		if (!state || state.disposed) return;
 		const msg = event.message;
 		if (!msg || msg.role !== "assistant") return;
 		// Capture cache stats from raw event usage
@@ -374,7 +374,7 @@ export default function contextInfo(pi: ExtensionAPI): void {
 	});
 
 	pi.on("message_update", async (event: any, _ctx: ExtensionContext) => {
-		if (!state) return;
+		if (!state || state.disposed) return;
 		// Sample streaming output tokens for TPS estimation
 		const output = event.assistantMessageEvent?.partial?.usage?.output;
 		if (typeof output === "number") {
@@ -383,14 +383,14 @@ export default function contextInfo(pi: ExtensionAPI): void {
 	});
 
 	pi.on("tool_execution_end", async () => {
-		if (state) {
+		if (state && !state.disposed) {
 			state.addToolCall();
 		}
 	});
 
 	pi.on("session_shutdown", async () => {
 		if (state) {
-			state.stopTimer();
+			state.dispose();
 		}
 		stateRef = undefined;
 	});

--- a/.pi/extensions/context-info/test/context-info.test.mts
+++ b/.pi/extensions/context-info/test/context-info.test.mts
@@ -1234,3 +1234,111 @@ describe("formatCacheStats", () => {
 		assert.strictEqual(formatCacheStats(undefined, 0), "\u{1F4E6} --/--");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Session shutdown behavior — dispose vs stopTimer
+// ---------------------------------------------------------------------------
+
+/** Create a minimal ExtensionContext for session_shutdown tests */
+function createShutdownMockCtx() {
+	return {
+		mode: "rpc",
+		ui: {
+			setFooter: () => {},
+			setStatus: () => {},
+			setWidget: () => {},
+			setWorkingIndicator: () => {},
+			notify: () => {},
+			theme: { fg: (_c: string, t: string) => t },
+		},
+		isProjectTrusted: () => true,
+		getContextUsage: () => undefined,
+		sessionManager: { getSessionFile: () => "/tmp/test_uuid.jsonl" },
+		model: { id: "test-model", contextWindow: 128000 },
+		cwd: "/tmp",
+	};
+}
+
+describe("context-info extension — session_shutdown disposes state", () => {
+	it("session_shutdown calls dispose — events after shutdown are safe (no throw)", async () => {
+		const handlers = new Map<string, (...args: any[]) => void>();
+		const pi = {
+			on: (event: string, handler: (...args: any[]) => void) => {
+				handlers.set(event, handler);
+			},
+			registerCommand: () => {},
+			getSessionName: () => undefined,
+			events: { on: () => {} },
+		};
+		contextInfo(pi as any);
+
+		const ctx = createShutdownMockCtx(); // mode="rpc"
+
+		// Start session — creates FooterState
+		await handlers.get("session_start")!({}, ctx);
+
+		// Shutdown session — dispose() sets disposed=true, stops timer
+		await handlers.get("session_shutdown")!();
+
+		// All events should be safe no-ops — guard on state.disposed
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("thinking_level_select")!({ level: "high" }, ctx);
+			})(),
+			"thinking_level_select after shutdown should not reject",
+		);
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("model_select")!({ model: { contextWindow: 256000 } }, ctx);
+			})(),
+			"model_select after shutdown should not reject",
+		);
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("turn_end")!({}, ctx);
+			})(),
+			"turn_end after shutdown should not reject",
+		);
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("message_end")!({ message: { role: "assistant", usage: {} } }, ctx);
+			})(),
+			"message_end after shutdown should not reject",
+		);
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("message_update")!({ assistantMessageEvent: {} }, ctx);
+			})(),
+			"message_update after shutdown should not reject",
+		);
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("tool_execution_end")!();
+			})(),
+			"tool_execution_end after shutdown should not reject",
+		);
+
+		assert.ok(true, "All events after session_shutdown completed without error");
+	});
+
+	it("session_shutdown does not throw when called without prior session_start", async () => {
+		const handlers = new Map<string, (...args: any[]) => void>();
+		const pi = {
+			on: (event: string, handler: (...args: any[]) => void) => {
+				handlers.set(event, handler);
+			},
+			registerCommand: () => {},
+			getSessionName: () => undefined,
+			events: { on: () => {} },
+		};
+		contextInfo(pi as any);
+
+		// No session_start before shutdown
+		await assert.doesNotReject(
+			(async () => {
+				await handlers.get("session_shutdown")!();
+			})(),
+			"session_shutdown without prior session should not reject",
+		);
+	});
+});

--- a/.pi/extensions/context-info/test/footer-state.test.mts
+++ b/.pi/extensions/context-info/test/footer-state.test.mts
@@ -302,6 +302,59 @@ describe("FooterState — reset", () => {
 });
 
 // ---------------------------------------------------------------------------
+// FooterState — dispose
+// ---------------------------------------------------------------------------
+
+describe("FooterState — dispose", () => {
+	it("dispose sets disposed = true", () => {
+		const state = new FooterState(createMockCtx());
+		assert.strictEqual(state.disposed, false);
+		state.dispose();
+		assert.strictEqual(state.disposed, true);
+	});
+
+	it("dispose stops the timer", () => {
+		const state = new FooterState(createMockCtx());
+		state.startTimer();
+		assert.ok(state.timerInterval !== null, "timer should be running");
+		state.dispose();
+		assert.strictEqual(state.timerInterval, null, "timer should be stopped");
+	});
+
+	it("callInstallFooter is no-op when disposed = true", () => {
+		const fn = mock.fn();
+		const state = new FooterState(createMockCtx(), fn);
+		state.dispose();
+		state.callInstallFooter();
+		assert.strictEqual(fn.mock.calls.length, 0, "should not call installFooterCb when disposed");
+	});
+
+	it("callInstallFooter calls installFooterCb when not disposed", () => {
+		const fn = mock.fn();
+		const state = new FooterState(createMockCtx(), fn);
+		state.callInstallFooter();
+		assert.strictEqual(fn.mock.calls.length, 1, "should call installFooterCb when not disposed");
+	});
+
+	it("addToolCall is no-op when disposed = true", () => {
+		const fn = mock.fn();
+		const state = new FooterState(createMockCtx(), fn);
+		state.dispose();
+		state.addToolCall();
+		assert.strictEqual(state.footerConfig.toolCallCount.value, 0, "should not increment tool count when disposed");
+		// callInstallFooter should also not fire
+		assert.strictEqual(fn.mock.calls.length, 0, "should not call installFooterCb when disposed");
+	});
+
+	it("dispose is idempotent — calling twice does not error", () => {
+		const state = new FooterState(createMockCtx());
+		state.dispose();
+		assert.doesNotThrow(() => state.dispose());
+		assert.strictEqual(state.disposed, true);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // FooterState — installFooter callback integration
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1161

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 28s | 47.8K | 17 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 41s | 16.2K | 5 | minimax-m3 |
| test-designer | ✓ SUCCESS | 2m 39s | 57.0K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 26s | 78.8K | 40 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 23s | 27.6K | 30 | minimax-m3 |

**Total:** 5 agents · 12m 38s · 227.4K tokens · 107 tool calls · 10 failed (9%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1161
Closes #1161