### PR TITLE
feat(#1301): Bug: lsp-auditor — buildServerMappings lacks input validation, crashes on malformed config

### DIFF
--- a/.pi/extensions/lsp-auditor/server-mappings.ts
+++ b/.pi/extensions/lsp-auditor/server-mappings.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ServerMapping } from "./types.ts";
+import type { LspAuditorSettings } from "./settings.ts";
 
 // ─── Defaults ────────────────────────────────────────────────────────
 
@@ -35,39 +36,26 @@ export const DEFAULT_SERVER_MAPPINGS: ServerMapping[] = [
 /**
  * Build the final server mapping list from user settings merged with defaults.
  * User config overrides/extends defaults.
+ *
+ * The input is already runtime-validated by readSettings() against the
+ * typebox schema — no ad-hoc typeof/Array.isArray guards needed here.
+ * Schema guarantees: extensions (string[], minItems 1), command (string, minLength 1),
+ * args (string[] | undefined), severityThreshold (enum value | undefined).
  */
-export function buildServerMappings(configRaw: unknown): ServerMapping[] {
-	if (!configRaw || typeof configRaw !== "object") return [...DEFAULT_SERVER_MAPPINGS];
-
-	const config = configRaw as {
-		servers?: Array<{
-			extensions: string[];
-			command: string;
-			args?: string[];
-			severityThreshold?: string;
-		}>;
-	};
-	if (!config.servers || !Array.isArray(config.servers) || config.servers.length === 0)
-		return [...DEFAULT_SERVER_MAPPINGS];
+export function buildServerMappings(config: LspAuditorSettings | undefined): ServerMapping[] {
+	if (!config?.servers?.length) return [...DEFAULT_SERVER_MAPPINGS];
 
 	const merged = [...DEFAULT_SERVER_MAPPINGS];
 
 	for (const srv of config.servers) {
-		if (!srv.extensions || !Array.isArray(srv.extensions) || srv.extensions.length === 0) continue;
-		if (!srv.command || typeof srv.command !== "string" || !srv.command.trim()) continue;
-
 		const exts = [...new Set(srv.extensions.map((e) => e.toLowerCase()))];
 
-		let threshold: "error" | "warning" | "info" = "warning";
-		if (srv.severityThreshold) {
-			const t = srv.severityThreshold.toLowerCase();
-			if (t === "error" || t === "warning" || t === "info") threshold = t;
-		}
+		const threshold: "error" | "warning" | "info" = srv.severityThreshold ?? "warning";
 
 		const newMapping: ServerMapping = {
 			extensions: exts,
 			command: srv.command.trim(),
-			args: srv.args || [],
+			args: srv.args ?? [],
 			severityThreshold: threshold,
 		};
 

--- a/.pi/extensions/lsp-auditor/settings.ts
+++ b/.pi/extensions/lsp-auditor/settings.ts
@@ -17,7 +17,7 @@ import { Value } from "typebox/value";
 // ─── Schema ──────────────────────────────────────────────────────────
 
 /** Schema for a single LSP server entry. Enforces types at runtime. */
-const ServerEntrySchema = Type.Object({
+export const ServerEntrySchema = Type.Object({
 	extensions: Type.Array(Type.String(), { minItems: 1 }),
 	command: Type.String({ minLength: 1 }),
 	args: Type.Optional(Type.Array(Type.String())),

--- a/.pi/extensions/lsp-auditor/settings.ts
+++ b/.pi/extensions/lsp-auditor/settings.ts
@@ -3,21 +3,38 @@
  *
  * Sync I/O (readFileSync/existsSync) acceptable — only called once per
  * audit start, not on hot path.
+ *
+ * Uses typebox schema for runtime validation at the config boundary.
+ * This is the outermost adapter: depends on node:fs and typebox.
+ * Returns validated domain shapes to all inner consumers.
  */
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { Type, type Static } from "typebox";
+import { Value } from "typebox/value";
+
+// ─── Schema ──────────────────────────────────────────────────────────
+
+/** Schema for a single LSP server entry. Enforces types at runtime. */
+const ServerEntrySchema = Type.Object({
+	extensions: Type.Array(Type.String(), { minItems: 1 }),
+	command: Type.String({ minLength: 1 }),
+	args: Type.Optional(Type.Array(Type.String())),
+	severityThreshold: Type.Optional(
+		Type.Union([Type.Literal("error"), Type.Literal("warning"), Type.Literal("info")]),
+	),
+});
+
+/** Schema for the full lspAuditor settings block. */
+const LspAuditorSettingsSchema = Type.Object({
+	servers: Type.Optional(Type.Array(ServerEntrySchema)),
+});
 
 // ─── Types ───────────────────────────────────────────────────────────
 
-export interface LspAuditorSettings {
-	servers?: Array<{
-		extensions: string[];
-		command: string;
-		args?: string[];
-		severityThreshold?: string;
-	}>;
-}
+/** Runtime-validated LSP auditor settings type, derived from schema. */
+export type LspAuditorSettings = Static<typeof LspAuditorSettingsSchema>;
 
 export interface PiSettings {
 	supervisor?: unknown;
@@ -29,12 +46,43 @@ export interface PiSettings {
 /**
  * Read and parse .pi/settings.json from the worktree.
  * Returns null if file doesn't exist or is unparseable.
+ *
+ * Validates the lspAuditor block at load time: malformed server entries
+ * are filtered out with console.warn, and structurally invalid lspAuditor
+ * values (non-object types) are dropped silently. Never throws for
+ * config shape issues — always returns a safe shape or null.
  */
 export function readSettings(worktreePath: string): PiSettings | null {
 	try {
 		const settingsPath = resolvePath(worktreePath, ".pi/settings.json");
 		if (!existsSync(settingsPath)) return null;
-		return JSON.parse(readFileSync(settingsPath, "utf-8"));
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const parsed: any = JSON.parse(readFileSync(settingsPath, "utf-8"));
+
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed) && "lspAuditor" in parsed) {
+			const la = parsed.lspAuditor;
+			if (la && typeof la === "object" && !Array.isArray(la)) {
+				if ("servers" in la && Array.isArray(la.servers)) {
+					const validServers: unknown[] = [];
+					for (const srv of la.servers) {
+						if (Value.Check(ServerEntrySchema, srv)) {
+							validServers.push(srv);
+						} else {
+							console.warn(
+								`[lsp-auditor] Dropped malformed server entry: ${JSON.stringify(srv)}`,
+							);
+						}
+					}
+					parsed.lspAuditor = { servers: validServers };
+				}
+				// If no "servers" key, keep lspAuditor as-is (empty object is valid per schema)
+			} else {
+				console.warn("[lsp-auditor] lspAuditor settings ignored: not a valid object");
+				delete parsed.lspAuditor;
+			}
+		}
+
+		return parsed as PiSettings;
 	} catch {
 		return null;
 	}

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor-settings.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor-settings.test.mts
@@ -10,10 +10,151 @@
 
 import assert from "node:assert";
 import { describe, it } from "node:test";
+import { Value } from "typebox/value";
 import { buildServerMappings } from "../server-mappings.ts";
+import type { LspAuditorSettings } from "../settings.ts";
+
+// Re-create schema references here for test isolation — avoids import of
+// non-exported schema objects while testing the same constraints.
+import { Type } from "typebox";
+
+const ServerEntrySchema = Type.Object({
+	extensions: Type.Array(Type.String(), { minItems: 1 }),
+	command: Type.String({ minLength: 1 }),
+	args: Type.Optional(Type.Array(Type.String())),
+	severityThreshold: Type.Optional(
+		Type.Union([Type.Literal("error"), Type.Literal("warning"), Type.Literal("info")]),
+	),
+});
 
 // ═══════════════════════════════════════════════════════════════════════
-// Tests
+// Phase 1: Schema validation tests
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("ServerEntrySchema — runtime validation", () => {
+	it("accepts valid server entry with all fields", () => {
+		assert.ok(
+			Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+				args: ["--stdio"],
+				severityThreshold: "warning",
+			}),
+		);
+	});
+
+	it("accepts entry with only required fields (extensions, command)", () => {
+		assert.ok(
+			Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+			}),
+		);
+	});
+
+	it("rejects non-string extension element (bug 1)", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts", 123],
+				command: "ts-ls",
+			}),
+		);
+	});
+
+	it("rejects non-string severityThreshold (bug 2)", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+				severityThreshold: 1,
+			}),
+		);
+	});
+
+	it("rejects non-array args (bug 3)", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+				args: "--stdio",
+			}),
+		);
+	});
+
+	it("rejects empty command", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "",
+			}),
+		);
+	});
+
+	it("rejects missing command", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+			}),
+		);
+	});
+
+	it("rejects missing extensions", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				command: "ts-ls",
+			}),
+		);
+	});
+
+	it("rejects empty extensions array (minItems: 1)", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [],
+				command: "ts-ls",
+			}),
+		);
+	});
+
+	it("rejects severityThreshold outside enum (e.g. 'CRITICAL')", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+				severityThreshold: "CRITICAL",
+			}),
+		);
+	});
+
+	it("rejects case-variant severityThreshold (e.g. 'Warning')", () => {
+		assert.ok(
+			!Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+				severityThreshold: "Warning",
+			}),
+		);
+	});
+
+	it("accepts entry with extra unknown fields", () => {
+		assert.ok(
+			Value.Check(ServerEntrySchema, {
+				extensions: [".ts"],
+				command: "ts-ls",
+				extraField: "ignored",
+			}),
+		);
+	});
+
+	it("Static type is assignable to expected shape (compile-time check)", () => {
+		// This is a compile-time assertion: if LspAuditorSettings has the right
+		// shape, this assignment works. If the schema drifts, this line fails.
+		const _check: LspAuditorSettings extends { servers?: Array<{ extensions: string[]; command: string }> } ? true : never = true;
+		assert.strictEqual(_check, true);
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 2: buildServerMappings integration
 // ═══════════════════════════════════════════════════════════════════════
 
 describe("buildServerMappings — config integration", () => {
@@ -46,18 +187,9 @@ describe("buildServerMappings — config integration", () => {
 		assert.ok(result.some((m) => m.extensions.includes(".kt")));
 	});
 
-	it("invalid severityThreshold → falls back to 'warning'", () => {
-		const config = {
-			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "CRITICAL" }],
-		};
-		const result = buildServerMappings(config);
-		const tsMapping = result.find((m) => m.extensions.includes(".ts"))!;
-		assert.strictEqual(tsMapping.severityThreshold, "warning");
-	});
-
 	it("valid severityThreshold 'error' honored", () => {
 		const config = {
-			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "error" }],
+			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "error" as const }],
 		};
 		const result = buildServerMappings(config);
 		const tsMapping = result.find((m) => m.extensions.includes(".ts"))!;
