### PR TITLE
feat(#1241): [Bug] Go CLI root command misdescribes product as Raspberry Pi management

### DIFF
--- a/cmd/cheasee-pi/root.go
+++ b/cmd/cheasee-pi/root.go
@@ -6,9 +6,10 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "cheasee-pi",
-	Short: "Cheasee-PI — Raspberry Pi management and monitoring",
-	Long: `Cheasee-PI is a tool for managing Raspberry Pi devices
-with support for Docker-based deployments, monitoring, and configuration.`,
+	Short: "Cheasee-PI — Token-saving Pi agent harness with Docker setup",
+	Long: `Cheasee-PI is a Pi agent harness built on the Pi coding agent (pi.dev).
+Its init command authenticates with GitHub, clones your fork, configures
+submodules, and extracts Docker compose files for containerized deployment.`,
 	Version:            "0.1.0",
 	DisableAutoGenTag:  true,
 }

--- a/cmd/cheasee-pi/root_test.go
+++ b/cmd/cheasee-pi/root_test.go
@@ -59,6 +59,15 @@ func TestRootCmd_HelpContainsAppName(t *testing.T) {
 	}
 }
 
+func TestRootCmd_NoRaspberryPiReference(t *testing.T) {
+	if strings.Contains(rootCmd.Short, "Raspberry") {
+		t.Error("rootCmd.Short must not reference Raspberry Pi")
+	}
+	if strings.Contains(rootCmd.Long, "Raspberry") {
+		t.Error("rootCmd.Long must not reference Raspberry Pi")
+	}
+}
+
 func TestRootCmd_UnknownFlagError(t *testing.T) {
 	rootCmd.SetArgs([]string{"--unknown-flag"})
 	err := rootCmd.Execute()


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1241

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 7s | 63.0K | 49 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 33s | 13.9K | 8 | minimax-m3 |
| test-designer | ✓ SUCCESS | 58s | 16.8K | 7 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 13s | 25.1K | 23 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 49s | 38.7K | 13 | minimax-m3 |

**Total:** 5 agents · 6m 40s · 157.5K tokens · 100 tool calls · 4 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1241
Closes #1241