### PR TITLE
feat(#1296): Bug: agent-harness — batchId never set, batch-aware read cache logic is dead code

### DIFF
--- a/.pi/extensions/agent-harness/agent-harness.ts
+++ b/.pi/extensions/agent-harness/agent-harness.ts
@@ -222,7 +222,7 @@ export class AgentHarness {
 					const offset = (args.offset ?? 0) as number;
 					const limit = (args.limit ?? "") as number;
 					const cacheKey = `${path}|${offset}|${limit}`;
-					const cached = this.state.readCache.get(cacheKey, sessionTurn, this.state.batchId);
+					const cached = this.state.readCache.get(cacheKey, sessionTurn);
 					if (cached) {
 						// Same-turn → pass through (let re-read happen in same turn)
 						if (cached.turn === sessionTurn) {
@@ -237,7 +237,7 @@ export class AgentHarness {
 						}
 					} else {
 						// Store existence marker to track that this path+offset+limit was recently read
-						this.state.readCache.set(cacheKey, sessionTurn, this.state.batchId);
+						this.state.readCache.set(cacheKey, sessionTurn);
 					}
 				}
 			}

--- a/.pi/extensions/agent-harness/lib/harness-state.test.ts
+++ b/.pi/extensions/agent-harness/lib/harness-state.test.ts
@@ -57,10 +57,6 @@ describe("HarnessState", () => {
 		assert.equal(state.toolCallIndex, 5); // not affected
 	});
 
-	it("batchId is undefined by default", () => {
-		const state = createHarnessState();
-		assert.equal(state.batchId, undefined);
-	});
 });
 
 // ── CACHE_TTL_TURNS ──

--- a/.pi/extensions/agent-harness/lib/harness-state.ts
+++ b/.pi/extensions/agent-harness/lib/harness-state.ts
@@ -17,8 +17,6 @@
 export interface CacheEntry {
 	turn: number;
 	timestamp: number;
-	/** Batch ID for parallel call grouping (optional). */
-	batchId?: number;
 }
 
 export interface ErrorEntry {
@@ -36,9 +34,9 @@ export interface ConsecutiveInfo {
 
 export interface ReadCache {
 	/** Get cached entry. Returns null on miss or TTL expiry. */
-	get(key: string, currentTurn: number, currentBatchId?: number): CacheEntry | null;
+	get(key: string, currentTurn: number): CacheEntry | null;
 	/** Set cached entry with current turn and timestamp. */
-	set(key: string, turn: number, batchId?: number): void;
+	set(key: string, turn: number): void;
 	/** Clear all cache entries. */
 	clear(): void;
 }
@@ -102,12 +100,6 @@ export interface HarnessState {
 	 * Used for cascade detection (sinceTurn tracking).
 	 */
 	sessionTurn: number;
-	/**
-	 * Batch ID for parallel call detection.
-	 * Set by session manager before dispatching parallel calls.
-	 * When undefined, falls back to toolCallIndex (backward compat).
-	 */
-	batchId?: number;
 }
 
 // ── Constants ──
@@ -126,7 +118,7 @@ export const CACHE_TTL_MS = 30_000;
  * Each agent session gets its own state via this factory.
  */
 export function createHarnessState(): HarnessState {
-	// ── Read Cache (TimedMap with dual TTL + batch awareness) ──
+	// ── Read Cache (TimedMap with dual TTL) ──
 
 	const cacheMap = new TimedMap<string, CacheEntry>({
 		ttlTurns: CACHE_TTL_TURNS,
@@ -134,27 +126,16 @@ export function createHarnessState(): HarnessState {
 	});
 
 	const readCache: ReadCache = {
-		get(key: string, currentTurn: number, currentBatchId?: number): CacheEntry | null {
-			// Batch-aware bypass: if both entry and current call share the same
-			// batchId, the entry is valid regardless of turn diff (parallel calls)
-			if (currentBatchId !== undefined) {
-				const entry = cacheMap.peek(key);
-				if (entry && entry.batchId !== undefined && entry.batchId === currentBatchId) {
-					return entry;
-				}
-			}
-
-			// Standard TTL check via TimedMap
+		get(key: string, currentTurn: number): CacheEntry | null {
 			return cacheMap.get(key, currentTurn);
 		},
 
-		set(key: string, turn: number, batchId?: number): void {
+		set(key: string, turn: number): void {
 			cacheMap.set(
 				key,
 				{
 					turn,
 					timestamp: Date.now(),
-					batchId,
 				},
 				turn,
 			);


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1296

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 22s | 42.6K | 30 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 40s | 20.4K | 9 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 10s | 28.2K | 24 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 35s | 42.9K | 23 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 14s | 41.4K | 21 | minimax-m3 |

**Total:** 5 agents · 7m 1s · 175.6K tokens · 107 tool calls · 3 failed (3%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1296
Closes #1296