@@ -70,17 +202,8 @@ describe("buildServerMappings — config integration", () => {
 		assert.strictEqual(result.length, 4);
 	});
 
-	it("command string empty → entry skipped, defaults kept", () => {
-		const config = {
-			servers: [{ extensions: [".ts"], command: "" }],
-		};
-		const result = buildServerMappings(config);
-		const tsMapping = result.find((m) => m.extensions.includes(".ts"))!;
-		assert.strictEqual(tsMapping.command, "typescript-language-server");
-	});
-
-	it("malformed config (null) → defaults", () => {
-		const result = buildServerMappings(null);
+	it("undefined config → defaults", () => {
+		const result = buildServerMappings(undefined);
 		assert.strictEqual(result.length, 4);
 	});
 
@@ -106,18 +229,9 @@ describe("buildServerMappings — config integration", () => {
 		assert.ok(result.some((m) => m.command === "sourcekit-lsp"));
 	});
 
-	it("severityThreshold with mixed case → normalized", () => {
-		const config = {
-			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "Warning" }],
-		};
-		const result = buildServerMappings(config);
-		const tsMapping = result.find((m) => m.extensions.includes(".ts"))!;
-		assert.strictEqual(tsMapping.severityThreshold, "warning");
-	});
-
 	it("severityThreshold 'info' honored", () => {
 		const config = {
-			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "info" }],
+			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "info" as const }],
 		};
 		const result = buildServerMappings(config);
 		const tsMapping = result.find((m) => m.extensions.includes(".ts"))!;

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor-settings.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor-settings.test.mts
@@ -9,23 +9,14 @@
  */
 
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { before, after, describe, it } from "node:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { Value } from "typebox/value";
 import { buildServerMappings } from "../server-mappings.ts";
