### PR TITLE
feat(#1243): [Bug] Init success message and installation doc reference non-existent 'cheasee-pi start' subcommand

### DIFF
--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -12,6 +12,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// nextStepHint is the post-init instruction printed after a successful init run.
+// It is a constant so both the CLI and documentation stay in sync.
+// If the compose filename or flag shape changes, update both init.go and
+// docs/installation.md in lockstep.
+const nextStepHint = "docker compose -f docker/docker-compose.yml up -d --build"
+
 var (
 	initAPIKey        string
 	initNoDockerCheck bool
@@ -222,7 +228,8 @@ func runInit(
 
 	path, _ := cfg.Path()
 	fmt.Fprintf(os.Stderr, "  ✓ Auth config saved to %s\n", path)
-	fmt.Fprintf(os.Stderr, "\n✅ Init complete! Next step: run 'cheasee-pi start'\n")
+	fmt.Fprintf(os.Stderr, "\n✅ Init complete! Next step:\n")
+	fmt.Fprintf(os.Stderr, "   %s\n", nextStepHint)
 	return nil
 }
 

--- a/cmd/cheasee-pi/init_test.go
+++ b/cmd/cheasee-pi/init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -755,6 +756,58 @@ func TestRunInitEnv_AllFallbacksFail(t *testing.T) {
 	err := runInitEnv(context.Background(), &mockEnvRenderer{}, uidResolver, &mockGitIdentity{}, t.TempDir(), mockConfirmFn(false, nil))
 	if err == nil {
 		t.Fatal("expected error when all UID fallbacks fail")
+	}
+}
+
+// ──────────────────────────────────────────────
+// Success message test
+// ──────────────────────────────────────────────
+
+func TestInit_SuccessMessage(t *testing.T) {
+	// Capture stderr to verify the success message
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+
+	// Restore after test
+	defer func() {
+		w.Close()
+		os.Stderr = oldStderr
+	}()
+
+	mockDocker := &mockDockerChecker{
+		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
+	}
+	mockCfg := &mockRepository{}
+	_, _, _, ext, env, probe, uid, gitID := defaultMocks()
+
+	err = runInit(context.Background(), mockDocker, mockCfg, "sk-abc123", false, true, "", t.TempDir(),
+		nil, nil, nil, ext, env, probe, uid, gitID, mockConfirmFn(true, nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	_, err = buf.ReadFrom(r)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	output := buf.String()
+
+	if strings.Contains(output, "cheasee-pi start") {
+		t.Error("success message must NOT reference 'cheasee-pi start'")
+	}
+	if !strings.Contains(output, "docker compose -f docker/docker-compose.yml up -d --build") {
+		t.Error("success message must contain the docker compose command")
+	}
+	if !strings.Contains(output, "✅ Init complete") {
+		t.Error("success message must contain the checkmark and 'Init complete'")
 	}
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -164,7 +164,8 @@ cheasee-pi init
 After completion, you'll see:
 
 ```
-✅ Init complete! Next step: run 'cheasee-pi start'
+✅ Init complete! Next step:
+   docker compose -f docker/docker-compose.yml up -d --build
 ```
 
 > **No GitHub?** Use `cheasee-pi init --no-github` to skip the GitHub OAuth and fork
@@ -173,18 +174,12 @@ After completion, you'll see:
 ### Step 6: Start the container
 
 ```bash
-cheasee-pi start
+docker compose -f docker/docker-compose.yml up -d --build
 ```
 
 This runs `docker compose up` with the configuration extracted in Step 5,
 building the OCI image (~2 min first time) and starting the container in
 detached mode.
-
-Alternatively, run docker compose directly:
-
-```bash
-docker compose -f docker/docker-compose.yml up -d --build
-```
 
 ### Step 7: Enter the container
 
@@ -437,7 +432,7 @@ Open the workspace: `zed .` from the `cheasee-pi` root.
 
 ## What happens under the hood
 
-`cheasee-pi start` (or the legacy `./cheasee-pi.sh`) runs `docker compose up` with:
+The `docker compose -f docker/docker-compose.yml up -d --build` command (or the legacy `./cheasee-pi.sh`) runs `docker compose up` with:
 
 - Image built from `docker/Dockerfile` (Debian 12-slim, Node.js 22, Python 3, ripgrep, ast-grep, pi, gosu)
 - Workspace root (`../` relative to `main/`) bind-mounted to `/workspaces` inside the container — your worktree at `/workspaces/main`
@@ -483,7 +478,7 @@ Rebuild the image without cache:
 
 ```bash
 docker compose -f docker/docker-compose.yml build --no-cache
-cheasee-pi start
+docker compose -f docker/docker-compose.yml up -d --build
 ```
 
 Or for the legacy path:
@@ -495,7 +490,7 @@ docker compose -f docker/docker-compose.yml build --no-cache
 
 ### Permission errors on bind-mounted files
 
-UID/GID mapping is automatic via `cheasee-pi.sh` or `cheasee-pi start`. If you need to run manually:
+UID/GID mapping is automatic via `cheasee-pi.sh` or the Docker Compose command. If you need to run manually:
 
 ```bash
 HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f docker/docker-compose.yml up
@@ -535,7 +530,7 @@ After installing, rebuild font cache and restart the Pi session:
 ```bash
 sudo fc-cache -fv
 # Exit pi (/exit), then restart:
-cheasee-pi start
+docker compose -f docker/docker-compose.yml up -d
 # Or legacy:
 ./cheasee-pi.sh
 ```
@@ -566,9 +561,9 @@ the font name to match the Nerd Font you installed.
 **Rebuild the container after any Dockerfile change:**
 
 ```bash
-cheasee-pi start --rebuild
+docker compose -f docker/docker-compose.yml up -d --build
 # Or legacy:
-./cheasee-pi.sh --rebuild
+./cheasee-pi.sh
 ```
 
 ---

--- a/test/docs-installation.test.mts
+++ b/test/docs-installation.test.mts
@@ -128,13 +128,23 @@ describe("docs/installation.md", () => {
 			);
 		});
 
-		it("Go CLI path mentions cheasee-pi start", () => {
+		it("Go CLI path does NOT mention cheasee-pi start", () => {
 			const content = readDoc();
 			const goSection = sectionContent(content, "Go\\s+CLI\\s+Path", "Legacy\\s+[Bb]ash\\s+Path");
 			assert.ok(goSection, "Go CLI Path section content not found");
 			assert.ok(
-				goSection.includes("cheasee-pi start"),
-				"Go CLI path missing 'cheasee-pi start'"
+				!goSection.includes("cheasee-pi start"),
+				"Go CLI path must NOT mention 'cheasee-pi start'"
+			);
+		});
+
+		it("Go CLI path Step 6 contains docker compose up --build", () => {
+			const content = readDoc();
+			const goSection = sectionContent(content, "Go\\s+CLI\\s+Path", "Legacy\\s+[Bb]ash\\s+Path");
+			assert.ok(goSection, "Go CLI Path section content not found");
+			assert.ok(
+				goSection.includes("docker compose -f docker/docker-compose.yml up -d --build"),
+				"Go CLI path missing docker compose command"
 			);
 		});
 	});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1243

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 20s | 145.8K | 20 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 34s | 18.6K | 11 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 30s | 36.1K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 48s | 54.4K | 31 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 35s | 47.7K | 30 | minimax-m3 |

**Total:** 5 agents · 8m 47s · 302.6K tokens · 107 tool calls · 6 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1243
Closes #1243