### PR TITLE
feat(#1185): Pipeline handler mock missing ctx.ui.setWidget — 12 subtests fail

### DIFF
--- a/.pi/extensions/supervisor/test/pipeline/handler.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/handler.test.mts
@@ -2,7 +2,7 @@
 // Tests the extracted post-loop function to verify merge runs before cleanup.
 // Mocks pi.exec and ctx.ui.confirm to simulate all code paths.
 
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
 import type { PipelineAgentResult, PrCreationResult } from "../../config/types.ts";
@@ -48,6 +48,7 @@ function createMockCtx(confirmResult: boolean = true): ExtensionCommandContext {
 		ui: {
 			notify: () => {},
 			setStatus: () => {},
+			setWidget: mock.fn(),
 			confirm: async () => confirmResult,
 		},
 	} as unknown as ExtensionCommandContext;


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1185

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 46s | 43.2K | 29 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 36s | 13.3K | 9 | minimax-m3 |
| test-designer | ✓ SUCCESS | 53s | 21.1K | 16 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 5s | 32.5K | 9 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 7s | 21.5K | 8 | minimax-m3 |

**Total:** 5 agents · 5m 27s · 131.6K tokens · 71 tool calls · 4 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1185
Closes #1185