### PR TITLE
feat(#1299): Dead Code: lsp-auditor - setLspRuntime/resetLspRuntime only called from tests

### DIFF
--- a/.pi/extensions/lsp-auditor/lsp-client.ts
+++ b/.pi/extensions/lsp-auditor/lsp-client.ts
@@ -44,6 +44,7 @@ let currentRuntime: LspRuntime | undefined;
  * Override the default runtime with a custom LspRuntime.
  * Used by tests to inject canned implementations without module mocking.
  *
+ * @internal - Test injection seam. Only call from test files.
  * @param runtime - LspRuntime to use
  * @throws TypeError if runtime is undefined
  */
@@ -57,6 +58,8 @@ export function setLspRuntime(runtime: LspRuntime): void {
 /**
  * Reset the injected runtime to use the default production implementation.
  * Must be called in afterEach to prevent cross-test bleed.
+ *
+ * @internal - Test injection seam. Only call from test files.
  */
 export function resetLspRuntime(): void {
 	currentRuntime = undefined;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
 			],
 			".pi/extensions/format-on-save/index.ts": [
 				"default"
+			],
+			".pi/extensions/lsp-auditor/lsp-client.ts": [
+				"exports"
 			]
 		},
 		"ignoreDependencies": [


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1299

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 23s | 39.8K | 27 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 50s | 23.0K | 14 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 3s | 21.9K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 24s | 26.8K | 40 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 7m 53s | 49.2K | 43 | minimax-m3 |

**Total:** 5 agents · 17m 32s · 160.7K tokens · 138 tool calls · 8 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1299
Closes #1299