### PR TITLE
feat(#1167): Bug: caveman - /caveman handler crashes on undefined args via unchecked optional chain

### DIFF
--- a/.pi/extensions/caveman/command.ts
+++ b/.pi/extensions/caveman/command.ts
@@ -99,7 +99,7 @@ export function registerCavemanCommand(
 			return items.length > 0 ? items : null;
 		},
 		handler: async (args, ctx) => {
-			const arg = args?.trim().toLowerCase();
+			const arg = (args ?? "").trim().toLowerCase();
 
 			// Open config dialog
 			if (arg === "config") {

--- a/.pi/extensions/caveman/test/caveman-command.test.mts
+++ b/.pi/extensions/caveman/test/caveman-command.test.mts
@@ -138,6 +138,26 @@ describe("command.ts — handler with empty args toggles", () => {
 	});
 });
 
+describe("command.ts — handler with args=undefined toggles", () => {
+	it("current off -> toggles to full", async () => {
+		const { def, configStore, ctx, notifications } = setupTest("off");
+		await def.handler(undefined as unknown as string, ctx);
+		assert.strictEqual(configStore.getLevel(), "full");
+	});
+
+	it("current full -> toggles to off", async () => {
+		const { def, configStore, ctx } = setupTest("full");
+		await def.handler(undefined as unknown as string, ctx);
+		assert.strictEqual(configStore.getLevel(), "off");
+	});
+
+	it("null does not throw", async () => {
+		const { def, configStore, ctx } = setupTest("off");
+		await def.handler(null as unknown as string, ctx);
+		assert.strictEqual(configStore.getLevel(), "full");
+	});
+});
+
 describe("command.ts — handler with invalid args", () => {
 	it("notifies error with 'Unknown'", async () => {
 		const { def, ctx, notifications } = setupTest("off");


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1167

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 33s | 28.7K | 16 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 48s | 13.4K | 9 | minimax-m3 |
| test-designer | ✓ SUCCESS | 28s | 13.4K | 6 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 0s | 16.6K | 14 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 56s | 18.5K | 18 | minimax-m3 |

**Total:** 5 agents · 6m 46s · 90.7K tokens · 63 tool calls · 4 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1167
Closes #1167