### PR TITLE
feat(#1184): Chat-progress widget rendering changed — tests fail on output format

### DIFF
--- a/.pi/extensions/supervisor/session/widget.ts
+++ b/.pi/extensions/supervisor/session/widget.ts
@@ -15,7 +15,6 @@ export function buildWidgetLines(
 	state: AgentRunState,
 	agentName: string,
 	model?: string,
-	idleWarning?: string | null,
 	now?: number,
 ): string[] {
 	const nowTs = now ?? Date.now();
@@ -64,26 +63,23 @@ export function renderWidgetFromDetails(
 			: "idle";
 
 	// Construct minimal AgentRunState from details
-	// buildWidgetLines() only accesses: contextInfoReceived, contextTokens, contextWindow,
-	// phase, liveThinking, currentTool, currentToolArgs, liveText, fullLog,
-	// toolCount, tokenCount, cacheRead, cacheWrite, startedAt
+	// buildWidgetLines() only reads: toolCount, tokenCount, cacheRead, cacheWrite, startedAt, thinkingLevel
+	// phase and currentTool are kept for getWorkingMessage.
+	// Other interface-required fields get empty defaults.
 	const state: AgentRunState = {
 		phase,
 		startedAt: details.startedAt ?? Date.now(),
 		tokenCount: details.runningTokenCount ?? 0,
 		toolCount: details.runningToolCount ?? details.toolCalls?.length ?? 0,
-		fullLog: details.recentLogEntries ?? [],
-		liveThinking: details.liveThinking ?? "",
-		liveText: details.liveText ?? "",
-		contextTokens: details.contextTokens,
-		contextWindow: details.contextWindow,
-		contextInfoReceived: details.contextTokens !== undefined && details.contextWindow !== undefined,
 		currentTool: details.currentTool,
-		currentToolArgs: details.currentToolArgs,
 		thinkingLevel: details.thinkingLevel,
-		// Fields required by interface:
+		// Fields required by interface (empty defaults — not read by buildWidgetLines):
+		fullLog: [],
+		liveThinking: "",
+		liveText: "",
 		textOutputLines: [],
 		thinkingOutputLines: [],
+		contextInfoReceived: false,
 		cacheRead: details.cacheRead,
 		cacheWrite: details.cacheWrite,
 		lastToolName: undefined,

--- a/.pi/extensions/supervisor/test/chat-progress.test.mts
+++ b/.pi/extensions/supervisor/test/chat-progress.test.mts
@@ -170,8 +170,7 @@ describe("Widget lifecycle (buildWidgetLines + setWidget)", () => {
 			liveThinking: "Deep thoughts...",
 		});
 		const lines = buildWidgetLines(state, "architect");
-		const thinkingLine = lines.find((l) => l.includes("Deep thoughts"));
-		assert.ok(thinkingLine, "thinking phase content should appear in widget");
+		assert.ok(!lines[0].includes("Deep thoughts"), "thinking content NOT in stats-only widget");
 	});
 
 	it("buildWidgetLines includes current tool when tool phase active", () => {
@@ -181,9 +180,7 @@ describe("Widget lifecycle (buildWidgetLines + setWidget)", () => {
 			currentToolArgs: '{"command": "echo hi"}',
 		});
 		const lines = buildWidgetLines(state, "developer");
-		// formatToolCall formats bash as "$ echo hi" so we check for $ not the raw tool name
-		const toolLine = lines.find((l) => l.includes("$ echo"));
-		assert.ok(toolLine, "current tool formatted call should appear in widget");
+		assert.ok(!lines[0].includes("$ echo"), "tool call NOT in stats-only widget");
 	});
 
 	it("buildWidgetLines includes stats footer with agent name and duration", () => {
@@ -241,10 +238,9 @@ describe("Widget lifecycle (buildWidgetLines + setWidget)", () => {
 		const state = createState({ phase: "idle" });
 		ui.setWidget("supervisor-agent", buildWidgetLines(state, "developer", "claude-sonnet-4"));
 
-		// Working change: thinking phase
-		state.phase = "thinking";
-		state.liveThinking = "Analyzing...";
-		ui.setWidget("supervisor-agent", buildWidgetLines(state, "developer", "claude-sonnet-4"));
+		// Working change with different stats
+		const state2 = createState({ phase: "thinking", toolCount: 3 });
+		ui.setWidget("supervisor-agent", buildWidgetLines(state2, "developer", "claude-sonnet-4"));
 
 		assert.equal(widgetCalls.length, 2);
 		// Second call should have different content
@@ -302,8 +298,8 @@ describe("Widget debounce + heartbeat (matching session-runner.ts)", () => {
 		// debounce is a runtime concern. What matters is the last state is correct.
 		assert.equal(widgetCalls.length, 3);
 		assert.ok(
-			widgetCalls[2].lines?.some((l) => l.includes("text")),
-			"last widget state should show text phase",
+			widgetCalls[2].lines?.some((l) => l.includes("subagent:dev")),
+			"last widget line should contain agent name, confirming widget was set with valid content",
 		);
 	});
 
@@ -547,8 +543,7 @@ describe("User-journey: widget progress during pipeline", () => {
 		});
 		ui.setWidget("supervisor-agent", buildWidgetLines(state, "architect"));
 
-		const thinkingLine = widgetCalls[0].lines?.find((l) => l.includes("Analyzing"));
-		assert.ok(thinkingLine, "widget should show thinking text");
+		assert.ok(!widgetCalls[0].lines?.[0]?.includes("Analyzing"), "thinking content absent in stats-only widget");
 	});
 
 	it("agent calls tool → widget shows 🔧 tool call via formatToolCall", () => {
@@ -560,9 +555,7 @@ describe("User-journey: widget progress during pipeline", () => {
 		});
 		ui.setWidget("supervisor-agent", buildWidgetLines(state, "developer"));
 
-		// formatToolCall formats bash as "$ ls -la", so we check for $ ls
-		const toolLine = widgetCalls[0].lines?.find((l) => l.includes("$ ls"));
-		assert.ok(toolLine, "widget should show formatted tool call");
+		assert.ok(!widgetCalls[0].lines?.[0]?.includes("$ ls"), "tool call absent in stats-only widget");
 	});
 
 	it("agent produces text → widget shows live text preview", () => {
@@ -573,8 +566,7 @@ describe("User-journey: widget progress during pipeline", () => {
 		});
 		ui.setWidget("supervisor-agent", buildWidgetLines(state, "developer"));
 
-		const textLine = widgetCalls[0].lines?.find((l) => l.includes("Here is my analysis"));
-		assert.ok(textLine, "widget should show live text preview");
+		assert.ok(!widgetCalls[0].lines?.[0]?.includes("Here is my analysis"), "live text absent in stats-only widget");
 	});
 
 	it("agent completes successfully → widget cleared, final result message shows SUCCESS", () => {
@@ -839,6 +831,7 @@ describe("User-journey: widget progress during pipeline", () => {
 		const details: Partial<SubagentDetails> = {
 			agentName: "developer",
 			phase: "idle",
+			runningTokenCount: 500,
 			contextTokens: 500,
 			contextWindow: 32000,
 			startedAt: Date.now() - 1000,
@@ -846,9 +839,8 @@ describe("User-journey: widget progress during pipeline", () => {
 
 		renderWidgetFromDetails(details, "developer", undefined, ctx, "agent-developer");
 
-		const contextLine = widgetCalls[0].lines?.find((l) => l.includes("Context:"));
-		assert.ok(contextLine, "widget should include context line");
-		assert.ok(contextLine?.includes("500"), "should show context token count");
+		assert.ok(widgetCalls[0].lines?.[0]?.includes("developer"), "should show agent name");
+		assert.ok(widgetCalls[0].lines?.[0]?.includes("500"), "should show token count in widget");
 	});
 
 	it("renderWidgetFromDetails widget shows 'computing...' when context info not yet received", () => {
@@ -863,12 +855,8 @@ describe("User-journey: widget progress during pipeline", () => {
 
 		renderWidgetFromDetails(details, "developer", undefined, ctx, "agent-developer");
 
-		const contextLine = widgetCalls[0].lines?.find((l) => l.includes("Context:"));
-		assert.ok(contextLine, "widget should include context line");
-		assert.ok(
-			contextLine?.includes("computing"),
-			"should show 'computing...' when context not ready",
-		);
+		assert.ok(widgetCalls[0].lines?.[0]?.includes("developer"), "should show agent name");
+		assert.ok(widgetCalls[0].lines?.[0]?.includes("⏱"), "should show duration");
 	});
 
 	it("pipeline dispatches agent → onUpdate calls renderWidgetFromDetails → widget shows progress", () => {
@@ -901,10 +889,6 @@ describe("User-journey: widget progress during pipeline", () => {
 			ctx,
 			"agent-developer",
 		);
-		assert.ok(
-			widgetCalls[1].lines?.some((l) => l.includes("Analyzing")),
-			"widget should update with thinking content",
-		);
 
 		// Phase 3: tool
 		renderWidgetFromDetails(
@@ -920,10 +904,6 @@ describe("User-journey: widget progress during pipeline", () => {
 			ctx,
 			"agent-developer",
 		);
-		assert.ok(
-			widgetCalls[2].lines?.some((l) => l.includes("file.ts") || l.includes("read")),
-			"widget should show tool call",
-		);
 
 		// Phase 4: text
 		renderWidgetFromDetails(
@@ -937,10 +917,6 @@ describe("User-journey: widget progress during pipeline", () => {
 			"claude-sonnet-4",
 			ctx,
 			"agent-developer",
-		);
-		assert.ok(
-			widgetCalls[3].lines?.some((l) => l.includes("implementation")),
-			"widget should show live text",
 		);
 
 		// Final state: completed with stats
@@ -965,43 +941,8 @@ describe("User-journey: widget progress during pipeline", () => {
 		for (const call of widgetCalls) {
 			assert.equal(call.id, "agent-developer", "all widget calls should use agent-developer ID");
 			if (call.lines) {
-				assert.ok(call.lines.length >= 2, "each widget should have at least 2 lines");
+				assert.ok(call.lines.length === 1, "each widget should have exactly 1 line");
 			}
 		}
-	});
-});
-
-// ═══════════════════════════════════════════════════════════════════
-// idleWarning formatting — via buildWidgetLines
-// ═══════════════════════════════════════════════════════════════════
-
-describe("idleWarning formatting", () => {
-	it("idle warning line appears when provided", () => {
-		const state = createState();
-		const lines = buildWidgetLines(state, "test", "model", "⚠ No events for 20s");
-		const found = lines.find((l) => l.includes("⚠ No events for 20s"));
-		assert.ok(found, "idle warning should appear in widget lines");
-	});
-
-	it("null idle warning omitted", () => {
-		const state = createState();
-		const lines = buildWidgetLines(state, "test", "model", null);
-		const found = lines.find((l) => l.includes("No events for"));
-		assert.equal(found, undefined, "should not contain idle warning when null");
-	});
-
-	it("undefined idle warning omitted", () => {
-		const state = createState();
-		const lines = buildWidgetLines(state, "test", "model", undefined);
-		const found = lines.find((l) => l.includes("No events for"));
-		assert.equal(found, undefined, "should not contain idle warning when undefined");
-	});
-
-	it("multiple idle warnings show latest only (line count stable)", () => {
-		const state = createState();
-		const lines1 = buildWidgetLines(state, "test", "model", "⚠ No events for 20s");
-		const lines2 = buildWidgetLines(state, "test", "model", "⚠ No events for 20s");
-		// Same args produce same result — line count is stable, no duplication
-		assert.deepEqual(lines1, lines2);
 	});
 });

--- a/.pi/extensions/supervisor/test/terminal-widget.test.mts
+++ b/.pi/extensions/supervisor/test/terminal-widget.test.mts
@@ -39,17 +39,17 @@ function createState(overrides?: Partial<AgentRunState>): AgentRunState {
 describe("Simplified widget — footer only", () => {
 	it("returns exactly one line", () => {
 		const state = createState();
-		const lines = buildWidgetLines(state, "developer", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "developer", undefined, 10000);
 		assert.strictEqual(lines.length, 1, "should return exactly 1 line");
 	});
 
 	it("contains subagent:agentName prefix", () => {
-		const lines = buildWidgetLines(createState(), "architect", undefined, undefined, 10000);
+		const lines = buildWidgetLines(createState(), "architect", undefined, 10000);
 		assert.ok(lines[0].includes("subagent:architect"));
 	});
 
 	it("includes model when provided", () => {
-		const lines = buildWidgetLines(createState(), "dev", "claude-sonnet-4", undefined, 10000);
+		const lines = buildWidgetLines(createState(), "dev", "claude-sonnet-4", 10000);
 		assert.ok(lines[0].includes("claude-sonnet-4"));
 	});
 
@@ -58,7 +58,6 @@ describe("Simplified widget — footer only", () => {
 			createState(),
 			"dev",
 			"anthropic/claude-sonnet-4",
-			undefined,
 			10000,
 		);
 		assert.ok(lines[0].includes("claude-sonnet-4"));
@@ -67,55 +66,55 @@ describe("Simplified widget — footer only", () => {
 
 	it("includes token count when > 0", () => {
 		const state = createState({ tokenCount: 1500 });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(lines[0].includes("1.5K tokens"));
 	});
 
 	it("omits token count when 0", () => {
 		const state = createState({ tokenCount: 0 });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("tokens"));
 	});
 
 	it("includes tool count when > 0", () => {
 		const state = createState({ toolCount: 5 });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(lines[0].includes("5 tools"));
 	});
 
 	it("omits tool count when 0", () => {
 		const state = createState({ toolCount: 0 });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("tools"));
 	});
 
 	it("includes duration", () => {
-		const lines = buildWidgetLines(createState(), "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(createState(), "dev", undefined, 10000);
 		assert.ok(lines[0].includes("10s"));
 	});
 
 	it("includes cache stats when cacheRead/cacheWrite > 0", () => {
 		const state = createState({ cacheRead: 1000, cacheWrite: 500 });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(lines[0].includes("📦"));
 		assert.ok(lines[0].includes("1.0K/500") || lines[0].includes("1000/500"));
 	});
 
 	it("omits cache stats when cacheRead/cacheWrite are 0", () => {
 		const state = createState({ cacheRead: 0, cacheWrite: 0 });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("📦"));
 	});
 
 	it("omits cache stats when cacheRead/cacheWrite are undefined", () => {
 		const state = createState({ cacheRead: undefined, cacheWrite: undefined });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("📦"));
 	});
 
 	it("ignores fullLog entries (no log section shown)", () => {
 		const state = createState({ fullLog: ["entry1", "entry2", "entry3"] });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.strictEqual(lines.length, 1, "only 1 line regardless of log entries");
 		assert.ok(!lines[0].includes("entry1"), "log entries not shown");
 	});
@@ -128,7 +127,7 @@ describe("Simplified widget — footer only", () => {
 			currentToolArgs: '{"command":"ls"}',
 			liveText: "live output",
 		});
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.strictEqual(lines.length, 1);
 		assert.ok(!lines[0].includes("deep"), "no thinking shown");
 		assert.ok(!lines[0].includes("bash"), "no tool shown");
@@ -137,22 +136,22 @@ describe("Simplified widget — footer only", () => {
 
 	it("ignores idleWarning", () => {
 		const state = createState();
-		const lines = buildWidgetLines(state, "dev", undefined, "⚠ Idle warning", 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.strictEqual(lines.length, 1);
 		assert.ok(!lines[0].includes("Idle"), "no idle warning shown");
 	});
 
 	it("uses the provided `now` timestamp for duration calculation", () => {
 		const state = createState({ startedAt: 5000 }); // started at 5s
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000); // now = 10s
+		const lines = buildWidgetLines(state, "dev", undefined, 10000); // now = 10s
 		// 10000 - 5000 = 5000ms = 5s
 		assert.ok(lines[0].includes("5s"), `expected 5s duration, got: ${lines[0]}`);
 	});
 
 	it("idempotent: same input produces same output", () => {
 		const state = createState({ tokenCount: 100, toolCount: 3 });
-		const a = buildWidgetLines(state, "dev", "m", undefined, 10000);
-		const b = buildWidgetLines(state, "dev", "m", undefined, 10000);
+		const a = buildWidgetLines(state, "dev", "m", 10000);
+		const b = buildWidgetLines(state, "dev", "m", 10000);
 		assert.deepEqual(a, b);
 	});
 
@@ -164,7 +163,7 @@ describe("Simplified widget — footer only", () => {
 			cacheWrite: 1500,
 			startedAt: 0,
 		});
-		const lines = buildWidgetLines(state, "developer", "deepseek-v4-flash", undefined, 63000);
+		const lines = buildWidgetLines(state, "developer", "deepseek-v4-flash", 63000);
 		const line = lines[0];
 		assert.ok(line.includes("subagent:developer"));
 		assert.ok(line.includes("deepseek-v4-flash"));
@@ -179,32 +178,32 @@ describe("Simplified widget — footer only", () => {
 			cacheRead: undefined,
 			cacheWrite: undefined,
 		});
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("undefined"), "no 'undefined' in output");
 	});
 
 	it("includes thinking level icon and name when state has thinkingLevel", () => {
 		const state = createState({ thinkingLevel: "medium" });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(lines[0].includes("◒ medium"), "should show '◒ medium' for medium thinking");
 	});
 
 	it("omits thinking level when state.thinkingLevel is undefined", () => {
 		const state = createState();
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("◒"), "should not show thinking icon when undefined");
 		assert.ok(!lines[0].includes("medium"), "should not show thinking name when undefined");
 	});
 
 	it("omits thinking level for unknown level string", () => {
 		const state = createState({ thinkingLevel: "bogus" });
-		const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", undefined, 10000);
 		assert.ok(!lines[0].includes("bogus"), "should not show unknown thinking level");
 	});
 
 	it("thinking level appears after model in stats line", () => {
 		const state = createState({ thinkingLevel: "high", tokenCount: 1000, toolCount: 3, cacheRead: 0, cacheWrite: 0, startedAt: 0 });
-		const lines = buildWidgetLines(state, "dev", "some-model", undefined, 10000);
+		const lines = buildWidgetLines(state, "dev", "some-model", 10000);
 		const line = lines[0];
 		const modelIdx = line.indexOf("some-model");
 		const thinkingIdx = line.indexOf("◓");
@@ -217,7 +216,7 @@ describe("Simplified widget — footer only", () => {
 		const iconMap: Record<string, string> = { off: "○", minimal: "◐", low: "◑", medium: "◒", high: "◓", xhigh: "●" };
 		for (const [level, icon] of Object.entries(iconMap)) {
 			const state = createState({ thinkingLevel: level });
-			const lines = buildWidgetLines(state, "dev", undefined, undefined, 10000);
+			const lines = buildWidgetLines(state, "dev", undefined, 10000);
 			assert.ok(lines[0].includes(icon), `level '${level}' should show icon '${icon}'`);
 			assert.ok(lines[0].includes(level), `level '${level}' should show name`);
 		}


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1184

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 4s | 35.8K | 20 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 3m 4s | 36.8K | 56 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 54s | 33.3K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 44s | 74.5K | 43 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 20s | 47.8K | 46 | minimax-m3 |

**Total:** 5 agents · 15m 6s · 228.2K tokens · 179 tool calls · 10 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1184
Closes #1184