### PR TITLE
feat(#1249): [Bug] .goreleaser.yml missing windows build — epic #1202 specifies linux/mac/windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -18,6 +19,9 @@ builds:
 archives:
   - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
     formats: ["tar.gz"]
+    format_overrides:
+      - goos: windows
+        formats: ["zip"]
     files:
       - README.md
       - LICENSE

--- a/cmd/cheasee-pi/installation_doc_test.go
+++ b/cmd/cheasee-pi/installation_doc_test.go
@@ -42,8 +42,9 @@ func TestInstallationDoc_NoIgnoreMissing(t *testing.T) {
 	}
 }
 
-// TestInstallationDoc_DownloadURLPattern verifies the curl URL pattern matches
-// GoReleaser default archive naming: cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz.
+// TestInstallationDoc_DownloadURLPattern verifies the doc contains a download
+// URL pattern matching GoReleaser archive naming for any supported platform.
+// linux/darwin use .tar.gz, windows uses .zip.
 func TestInstallationDoc_DownloadURLPattern(t *testing.T) {
 	data, err := os.ReadFile(docPath())
 	if err != nil {
@@ -51,8 +52,35 @@ func TestInstallationDoc_DownloadURLPattern(t *testing.T) {
 	}
 	content := string(data)
 
-	if !strings.Contains(content, "cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz") {
-		t.Error("curl URL must use GoReleaser default naming: cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz")
+	if !strings.Contains(content, ".tar.gz") && !strings.Contains(content, ".zip") {
+		t.Error("doc must reference .tar.gz (linux/mac) or .zip (windows) archive files")
+	}
+	hasTarball := strings.Contains(content, "cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz")
+	hasZip := strings.Contains(content, "cheasee-pi_${VERSION}_${OS}_${ARCH}.zip") ||
+		strings.Contains(content, "cheasee-pi_${VERSION}_windows_${ARCH}.zip") ||
+		strings.Contains(content, "_windows_${ARCH}.zip")
+	if !hasTarball && !hasZip {
+		t.Error("doc curl URL must use GoReleaser naming pattern: cheasee-pi_${VERSION}_${OS}_${ARCH}.(tar.gz|zip)")
+	}
+}
+
+// TestInstallationDoc_WindowsDownloadPath verifies the doc includes a
+// Windows-specific download path (PowerShell snippet, .exe mention, or
+// _windows_ archive URL reference).
+func TestInstallationDoc_WindowsDownloadPath(t *testing.T) {
+	data, err := os.ReadFile(docPath())
+	if err != nil {
+		t.Fatalf("reading docs/installation.md: %v", err)
+	}
+	content := string(data)
+
+	// Check for at least one Windows-specific signal
+	hasWindowsSignal := strings.Contains(content, "PowerShell") ||
+		strings.Contains(content, ".exe") ||
+		strings.Contains(content, "_windows_") ||
+		strings.Contains(content, "Windows")
+	if !hasWindowsSignal {
+		t.Error("doc must reference Windows download path (PowerShell, .exe, or _windows_ archive)")
 	}
 }
 

--- a/cmd/cheasee-pi/release_config_test.go
+++ b/cmd/cheasee-pi/release_config_test.go
@@ -39,7 +39,7 @@ func TestGoReleaserConfig_Version2(t *testing.T) {
 	}
 }
 
-func TestGoReleaserConfig_GoosContainsLinuxAndDarwin(t *testing.T) {
+func TestGoReleaserConfig_GoosContainsAllTargets(t *testing.T) {
 	data, err := os.ReadFile(goreleaserPath())
 	if err != nil {
 		t.Fatalf("reading .goreleaser.yml: %v", err)
@@ -51,6 +51,9 @@ func TestGoReleaserConfig_GoosContainsLinuxAndDarwin(t *testing.T) {
 	}
 	if !strings.Contains(content, "darwin") {
 		t.Error(".goreleaser.yml goos must include darwin")
+	}
+	if !strings.Contains(content, "windows") {
+		t.Error(".goreleaser.yml goos must include windows")
 	}
 }
 
@@ -105,6 +108,21 @@ func TestGoReleaserConfig_CgoEnabled(t *testing.T) {
 
 	if !strings.Contains(content, "CGO_ENABLED=0") {
 		t.Error(".goreleaser.yml must have CGO_ENABLED=0 in builds[0].env")
+	}
+}
+
+func TestGoReleaserConfig_ArchiveFormatOverridesWindows(t *testing.T) {
+	data, err := os.ReadFile(goreleaserPath())
+	if err != nil {
+		t.Fatalf("reading .goreleaser.yml: %v", err)
+	}
+	content := string(data)
+
+	if !strings.Contains(content, "format_overrides") {
+		t.Error(".goreleaser.yml archives must include format_overrides for windows .zip")
+	}
+	if !strings.Contains(content, "windows") && !strings.Contains(content, "zip") {
+		t.Error(".goreleaser.yml format_overrides must specify goos: windows and formats: [zip]")
 	}
 }
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -64,8 +64,7 @@ don't render after installation.
 `cheasee-pi init` to set up your fork, clone, submodule, and Docker configuration in a
 single interactive command.
 
-**Supported platforms:** Linux (amd64, arm64) and macOS (amd64, arm64). Windows users
-should follow the [Legacy Bash Path](#legacy-bash-path) via WSL2.
+**Supported platforms:** Linux (amd64, arm64), macOS (amd64, arm64), and Windows (amd64, arm64).
 
 > **Size:** The Go binary is ~15–30 MB. Compare to a full repo clone at ~500 MB
 > (includes node_modules, test fixtures, images) — a 15–30× bandwidth saving.
@@ -75,7 +74,7 @@ should follow the [Legacy Bash Path](#legacy-bash-path) via WSL2.
 Visit the [GitHub Releases page](https://github.com/SchneiderDaniel/cheasee-pi/releases)
 and download the archive matching your OS and architecture.
 
-Or use the terminal to detect your platform and download automatically:
+**Linux / macOS** — use the terminal:
 
 ```bash
 # Detect OS and architecture
@@ -94,11 +93,22 @@ VERSION="1.0.0"
 curl -fLO "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v${VERSION}/cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz"
 ```
 
-Adjust `VERSION` to the latest release tag.
+**Windows (PowerShell)** — run in PowerShell:
+
+```powershell
+# Detect architecture
+$ARCH = if ((Get-CimInstance Win32_ComputerSystem).SystemType -match "ARM") { "arm64" } else { "amd64" }
+$VERSION = "1.0.0"
+Invoke-WebRequest -Uri "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v$VERSION/cheasee-pi_$VERSION`_windows_$ARCH.zip" -OutFile "cheasee-pi.zip"
+```
+
+Adjust `$VERSION` to the latest release tag.
 
 ### Step 2: Verify the checksum (optional but recommended)
 
 Download the checksums file and verify the archive:
+
+**Linux / macOS:**
 
 ```bash
 curl -fLO "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v${VERSION}/checksums.txt"
@@ -107,12 +117,44 @@ sha256sum -c checksums.txt 2>&1 | grep OK
 
 Expected output includes `cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz: OK`.
 
+**Windows (PowerShell):**
+
+```powershell
+$VERSION = "1.0.0"
+Invoke-WebRequest -Uri "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v$VERSION/checksums.txt" -OutFile "checksums.txt"
+# Verify the .zip checksum (PowerShell 5.1+)
+$expectedHash = (Get-Content checksums.txt | Select-String "cheasee-pi_$VERSION`_windows_amd64.zip" | ForEach-Object { $_ -split ' ' | Select-Object -First 1 })
+$actualHash = (Get-FileHash cheasee-pi.zip -Algorithm SHA256).Hash.ToLower()
+if ($expectedHash -eq $actualHash) { Write-Host "OK" } else { Write-Host "CHECKSUM MISMATCH" }
+```
+
 ### Step 3: Extract and install
+
+**Linux / macOS:**
 
 ```bash
 tar -xzf "cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz"
 chmod +x cheasee-pi
 sudo mv cheasee-pi /usr/local/bin/
+```
+
+**Windows (PowerShell):**
+
+```powershell
+# Extract the downloaded archive
+tar -xf cheasee-pi.zip
+# Place in a directory on your PATH (e.g., C:\cheasee-pi)
+Move-Item cheasee-pi.exe C:\cheasee-pi\
+# Add to PATH for the current session
+$env:Path += ";C:\cheasee-pi"
+# To make permanent, add to your PowerShell profile:
+# [Environment]::SetEnvironmentVariable("Path", [Environment]::GetEnvironmentVariable("Path", "User") + ";C:\cheasee-pi", "User")
+```
+
+Verify the binary works:
+
+```powershell
+cheasee-pi version
 ```
 
 > **macOS only:** Gatekeeper may block the unsigned binary. If you see

--- a/test/goreleaser-config.test.mts
+++ b/test/goreleaser-config.test.mts
@@ -17,6 +17,11 @@ import { load } from "js-yaml";
 
 const CONFIG_PATH = resolve(import.meta.dirname, "..", ".goreleaser.yml");
 
+interface FormatOverride {
+	goos: string;
+	formats: string[];
+}
+
 interface GoReleaserConfig {
 	version: number;
 	before?: { hooks: string[] };
@@ -26,8 +31,14 @@ interface GoReleaserConfig {
 		goos: string[];
 		goarch: string[];
 	}>;
+	archives?: Array<{
+		name_template: string;
+		formats: string[];
+		format_overrides?: FormatOverride[];
+		files: string[];
+	}>;
 	checksum?: { name_template: string };
-	release?: { github: { owner: string; repo: string } };
+	release?: { github: { owner: string; name: string } };
 }
 
 function parseConfig(): GoReleaserConfig {
@@ -55,10 +66,11 @@ describe(".goreleaser.yml", () => {
 			assert.strictEqual(config.builds[0].main, "./cmd/cheasee-pi");
 		});
 
-		it("builds[0].goos contains linux and darwin", () => {
+		it("builds[0].goos contains all target OSes", () => {
 			const config = parseConfig();
 			assert.ok(config.builds[0].goos.includes("linux"), "missing linux in goos");
 			assert.ok(config.builds[0].goos.includes("darwin"), "missing darwin in goos");
+			assert.ok(config.builds[0].goos.includes("windows"), "missing windows in goos");
 		});
 
 		it("builds[0].goarch contains amd64 and arm64", () => {
@@ -73,7 +85,20 @@ describe(".goreleaser.yml", () => {
 		});
 	});
 
-	describe("Phase 3: Checksum configuration", () => {
+	describe("Phase 3: Archive configuration", () => {
+		it("archives[0].format_overrides includes windows with zip format", () => {
+			const config = parseConfig();
+			assert.ok(config.archives, "archives section missing");
+			assert.ok(config.archives.length > 0, "no archives defined");
+			const overrides = config.archives[0].format_overrides;
+			assert.ok(overrides, "format_overrides missing in archives[0]");
+			const winOverride = overrides.find((o) => o.goos === "windows");
+			assert.ok(winOverride, "missing format_override for windows");
+			assert.ok(winOverride.formats.includes("zip"), "windows format_override must include zip");
+		});
+	});
+
+	describe("Phase 4: Checksum configuration", () => {
 		it("checksum name_template is checksums.txt", () => {
 			const config = parseConfig();
 			assert.ok(config.checksum, "checksum section missing");
@@ -81,7 +106,7 @@ describe(".goreleaser.yml", () => {
 		});
 	});
 
-	describe("Phase 4: Release target", () => {
+	describe("Phase 5: Release target", () => {
 		it("release.github.owner is SchneiderDaniel", () => {
 			const config = parseConfig();
 			assert.ok(config.release, "release section missing");
@@ -89,9 +114,9 @@ describe(".goreleaser.yml", () => {
 			assert.strictEqual(config.release.github.owner, "SchneiderDaniel");
 		});
 
-		it("release.github.repo is cheasee-pi", () => {
+		it("release.github.name is cheasee-pi", () => {
 			const config = parseConfig();
-			assert.strictEqual(config.release.github.repo, "cheasee-pi");
+			assert.strictEqual(config.release.github.name, "cheasee-pi");
 		});
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1249

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 52s | 41.9K | 39 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 59s | 22.2K | 19 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 0s | 29.7K | 23 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 40s | 40.5K | 30 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 37s | 62.3K | 43 | minimax-m3 |

**Total:** 5 agents · 10m 8s · 196.6K tokens · 154 tool calls · 15 failed (10%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1249
Closes #1249