### PR TITLE
feat(#1236): [Bug] PR creation force-push overwrites existing branch commits when worktree recreated from main

### DIFF
--- a/.pi/extensions/supervisor/config/types.ts
+++ b/.pi/extensions/supervisor/config/types.ts
@@ -259,6 +259,8 @@ export interface PrCreationResult {
 	wasUpdate?: boolean;
 	/** Source identifier for error tracking (e.g. "pr-creation") */
 	source?: string;
+	/** Whether the push was skipped (branch already ahead of base) */
+	pushSkipped?: boolean;
 }
 
 // ─── Merge result ────────────────────────────────────────────────────

--- a/.pi/extensions/supervisor/pipeline/pr-creation.ts
+++ b/.pi/extensions/supervisor/pipeline/pr-creation.ts
@@ -73,11 +73,86 @@ export async function createPrOnApproval(
 	const prTitle = `feat(#${issueNum}): ${issueTitle}`;
 	log.info("pr-creation", `PR title: ${prTitle}`);
 
-	// ─── Phase 2: Push branch (if worktree exists) with retry ───────
+	// ─── Phase 2: Pre-check — verify head has commits beyond base ──
+	// Runs BEFORE push to avoid force-pushing over existing remote commits.
+	// When the remote branch already has commits ahead of main, the push is
+	// skipped entirely (the branch is already up-to-date on the remote).
+	//
+	// Fallback: if port.compareBranches fails (network error), use local git
+	// fetch + merge-base --is-ancestor to determine whether to push.
+	let skipPush = false;
+	if (worktreePath) {
+		if (port) {
+			try {
+				const aheadCount = await port.compareBranches(config.defaultBranch!, headBranch, config.repo);
+				if (aheadCount === 0) {
+					log.warn(
+						"pr-creation",
+						`No commits between ${config.defaultBranch} and ${headBranch} — skipping push and PR`,
+					);
+					ctx.ui.notify("Already implemented on base branch — no PR needed", "info");
+					return {
+						success: false,
+						error: "Already implemented on base branch — no new changes to PR",
+						source: "pr-creation",
+						pushSkipped: true,
+					};
+				}
+				log.info("pr-creation", `Head is ${aheadCount} commits ahead of ${config.defaultBranch}`);
+			} catch (compareErr: unknown) {
+				// Local fallback: fetch + merge-base --is-ancestor
+				const compareMsg = compareErr instanceof Error ? compareErr.message : String(compareErr);
+				log.warn("pr-creation", `compareBranches failed: ${compareMsg} — using local fallback`);
+
+				try {
+					await pi.exec("git", ["fetch", config.remote!, headBranch], {
+						cwd: worktreePath,
+						timeout: 30000,
+					});
+					const mergeBase = await pi.exec(
+						"git",
+						["merge-base", "--is-ancestor", config.defaultBranch!, headBranch],
+						{ cwd: worktreePath, timeout: 15000 },
+					);
+					// merge-base --is-ancestor exits 0 if defaultBranch is ancestor of headBranch
+					if (mergeBase.code !== 0) {
+						log.warn(
+							"pr-creation",
+							`Local check: ${headBranch} is not ahead of ${config.defaultBranch} — skipping PR`,
+						);
+						ctx.ui.notify("Already implemented on base branch — no PR needed", "info");
+						return {
+							success: false,
+							error: "Already implemented on base branch — no new changes to PR",
+							source: "pr-creation",
+							pushSkipped: true,
+						};
+					}
+					log.info("pr-creation", "Local check passed — head is ahead of base");
+				} catch (fallbackErr: unknown) {
+					// Local fallback also failed — fail closed, skip push
+					const fallbackMsg = fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
+					log.error("pr-creation", `Local ahead check failed: ${fallbackMsg} — skipping push (fail-closed)`);
+					ctx.ui.notify(`Cannot verify branch state — skipping push: ${fallbackMsg}`, "error");
+					return {
+						success: false,
+						error: `Cannot verify branch state: ${fallbackMsg}`,
+						source: "pr-creation",
+						pushSkipped: true,
+					};
+				}
+			}
+		} else {
+			log.warn("pr-creation", "Port not available — cannot verify ahead count, proceeding with push");
+		}
+	}
+
+	// ─── Phase 3: Push branch (if worktree exists) with retry ───────
 	// Timeout: 60s per attempt. Retry with exponential backoff (3 attempts).
+	// Uses --force-with-lease to avoid overwriting remote commits we haven't seen.
 	const MAX_PUSH_RETRIES = 3;
 	const PUSH_RETRY_DELAYS_MS = [3000, 5000, 10000];
-	if (worktreePath) {
+	if (worktreePath && !skipPush) {
 		log.info("pr-creation", `Pushing ${headBranch} from worktree`);
 		let lastPushErr: unknown;
 		let pushSucceeded = false;
@@ -91,7 +166,7 @@ export async function createPrOnApproval(
 					);
 					await new Promise((resolve) => setTimeout(resolve, delayMs));
 				}
-				await pi.exec("git", ["push", "--force", config.remote!, headBranch], {
+				await pi.exec("git", ["push", "--force-with-lease", config.remote!, headBranch], {
 					cwd: worktreePath,
 					timeout: 60000,
 				});
@@ -117,31 +192,8 @@ export async function createPrOnApproval(
 				source: "pr-creation",
 			};
 		}
-	}
-
-	// ─── Phase 3: Pre-check — verify head has commits beyond base ──
-	// Only runs when worktree exists (branch was pushed). Skip check if
-	// no worktree since there are no new commits to PR.
-	if (worktreePath && port) {
-		try {
-			const aheadCount = await port.compareBranches(config.defaultBranch!, headBranch, config.repo);
-			if (aheadCount === 0) {
-				log.warn(
-					"pr-creation",
-					`No commits between ${config.defaultBranch} and ${headBranch} — skipping PR`,
-				);
-				ctx.ui.notify("Already implemented on base branch — no PR needed", "info");
-				return {
-					success: false,
-					error: "Already implemented on base branch — no new changes to PR",
-					source: "pr-creation",
-				};
-			}
-			log.info("pr-creation", `Head is ${aheadCount} commits ahead of ${config.defaultBranch}`);
-		} catch (compareErr: unknown) {
-			const compareMsg = compareErr instanceof Error ? compareErr.message : String(compareErr);
-			log.warn("pr-creation", `Commit count check failed: ${compareMsg} — attempting PR anyway`);
-		}
+	} else if (!worktreePath) {
+		log.info("pr-creation", "No worktree path — skipping push");
 	}
 
 	// ─── Phase 4: Check for existing PR ────────────────────────────

--- a/.pi/extensions/supervisor/pipeline/worktree.ts
+++ b/.pi/extensions/supervisor/pipeline/worktree.ts
@@ -11,6 +11,65 @@ import type { NotifyFn } from "./helpers.ts";
 
 // ─── Create Worktree ─────────────────────────────────────────────
 
+/**
+ * Reconcile the worktree branch to match the remote tracking branch if one exists.
+ *
+ * When a worktree is recreated after pipeline cleanup (local branch deleted but
+ * remote branch persists), the new local branch may be at defaultBranch HEAD while
+ * the remote tracking branch has the developer's actual commits. This function
+ * detects that scenario and resets the worktree to match its remote counterpart.
+ *
+ * Returns Result<void> — never throws. On failure, the caller decides whether
+ * reconciliation is fatal (createWorktree treats it as fatal).
+ */
+export async function reconcileToRemoteBranch(
+	pi: ExtensionAPI,
+	cwd: string,
+	wtPath: string,
+	worktreeBranch: string,
+	remote: string,
+	notify: NotifyFn,
+): Promise<Result<void>> {
+	const log = getDebugLogger();
+	const remoteRef = `refs/remotes/${remote}/${worktreeBranch}`;
+
+	try {
+		// Check if remote tracking branch exists
+		// rev-parse --verify exits 128 when the ref doesn't exist — pi.exec
+		// may throw or return a result, so handle both via try/catch.
+		try {
+			await pi.exec("git", ["rev-parse", "--verify", remoteRef], { cwd, timeout: 10000 });
+		} catch {
+			log.info("worktree", `No remote tracking branch ${remote}/${worktreeBranch} — skipping reconciliation`);
+			return { ok: true, value: undefined };
+		}
+
+		log.info("worktree", `Remote tracking branch ${remote}/${worktreeBranch} exists — reconciling`);
+
+		// Fetch latest from remote for this branch
+		await pi.exec(
+			"git",
+			["fetch", remote, worktreeBranch],
+			{ cwd, timeout: 30000 },
+		);
+
+		// Reset worktree to match remote tracking branch
+		await pi.exec(
+			"git",
+			["reset", "--hard", `${remote}/${worktreeBranch}`],
+			{ cwd: wtPath, timeout: 15000 },
+		);
+
+		log.info("worktree", `Worktree reconciled to ${remote}/${worktreeBranch}`);
+		notify.info(`Reconciled worktree to remote branch ${remote}/${worktreeBranch}`);
+		return { ok: true, value: undefined };
+	} catch (err: unknown) {
+		const msg = err instanceof Error ? err.message : String(err);
+		log.error("worktree", `Reconciliation failed: ${msg}`);
+		return { ok: false, error: msg, source: "worktree" };
+	}
+}
+
 export async function createWorktree(
 	pi: ExtensionAPI,
 	cwd: string,
@@ -36,6 +95,13 @@ export async function createWorktree(
 					throw new Error(result.stderr || result.stdout || "git worktree add failed");
 				}
 				log.info("worktree", `Worktree created at ${wt}`);
+
+				// Reconcile to remote tracking branch if one exists
+				const reconcile = await reconcileToRemoteBranch(pi, cwd, wt, worktreeBranch, "origin", notify);
+				if (!reconcile.ok) {
+					throw new Error(`Reconciliation failed: ${reconcile.error}`);
+				}
+
 				return wt;
 			} catch (err: unknown) {
 				const attempt1Err = err instanceof Error ? err.message : String(err);
@@ -52,6 +118,13 @@ export async function createWorktree(
 					throw new Error(result.stderr || result.stdout || "git worktree add failed");
 				}
 				log.info("worktree", `Worktree attached at ${wt} (existing branch ${worktreeBranch})`);
+
+				// Reconcile to remote tracking branch if one exists
+				const reconcile = await reconcileToRemoteBranch(pi, cwd, wt, worktreeBranch, "origin", notify);
+				if (!reconcile.ok) {
+					throw new Error(`Reconciliation failed: ${reconcile.error}`);
+				}
+
 				return wt;
 			} catch (err2: unknown) {
 				const attempt2Err = err2 instanceof Error ? err2.message : String(err2);
@@ -62,6 +135,13 @@ export async function createWorktree(
 			try {
 				await pi.exec("test", ["-d", wt], { timeout: 5000 });
 				log.warn("worktree", "Both attempts failed but worktree dir exists — using it");
+
+				// Reconcile to remote tracking branch if one exists
+				const reconcile = await reconcileToRemoteBranch(pi, cwd, wt, worktreeBranch, "origin", notify);
+				if (!reconcile.ok) {
+					throw new Error(`Reconciliation failed: ${reconcile.error}`);
+				}
+
 				return wt;
 			} catch {
 				// Directory doesn't exist — throw to stop pipeline early

--- a/.pi/extensions/supervisor/test/pipeline/pr-creation.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/pr-creation.test.mts
@@ -132,12 +132,12 @@ const mockAgentResult: PipelineAgentResult = {
 // ─── Tests ─────────────────────────────────────────────────────────
 
 describe("createPrOnApproval()", () => {
-	it("Happy path with worktree: push → compare check → list PR → create PR → success notifications", async () => {
+	it("Happy path first run: compareBranches returns ahead_by=3 BEFORE push → push with --force-with-lease → PR created", async () => {
 		const execCalls: ExecCall[] = [];
 		const notifyCalls: NotifyCall[] = [];
 		const pi = createMockPi(
 			[
-				// 1. git push --force
+				// 1. git push --force-with-lease (ahead_by=3, push proceeds)
 				{ code: 0, stdout: "Everything up-to-date", stderr: "" },
 			],
 			execCalls,
@@ -163,10 +163,10 @@ describe("createPrOnApproval()", () => {
 		// Verify only git push is an exec call (the rest use port)
 		assert.equal(execCalls.length, 1, "should have 1 exec call (git push)");
 
-		// 1. git push
+		// 1. git push uses --force-with-lease
 		assert.equal(execCalls[0].cmd, "git");
 		assert.equal(execCalls[0].args[0], "push");
-		assert.equal(execCalls[0].args[1], "--force");
+		assert.equal(execCalls[0].args[1], "--force-with-lease");
 		assert.equal(execCalls[0].args[2], "origin");
 		assert.equal(execCalls[0].args[3], "worktree-git-issue-42-test");
 		assert.equal(execCalls[0].opts.cwd, "/worktrees/wt-42");
@@ -841,18 +841,13 @@ describe("createPrOnApproval()", () => {
 		assert.equal(callCount, 2, "should make exactly 2 attempts");
 	});
 
-	// ─── Bug 2: ahead_by=0 ─────────────────────────────────────────
+	// ─── Bug 2 (fix): ahead_by=0 checked before push ────────────────
 
-	it("Bug 2: ahead_by=0 returns success=false with 'No commits ahead' error", async () => {
+	it("Bug 2 (fix): ahead_by=0 — push skipped, pushSkipped=true, no git push exec calls", async () => {
 		const execCalls: ExecCall[] = [];
 		const notifyCalls: NotifyCall[] = [];
-		const pi = createMockPi(
-			[
-				// 1. git push --force OK
-				{ code: 0, stdout: "push ok", stderr: "" },
-			],
-			execCalls,
-		);
+		// No mock exec results needed — ahead_by check runs first and returns early
+		const pi = createMockPi([], execCalls);
 		const ctx = createMockCtx(notifyCalls);
 		const port = createMockComparePort(0); // ahead_by = 0
 
@@ -871,27 +866,27 @@ describe("createPrOnApproval()", () => {
 			port,
 		);
 
+		// No git push exec calls should be made
+		const gitPushCalls = execCalls.filter((c) => c.cmd === "git" && c.args[0] === "push");
+		assert.equal(gitPushCalls.length, 0, "no git push should be called when ahead_by=0");
+
+		// Result should indicate failure with pushSkipped
 		assert.ok(result, "should return a PrCreationResult");
 		assert.equal(result.success, false, "should indicate failure when no commits ahead");
+		assert.equal(result.pushSkipped, true, "pushSkipped should be true when ahead_by=0");
 		assert.ok(result.error, "should contain error message");
 		assert.ok(
-			result.error!.toLowerCase().includes("no commits") ||
-				result.error!.toLowerCase().includes("skipped") ||
-				result.error!.toLowerCase().includes("no new changes"),
-			`error should mention no commits: ${result.error}`,
+			result.error!.toLowerCase().includes("no new changes") ||
+				result.error!.toLowerCase().includes("no changes"),
+			`error should mention no changes: ${result.error}`,
 		);
 		assert.equal(result.prNumber, undefined, "prNumber should be undefined when no commits");
 	});
 
-	it("Bug 2: ahead_by=0 does NOT report 'created' in output (no misleading PR #undefined)", async () => {
+	it("Bug 2 (fix): ahead_by=0 — no misleading PR notifications, pushSkipped=true", async () => {
 		const execCalls: ExecCall[] = [];
 		const notifyCalls: NotifyCall[] = [];
-		const pi = createMockPi(
-			[
-				{ code: 0, stdout: "push ok", stderr: "" },
-			],
-			execCalls,
-		);
+		const pi = createMockPi([], execCalls);
 		const ctx = createMockCtx(notifyCalls);
 		const port = createMockComparePort(0); // ahead_by = 0
 
@@ -910,12 +905,229 @@ describe("createPrOnApproval()", () => {
 			port,
 		);
 
-		// No PR creation should be attempted
+		// No PR creation should be attempted — no "PR #" notifications
 		const infoNotifies = notifyCalls.filter((n) => n.message.includes("PR #"));
 		assert.equal(infoNotifies.length, 0, "no PR notifications should be sent");
 
 		// The result should not be misleading
 		assert.equal(result.success, false, "should not indicate success");
 		assert.equal(result.prNumber, undefined, "prNumber should be undefined");
+		assert.equal(result.pushSkipped, true, "pushSkipped should be true");
+	});
+
+	describe("createPrOnApproval - Phase reorder: ahead_by check before push — Bug fix", () => {
+		it("Re-run with reconciliation (remote ahead): ahead_by=3 before push → push proceeds → existing PR updated", async () => {
+			const execCalls: ExecCall[] = [];
+			const notifyCalls: NotifyCall[] = [];
+			const pi = createMockPi(
+				[
+					{ code: 0, stdout: "push ok", stderr: "" },
+				],
+				execCalls,
+			);
+			const ctx = createMockCtx(notifyCalls);
+			const port = createMockComparePort(3, 123); // ahead_by=3, existing PR
+
+			const result = await createPrOnApproval(
+				pi,
+				ctx,
+				42,
+				"Test issue",
+				mockConfig as any,
+				[mockAgentResult],
+				"/worktrees/wt-42",
+				"worktree-git-issue-42-test",
+				undefined,
+				undefined,
+				undefined,
+				port,
+			);
+
+			assert.equal(result.success, true, "should succeed");
+			assert.equal(result.prNumber, 123, "should return existing PR number");
+			assert.equal(result.wasUpdate, true, "should be marked as update");
+			assert.equal(result.pushSkipped, undefined, "pushSkipped should be undefined when push proceeds");
+
+			const gitPushCalls = execCalls.filter((c) => c.cmd === "git" && c.args[0] === "push");
+			assert.equal(gitPushCalls.length, 1, "push should be called once");
+			assert.equal(gitPushCalls[0].args[1], "--force-with-lease", "push should use --force-with-lease");
+		});
+
+		it("compareBranches throws → local fallback: fetch + merge-base succeeds, head is ahead → push proceeds", async () => {
+			const execCalls: ExecCall[] = [];
+			const notifyCalls: NotifyCall[] = [];
+			const pi = createMockPi(
+				[
+					{ code: 0, stdout: "", stderr: "" },  // git fetch origin <branch>
+					{ code: 0, stdout: "", stderr: "" },  // git merge-base --is-ancestor exits 0
+					{ code: 0, stdout: "push ok", stderr: "" },  // git push --force-with-lease
+				],
+				execCalls,
+			);
+			const ctx = createMockCtx(notifyCalls);
+			const port = createMockGitHubPort({
+				compareBranches: async () => { throw new Error("API rate limit"); },
+				listPullRequestsForBranch: async () => null,
+				createPullRequest: async () => ({ number: 456 }),
+			});
+
+			const result = await createPrOnApproval(
+				pi,
+				ctx,
+				42,
+				"Test issue",
+				mockConfig as any,
+				[mockAgentResult],
+				"/worktrees/wt-42",
+				"worktree-git-issue-42-test",
+				undefined,
+				undefined,
+				undefined,
+				port,
+			);
+
+			assert.equal(result.success, true, "should succeed after fallback check passes");
+			assert.equal(result.pushSkipped, undefined, "pushSkipped should be undefined when push proceeds");
+
+			// Verify exec call order: fetch → merge-base → push
+			assert.equal(execCalls.length, 3, "should have 3 exec calls (fetch, merge-base, push)");
+			assert.ok(execCalls[0].args.includes("fetch"), "first should be git fetch");
+			assert.ok(execCalls[1].args.includes("merge-base"), "second should be git merge-base");
+			assert.ok(execCalls[2].args.includes("push"), "third should be git push");
+			assert.equal(execCalls[2].args[1], "--force-with-lease", "push should use --force-with-lease");
+		});
+
+		it("compareBranches throws → local fallback: merge-base says NOT ahead → push skipped", async () => {
+			const execCalls: ExecCall[] = [];
+			const notifyCalls: NotifyCall[] = [];
+			const pi = createMockPi(
+				[
+					{ code: 0, stdout: "", stderr: "" },  // git fetch succeeds
+					{ code: 1, stdout: "", stderr: "" },  // git merge-base exits 1 (NOT ancestor)
+				],
+				execCalls,
+			);
+			const ctx = createMockCtx(notifyCalls);
+			const port = createMockGitHubPort({
+				compareBranches: async () => { throw new Error("API rate limit"); },
+			});
+
+			const result = await createPrOnApproval(
+				pi,
+				ctx,
+				42,
+				"Test issue",
+				mockConfig as any,
+				[mockAgentResult],
+				"/worktrees/wt-42",
+				"worktree-git-issue-42-test",
+				undefined,
+				undefined,
+				undefined,
+				port,
+			);
+
+			assert.equal(result.success, false, "should fail when merge-base says not ahead");
+			assert.equal(result.pushSkipped, true, "pushSkipped should be true");
+
+			const gitPushCalls = execCalls.filter((c) => c.cmd === "git" && c.args[0] === "push");
+			assert.equal(gitPushCalls.length, 0, "no push should be called");
+		});
+
+		it("compareBranches throws → local fallback fetch fails → push skipped (fail-closed)", async () => {
+			const execCalls: ExecCall[] = [];
+			const notifyCalls: NotifyCall[] = [];
+			const pi = createMockPi(
+				[
+					{ code: 1, stdout: "", stderr: "fetch failed" },  // git fetch fails
+				],
+				execCalls,
+			);
+			const ctx = createMockCtx(notifyCalls);
+			const port = createMockGitHubPort({
+				compareBranches: async () => { throw new Error("API rate limit"); },
+			});
+
+			const result = await createPrOnApproval(
+				pi,
+				ctx,
+				42,
+				"Test issue",
+				mockConfig as any,
+				[mockAgentResult],
+				"/worktrees/wt-42",
+				"worktree-git-issue-42-test",
+				undefined,
+				undefined,
+				undefined,
+				port,
+			);
+
+			assert.equal(result.success, false, "should fail when fetch fails");
+			assert.equal(result.pushSkipped, true, "pushSkipped should be true (fail-closed)");
+
+			const errorNotifies = notifyCalls.filter((n) => n.level === "error");
+			assert.ok(errorNotifies.length > 0, "should have error notification");
+		});
+
+		it("No worktree path: ahead_by check + push skipped, PR creation proceeds", async () => {
+			const execCalls: ExecCall[] = [];
+			const notifyCalls: NotifyCall[] = [];
+			const pi = createMockPi([], execCalls);
+			const ctx = createMockCtx(notifyCalls);
+			const port = createMockComparePort(3);
+
+			await createPrOnApproval(
+				pi,
+				ctx,
+				42,
+				"Test issue",
+				mockConfig as any,
+				[mockAgentResult],
+				undefined,
+				"worktree-git-issue-42-test",
+				undefined,
+				undefined,
+				undefined,
+				port,
+			);
+
+			const gitPushCalls = execCalls.filter((c) => c.cmd === "git" && c.args[0] === "push");
+			assert.equal(gitPushCalls.length, 0, "no git push when worktreePath is undefined");
+
+			const infoNotifies = notifyCalls.filter((n) => n.level === "info" && n.message.includes("PR #"));
+			assert.ok(infoNotifies.length > 0, "should have PR notification");
+		});
+
+		it("--force-with-lease used in exec args instead of bare --force", async () => {
+			const execCalls: ExecCall[] = [];
+			const pi = createMockPi(
+				[
+					{ code: 0, stdout: "push ok", stderr: "" },
+				],
+				execCalls,
+			);
+			const ctx = createMockCtx([]);
+			const port = createMockComparePort(3);
+
+			await createPrOnApproval(
+				pi,
+				ctx,
+				42,
+				"Test issue",
+				mockConfig as any,
+				[mockAgentResult],
+				"/worktrees/wt-42",
+				"worktree-git-issue-42-test",
+				undefined,
+				undefined,
+				undefined,
+				port,
+			);
+
+			const pushCall = execCalls.find((c) => c.cmd === "git" && c.args[0] === "push");
+			assert.ok(pushCall, "push should be called");
+			assert.equal(pushCall!.args[1], "--force-with-lease", "should use --force-with-lease");
+		});
 	});
 });

--- a/.pi/extensions/supervisor/test/pipeline/worktree.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/worktree.test.mts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	createWorktree,
+	reconcileToRemoteBranch,
 	installWorktreeDeps,
 	cleanupWorktree,
 	deleteBranch,
@@ -42,6 +43,27 @@ function createMockPi(
 	} as ExtensionAPI;
 }
 
+/**
+ * Create a mock pi.exec that records calls but doesn't execute results in order.
+ * Unlike createMockPi, this uses a map of command patterns to results for when
+ * you need different responses for different commands (e.g., rev-parse=0 vs fetch=0).
+ */
+function createMockPiWithDefaults(defaultResult: { code: number; stdout: string; stderr: string }): ExtensionAPI {
+	const callLog: ExecCall[] = [];
+	return {
+		exec: ((cmd: string, args: string[], opts?: Record<string, unknown>) => {
+			callLog.push({ cmd, args: args || [], opts: opts || {} });
+			const result = { ...defaultResult };
+			if (result.code !== 0) {
+				return Promise.reject(
+					new Error(result.stderr || result.stdout || `Command failed: ${cmd}`),
+				);
+			}
+			return Promise.resolve(result);
+		}) as ExtensionAPI["exec"],
+	} as unknown as ExtensionAPI;
+}
+
 function createMockNotify(): { notify: NotifyFn; calls: Array<{ level: string; msg: string }> } {
 	const calls: Array<{ level: string; msg: string }> = [];
 	const notify: NotifyFn = {
@@ -56,7 +78,14 @@ function createMockNotify(): { notify: NotifyFn; calls: Array<{ level: string; m
 describe("createWorktree()", () => {
 	it("creates worktree with -b flag on first attempt — returns { ok: true, value }", async () => {
 		const calls: ExecCall[] = [];
-		const pi = createMockPi([{ code: 0, stdout: "", stderr: "" }], calls);
+		// add succeeds → reconciliation: rev-parse exits 128 (no remote ref)
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" },
+				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },
+			],
+			calls,
+		);
 		const { notify } = createMockNotify();
 		const result = await createWorktree(
 			pi,
@@ -78,6 +107,9 @@ describe("createWorktree()", () => {
 			result.ok ? result.value : "",
 			"main",
 		]);
+		// Reconciliation: rev-parse exits 128 → no-op, no fetch/reset
+		assert.equal(calls.length, 2, "should have 2 exec calls (add + rev-parse)");
+		assert.deepEqual(calls[1].args, ["rev-parse", "--verify", "refs/remotes/origin/feature-branch"]);
 	});
 
 	it("falls back to add without -b when first attempt fails — returns { ok: true }", async () => {
@@ -86,6 +118,7 @@ describe("createWorktree()", () => {
 			[
 				{ code: 1, stdout: "", stderr: "already exists" },
 				{ code: 0, stdout: "", stderr: "" },
+				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },
 			],
 			calls,
 		);
@@ -99,7 +132,7 @@ describe("createWorktree()", () => {
 			notify,
 		);
 		assert.equal(result.ok, true);
-		assert.equal(calls.length, 2);
+		assert.equal(calls.length, 3, "should have 3 exec calls (add -b fail, add, rev-parse)");
 		assert.deepEqual(calls[1].args, ["worktree", "add", calls[1].args[2], "feature-branch"]);
 	});
 
@@ -108,6 +141,7 @@ describe("createWorktree()", () => {
 			{ code: 1, stdout: "", stderr: "error" },
 			{ code: 1, stdout: "", stderr: "already exists" },
 			{ code: 0, stdout: "", stderr: "" }, // test -d succeeds
+			{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" }, // rev-parse: no remote
 		]);
 		const { notify } = createMockNotify();
 		const result = await createWorktree(pi, "/repo", "../worktrees", "branch", "main", notify);
@@ -119,7 +153,7 @@ describe("createWorktree()", () => {
 			{ code: 1, stdout: "", stderr: "error" },
 			{ code: 1, stdout: "", stderr: "already exists" },
 			{ code: 1, stdout: "", stderr: "directory not found" }, // test -d fails
-		]);
+		]);		// Both attempts fail AND dir doesn't exist → reconciliation never reached
 		const { notify, calls } = createMockNotify();
 		const result = await createWorktree(pi, "/repo", "../worktrees", "branch", "main", notify);
 		assert.equal(result.ok, false);
@@ -135,7 +169,11 @@ describe("createWorktree()", () => {
 	});
 
 	it("does not call notify.error when create succeeds", async () => {
-		const pi = createMockPi([{ code: 0, stdout: "", stderr: "" }]);
+		// add succeeds → rev-parse: no remote (128)
+		const pi = createMockPi([
+			{ code: 0, stdout: "", stderr: "" },
+			{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },
+		]);
 		const { notify, calls } = createMockNotify();
 		const result = await createWorktree(
 			pi,
@@ -347,5 +385,113 @@ describe("cleanupWorktree()", () => {
 		assert.equal(result.ok, true);
 		assert.equal(calls.length, 3, "All 3 git commands when skipBranch omitted");
 		assert.deepEqual(calls[2].args, ["branch", "-D", "branch"]);
+	});
+});
+
+// ─── Tests: reconcileToRemoteBranch() ─────────────────────────────
+
+describe("reconcileToRemoteBranch()", () => {
+	it("remote ref exists — fetches and resets worktree, returns { ok: true }", async () => {
+		const calls: ExecCall[] = [];
+		// rev-parse succeeds → fetch succeeds → reset succeeds
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" },  // rev-parse
+				{ code: 0, stdout: "", stderr: "" },  // fetch
+				{ code: 0, stdout: "", stderr: "" },  // reset
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+		const result = await reconcileToRemoteBranch(pi, "/repo", "/wt", "feature", "origin", notify);
+		assert.equal(result.ok, true, "should succeed when remote ref exists");
+		assert.equal(calls.length, 3);
+		assert.deepEqual(calls[0].args, ["rev-parse", "--verify", "refs/remotes/origin/feature"]);
+		assert.deepEqual(calls[1].args, ["fetch", "origin", "feature"]);
+		assert.deepEqual(calls[2].args, ["reset", "--hard", "origin/feature"]);
+	});
+
+	it("no remote ref — no fetch, no reset, returns { ok: true }", async () => {
+		const calls: ExecCall[] = [];
+		// rev-parse exits 128 (no remote ref)
+		const pi = createMockPi(
+			[
+				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+		const result = await reconcileToRemoteBranch(pi, "/repo", "/wt", "feature", "origin", notify);
+		assert.equal(result.ok, true, "should succeed (no-op) when no remote ref");
+		assert.equal(calls.length, 1, "only rev-parse call");
+	});
+
+	it("fetch fails — returns { ok: false, error }", async () => {
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" },  // rev-parse succeeds
+				{ code: 1, stdout: "", stderr: "fetch failed: network error" },  // fetch fails
+			],
+			calls,
+		);
+		const { notify, calls: notifyCalls } = createMockNotify();
+		const result = await reconcileToRemoteBranch(pi, "/repo", "/wt", "feature", "origin", notify);
+		assert.equal(result.ok, false);
+		if (!result.ok) {
+			assert.ok(result.error.includes("fetch failed"), "error should mention fetch failure");
+			assert.equal(result.source, "worktree");
+		}
+		// Should not call notify.error (function returns error, caller decides fatality)
+		assert.equal(notifyCalls.length, 0, "reconcileToRemoteBranch should not call notify itself");
+	});
+
+	it("fetch succeeds but reset fails — returns { ok: false }", async () => {
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" },  // rev-parse succeeds
+				{ code: 0, stdout: "", stderr: "" },  // fetch succeeds
+				{ code: 1, stdout: "", stderr: "reset failed: dirty index" },  // reset fails
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+		const result = await reconcileToRemoteBranch(pi, "/repo", "/wt", "feature", "origin", notify);
+		assert.equal(result.ok, false);
+		if (!result.ok) {
+			assert.ok(result.error.includes("reset failed"), "error should mention reset failure");
+			assert.equal(result.source, "worktree");
+		}
+	});
+
+	it("calls notify.info on successful reconciliation", async () => {
+		const pi = createMockPi([
+			{ code: 0, stdout: "", stderr: "" },  // rev-parse
+			{ code: 0, stdout: "", stderr: "" },  // fetch
+			{ code: 0, stdout: "", stderr: "" },  // reset
+		]);
+		const { notify, calls: notifyCalls } = createMockNotify();
+		const result = await reconcileToRemoteBranch(pi, "/repo", "/wt", "feature", "origin", notify);
+		assert.equal(result.ok, true);
+		// notify.info should be called with reconciliation message
+		const reconcileInfo = notifyCalls.find((c) => c.msg.includes("Reconciled worktree to remote"));
+		assert.ok(reconcileInfo, "notify.info should be called on successful reconciliation");
+	});
+
+	it("first run (no remote) — createWorktree exec call count unchanged from expected", async () => {
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" },  // worktree add -b succeeds
+				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },  // rev-parse: no remote
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+		const result = await createWorktree(pi, "/repo", "../worktrees", "feature", "main", notify);
+		assert.equal(result.ok, true);
+		// Only 2 calls: worktree add + rev-parse (no fetch/reset since no remote)
+		assert.equal(calls.length, 2, "should have 2 exec calls on first run (add + no-op rev-parse)");
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1236

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 49s | 73.2K | 37 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 12s | 30.1K | 22 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 58s | 41.4K | 19 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 11m 25s | 104.1K | 54 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 51s | 74.2K | 31 | minimax-m3 |

**Total:** 5 agents · 21m 14s · 323.0K tokens · 163 tool calls · 10 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1236
Closes #1236