### PR TITLE
feat(#1248): [Bug] Install/README quick-start buries run-pi.sh, forces multiple individual docker commands despite simplicity goal

### DIFF
--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -14,9 +14,9 @@ import (
 
 // nextStepHint is the post-init instruction printed after a successful init run.
 // It is a constant so both the CLI and documentation stay in sync.
-// If the compose filename or flag shape changes, update both init.go and
+// If the script path changes, update both init.go and
 // docs/installation.md in lockstep.
-const nextStepHint = "docker compose -f docker/docker-compose.yml up -d --build"
+const nextStepHint = "bash docker/run-pi.sh"
 
 var (
 	initAPIKey        string

--- a/cmd/cheasee-pi/init_test.go
+++ b/cmd/cheasee-pi/init_test.go
@@ -842,8 +842,8 @@ func TestInit_SuccessMessage(t *testing.T) {
 	if strings.Contains(output, "cheasee-pi start") {
 		t.Error("success message must NOT reference 'cheasee-pi start'")
 	}
-	if !strings.Contains(output, "docker compose -f docker/docker-compose.yml up -d --build") {
-		t.Error("success message must contain the docker compose command")
+	if !strings.Contains(output, "bash docker/run-pi.sh") {
+		t.Error("success message must contain the convenience script command")
 	}
 	if !strings.Contains(output, "✅ Init complete") {
 		t.Error("success message must contain the checkmark and 'Init complete'")

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,12 +44,28 @@ All components run locally. No code leaves your machine (except LLM API calls to
 see the full [Installation guide](installation.md) for step-by-step setup
 (both Go CLI and legacy bash paths).
 
-TL;DR — native Docker workflow (works with either path once set up):
+TL;DR — one-command convenience script (works with either path once set up):
 
 ```bash
-# Clone the repo (legacy path) or cd into your init-created workspace (Go CLI path)
+# cd into your init-created workspace (Go CLI path) or cloned repo (legacy path)
 cd cheasee-pi
 
+# Start container, inject API keys, and run pi — all in one command
+bash docker/run-pi.sh
+```
+
+`bash docker/run-pi.sh` starts the container if needed, injects API keys from
+your saved `auth.json` or environment variables, and opens the pi TUI.
+When you're done, `bash docker/stop-pi.sh` stops the container cleanly.
+
+First run builds the Docker image (~2 min). Set your API key inside the container
+when pi prompts you.
+
+### Advanced — native Docker workflow
+
+If you need to manage the container directly (alternative to the convenience script):
+
+```bash
 # Build image and start container
 docker compose -f docker/docker-compose.yml up -d --build
 
@@ -60,8 +76,7 @@ docker exec -it --user agentuser -w /workspaces/main cheasee-pi pi
 docker compose -f docker/docker-compose.yml down
 ```
 
-First run builds the Docker image (~2 min). Set your API key inside the container
-when pi prompts you, or pass it via `-e`:
+Pass API keys from your host environment with `-e`:
 
 ```bash
 docker exec -it -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY \

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -165,30 +165,42 @@ After completion, you'll see:
 
 ```
 ✅ Init complete! Next step:
-   docker compose -f docker/docker-compose.yml up -d --build
+   bash docker/run-pi.sh
 ```
 
 > **No GitHub?** Use `cheasee-pi init --no-github` to skip the GitHub OAuth and fork
 > steps. You'll need to provide your API key manually.
 
-### Step 6: Start the container
+### Step 6: Run pi with the convenience script
 
 ```bash
+bash docker/run-pi.sh
+```
+
+This single command starts the container if needed, injects API keys from your
+saved `auth.json` or environment variables, and opens the pi TUI. First run
+builds the Docker image (~2 min).
+
+When you're done, stop the container with:
+
+```bash
+bash docker/stop-pi.sh
+```
+
+#### Advanced — native Docker workflow
+
+If you need to manage the container directly (alternative to the convenience script):
+
+```bash
+# Build image and start container
 docker compose -f docker/docker-compose.yml up -d --build
-```
 
-This runs `docker compose up` with the configuration extracted in Step 5,
-building the OCI image (~2 min first time) and starting the container in
-detached mode.
-
-### Step 7: Enter the container
-
-```bash
+# Run pi inside the container
 docker exec -it --user agentuser -w /workspaces/main cheasee-pi pi
-```
 
-On first run, pi will prompt you to configure your API key. Follow the
-interactive setup.
+# Stop and remove container when done
+docker compose -f docker/docker-compose.yml down
+```
 
 To pass API keys from your host environment:
 
@@ -199,7 +211,7 @@ docker exec -it \
   --user agentuser -w /workspaces/main cheasee-pi pi
 ```
 
-### Step 8: Configure repository settings
+### Step 7: Configure repository settings
 
 After forking, update `.pi/settings.json` so the pipeline targets your fork:
 

--- a/test/docs-installation.test.mts
+++ b/test/docs-installation.test.mts
@@ -138,13 +138,23 @@ describe("docs/installation.md", () => {
 			);
 		});
 
-		it("Go CLI path Step 6 contains docker compose up --build", () => {
+		it("Go CLI path references docker/run-pi.sh", () => {
+			const content = readDoc();
+			const goSection = sectionContent(content, "Go\\s+CLI\\s+Path", "Legacy\\s+[Bb]ash\\s+Path");
+			assert.ok(goSection, "Go CLI Path section content not found");
+			assert.ok(
+				goSection.includes("run-pi.sh"),
+				"Go CLI path must mention run-pi.sh"
+			);
+		});
+
+		it("Go CLI path still contains docker compose up --build in Advanced subsection", () => {
 			const content = readDoc();
 			const goSection = sectionContent(content, "Go\\s+CLI\\s+Path", "Legacy\\s+[Bb]ash\\s+Path");
 			assert.ok(goSection, "Go CLI Path section content not found");
 			assert.ok(
 				goSection.includes("docker compose -f docker/docker-compose.yml up -d --build"),
-				"Go CLI path missing docker compose command"
+				"Go CLI path missing docker compose command in Advanced subsection"
 			);
 		});
 	});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1248

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 26s | 77.5K | 49 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 29s | 32.7K | 25 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 25s | 31.2K | 17 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 20s | 71.7K | 25 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 46s | 68.5K | 68 | minimax-m3 |

**Total:** 5 agents · 12m 26s · 281.6K tokens · 184 tool calls · 9 failed (5%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1248
Closes #1248