### PR TITLE
feat(#1244): [Bug] installation.md claims init saves auth to ~/.pi/agent/auth.json (actual: ~/.config/cheasee-pi/auth.json)

### DIFF
--- a/cmd/cheasee-pi/installation_doc_test.go
+++ b/cmd/cheasee-pi/installation_doc_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docPath is the path to the installation doc relative to this test file.
+func docPath() string {
+	// Test runs from the package directory (cmd/cheasee-pi/).
+	return filepath.Join("..", "..", "docs", "installation.md")
+}
+
+// TestInstallationDoc_Path verifies that Step 5 bullet 8 of the installation
+// doc matches the path that config.go:fileRepository.configPath() actually
+// writes to — the XDG user config dir, not the legacy ~/.pi/agent/auth.json.
+func TestInstallationDoc_Path(t *testing.T) {
+	data, err := os.ReadFile(docPath())
+	if err != nil {
+		t.Fatalf("reading docs/installation.md: %v", err)
+	}
+	content := string(data)
+
+	// The doc must use the XDG user config directory path (matches
+	// filepath.Join(userConfigDir, "cheasee-pi", "auth.json") in config.go).
+	if !strings.Contains(content, "cheasee-pi/auth.json") &&
+		!strings.Contains(content, "cheasee-pi" + string(os.PathSeparator) + "auth.json") {
+		t.Error("Step 5 bullet 8 should reference cheasee-pi/auth.json (XDG path suffix from config.go)")
+	}
+
+	// The doc must no longer contain the legacy shell-script path.
+	if strings.Contains(content, "~/.pi/agent/auth.json") {
+		t.Error("Step 5 bullet 8 should not contain the legacy path ~/.pi/agent/auth.json")
+	}
+
+	// The doc should reference the runtime confirmation line as the
+	// authoritative source of the exact path.
+	if !strings.Contains(content, "Auth config saved to") &&
+		!strings.Contains(content, "✓ Auth config saved to") {
+		t.Error("Step 5 bullet 8 should reference the runtime output \"✓ Auth config saved to...\"")
+	}
+}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -159,7 +159,7 @@ cheasee-pi init
 5. Configure the submodule (prompts for your repo URL)
 6. Extract embedded `docker-compose.yml`, `Dockerfile`, and `entrypoint.sh`
 7. Generate `docker/.env` with your settings
-8. Save authentication config to `~/.pi/agent/auth.json`
+8. Save authentication config to your platform's XDG user config directory (e.g., `~/.config/cheasee-pi/auth.json` on Linux; the exact path is printed at runtime as "✓ Auth config saved to...")
 
 After completion, you'll see:
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1244

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 59s | 110.1K | 26 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 38s | 13.6K | 8 | minimax-m3 |
| test-designer | ✓ SUCCESS | 55s | 16.9K | 16 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 16s | 21.8K | 21 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 20s | 40.3K | 18 | minimax-m3 |

**Total:** 5 agents · 6m 8s · 202.7K tokens · 89 tool calls · 3 failed (3%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1244
Closes #1244