### PR TITLE
feat(#1261): [Bug] cmd/cheasee-pi test package does not compile on main — stray braces in init_test.go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
+      - name: Run tests
+        run: go test ./cmd/cheasee-pi/...
       - name: Build smoke test
         run: go build ./cmd/cheasee-pi/
       - name: Validate GoReleaser config

--- a/cmd/cheasee-pi/init_test.go
+++ b/cmd/cheasee-pi/init_test.go
@@ -1118,8 +1118,6 @@ func TestAuthPerProvider_MarshalOmitGitHubTokenWhenEmpty(t *testing.T) {
 		t.Error("expected openai provider key in output")
 	}
 }
-	}
-}
 
 // ──────────────────────────────────────────────
 // Legacy/backward compat tests


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1261

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 55s | 21.3K | 19 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 28s | 9.7K | 5 | minimax-m3 |
| test-designer | ✓ SUCCESS | 34s | 11.1K | 9 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 45s | 15.4K | 17 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 6s | 35.8K | 18 | minimax-m3 |

**Total:** 5 agents · 4m 46s · 93.2K tokens · 68 tool calls · 8 failed (12%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1261
Closes #1261