+import { readSettings, ServerEntrySchema } from "../settings.ts";
 import type { LspAuditorSettings } from "../settings.ts";
-
-// Re-create schema references here for test isolation — avoids import of
-// non-exported schema objects while testing the same constraints.
-import { Type } from "typebox";
-
-const ServerEntrySchema = Type.Object({
-	extensions: Type.Array(Type.String(), { minItems: 1 }),
-	command: Type.String({ minLength: 1 }),
-	args: Type.Optional(Type.Array(Type.String())),
-	severityThreshold: Type.Optional(
-		Type.Union([Type.Literal("error"), Type.Literal("warning"), Type.Literal("info")]),
-	),
-});
 
 // ═══════════════════════════════════════════════════════════════════════
 // Phase 1: Schema validation tests
@@ -236,5 +227,224 @@ describe("buildServerMappings — config integration", () => {
 		const result = buildServerMappings(config);
 		const tsMapping = result.find((m) => m.extensions.includes(".ts"))!;
 		assert.strictEqual(tsMapping.severityThreshold, "info");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 3: Adapter/integration tests (filesystem → readSettings → buildServerMappings)
+// ═══════════════════════════════════════════════════════════════════════
+
+function withTempSettings(
+	settings: Record<string, unknown>,
+	fn: (worktreePath: string) => void,
+): void {
+	const tmpDir = mkdtempSync(join(tmpdir(), "lsp-auditor-integration-"));
+	try {
+		const piDir = join(tmpDir, ".pi");
+		mkdirSync(piDir, { recursive: true });
+		writeFileSync(join(piDir, "settings.json"), JSON.stringify(settings));
+		fn(tmpDir);
+	} finally {
+		rmSync(tmpDir, { recursive: true, force: true });
+	}
+}
+
+describe("readSettings → buildServerMappings — filesystem integration", () => {
+	it("valid config round-trip", () => {
+		withTempSettings(
+			{
+				lspAuditor: {
+					servers: [
+						{ extensions: [".ts"], command: "custom-ts", args: ["--stdio"] },
+						{ extensions: [".kt"], command: "kotlin-ls" },
+					],
+				},
+			},
+			(worktree) => {
+				const settings = readSettings(worktree);
+				assert.ok(settings, "settings should not be null");
+				assert.ok(settings!.lspAuditor, "lspAuditor should be present");
+				assert.strictEqual(settings!.lspAuditor!.servers!.length, 2);
+
+				const mappings = buildServerMappings(settings!.lspAuditor);
+				assert.ok(mappings.some((m) => m.command === "custom-ts"));
+				assert.ok(mappings.some((m) => m.command === "kotlin-ls"));
+				// Defaults still present for non-overlapping extensions
+				assert.ok(mappings.some((m) => m.command === "pyright-langserver"));
+				assert.ok(mappings.some((m) => m.command === "rust-analyzer"));
+				assert.ok(mappings.some((m) => m.command === "gopls"));
+			},
+		);
+	});
+
+	it("bug 1: non-string extension element -> entry dropped, no crash", () => {
+		withTempSettings(
+			{
+				lspAuditor: {
+					servers: [
+						{ extensions: [".ts", 123], command: "bad-ts" },
+						{ extensions: [".py"], command: "custom-py", args: ["--stdio"] },
+					],
+				},
+			},
+			(worktree) => {
+				const settings = readSettings(worktree);
+				assert.ok(settings, "settings should not be null");
+				// Malformed entry filtered out, only valid one remains
+				assert.strictEqual(settings!.lspAuditor!.servers!.length, 1);
+				assert.strictEqual(settings!.lspAuditor!.servers![0]!.command, "custom-py");
+
+				// No crash when building mappings
+				const mappings = buildServerMappings(settings!.lspAuditor);
+				assert.ok(mappings.some((m) => m.command === "custom-py"));
+				assert.ok(mappings.some((m) => m.command === "typescript-language-server"));
+			},
+		);
+	});
+
+	it("bug 3: string args -> entry dropped, no crash, defaults apply", () => {
+		withTempSettings(
+			{
+				lspAuditor: {
+					servers: [
+						{ extensions: [".ts"], command: "ts-ls", args: "--stdio" },
+					],
+				},
+			},
+			(worktree) => {
+				const settings = readSettings(worktree);
+				assert.ok(settings, "settings should not be null");
+				// Malformed entry filtered out
+				assert.strictEqual(settings!.lspAuditor!.servers!.length, 0);
+
+				// No crash — defaults apply
+				const mappings = buildServerMappings(settings!.lspAuditor);
+				assert.strictEqual(mappings.length, 4);
+				const tsMapping = mappings.find((m) => m.extensions.includes(".ts"))!;
+				assert.strictEqual(tsMapping.command, "typescript-language-server");
+				assert.deepStrictEqual(tsMapping.args, ["--stdio"]);
+			},
+		);
+	});
+
+	it("all entries malformed -> lspAuditor undefined, defaults only", () => {
+		withTempSettings(
+			{
+				lspAuditor: {
+					servers: [
+						{ extensions: [".ts", 123], command: "bad-ts" },
+						{ extensions: [".py"], command: 42 },
+					],
+				},
+			},
+			(worktree) => {
+				const settings = readSettings(worktree);
+				assert.ok(settings, "settings should not be null");
+				// Both malformed -> empty servers array
+				assert.strictEqual(settings!.lspAuditor!.servers!.length, 0);
+
+				const mappings = buildServerMappings(settings!.lspAuditor);
+				assert.strictEqual(mappings.length, 4);
+			},
+		);
+	});
+
+	it("lspAuditor is non-object (array) -> undefined, defaults apply", () => {
+		withTempSettings(
+			{
+				lspAuditor: ["not", "an", "object"],
+			},
+			(worktree) => {
+				const settings = readSettings(worktree);
+				assert.ok(settings, "settings should not be null");
+				assert.strictEqual(settings!.lspAuditor, undefined);
+
+				const mappings = buildServerMappings(settings!.lspAuditor);
+				assert.strictEqual(mappings.length, 4);
+			},
+		);
+	});
+
+	describe("user-journey: console.warn emitted for dropped entries", () => {
+		let originalWarn: typeof console.warn;
+		let warnMessages: string[];
+
+		before(() => {
+			originalWarn = console.warn;
+		});
+
+		after(() => {
+			console.warn = originalWarn;
+		});
+
+		it("settings with non-string extension logs warning with entry content", () => {
+			warnMessages = [];
+			console.warn = (...args: unknown[]) => {
+				warnMessages.push(args.join(" "));
+			};
+
+			withTempSettings(
+				{
+					lspAuditor: {
+						servers: [
+							{ extensions: [".ts", 123], command: "ts-ls" },
+							{ extensions: [".py"], command: "pyright-langserver", args: ["--stdio"] },
+						],
+					},
+				},
+				(worktree) => {
+					const settings = readSettings(worktree);
+					assert.ok(settings, "settings should not be null");
+
+					// Verify warning was emitted with malformed entry content
+					assert.ok(
+						warnMessages.some((m) => m.includes("123") && m.includes("[lsp-auditor]")),
+						"console.warn should mention the malformed entry",
+					);
+					assert.ok(
+						warnMessages.some((m) => m.includes("Dropped malformed server entry")),
+						"console.warn should say 'Dropped malformed server entry'",
+					);
+
+					// Valid entry still processed
+					const mappings = buildServerMappings(settings!.lspAuditor);
+					assert.ok(mappings.some((m) => m.command === "pyright-langserver"));
+					assert.ok(mappings.some((m) => m.command === "typescript-language-server"));
+				},
+			);
+
+			console.warn = originalWarn;
+		});
+
+		it("settings with string args logs warning with entry content", () => {
+			warnMessages = [];
+			console.warn = (...args: unknown[]) => {
+				warnMessages.push(args.join(" "));
+			};
+
+			withTempSettings(
+				{
+					lspAuditor: {
+						servers: [
+							{ extensions: [".ts"], command: "ts-ls", args: "--stdio" },
+						],
+					},
+				},
+				(worktree) => {
+					readSettings(worktree);
+
+					assert.ok(
+						warnMessages.some((m) => m.includes("--stdio") && m.includes("[lsp-auditor]")),
+						"console.warn should mention the malformed args entry",
+					);
+					assert.ok(
+						warnMessages.some((m) => m.includes("Dropped malformed server entry")),
+						"console.warn should say 'Dropped malformed server entry'",
+					);
+				},
+			);
+
+			console.warn = originalWarn;
+		});
 	});
 });

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
@@ -294,25 +294,9 @@ describe("buildServerMappings", () => {
 		assert.strictEqual(ts!.severityThreshold, "error");
 	});
 
-	it("invalid severityThreshold → falls back to warning", () => {
-		const result = buildServerMappings({
-			servers: [{ extensions: [".ts"], command: "ts-ls", severityThreshold: "critical" }],
-		});
-		const ts = result.find((m) => m.extensions.includes(".ts"));
-		assert.strictEqual(ts!.severityThreshold, "warning");
-	});
-
 	it("empty servers → returns defaults", () => {
 		const result = buildServerMappings({ servers: [] });
 		assert.strictEqual(result.length, 4);
-	});
-
-	it("empty command → entry skipped", () => {
-		const result = buildServerMappings({
-			servers: [{ extensions: [".ts"], command: "" }],
-		});
-		const ts = result.find((m) => m.extensions.includes(".ts"));
-		assert.strictEqual(ts!.command, "typescript-language-server");
 	});
 
 	it("extensions deduplicated", () => {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1301

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 38s | 35.2K | 40 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 0s | 30.0K | 21 | minimax-m3 |
| test-designer | ✓ SUCCESS | 2m 2s | 38.1K | 24 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 6m 11s | 65.5K | 43 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 28s | 58.8K | 27 | minimax-m3 |
| developer | ✓ SUCCESS | 2m 7s | 56.2K | 18 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 51s | 51.9K | 28 | minimax-m3 |

**Total:** 7 agents · 18m 18s · 335.5K tokens · 201 tool calls · 8 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1301
Closes #1301