### PR TITLE
feat(#1283): Dead Code: agent-harness - shouldBlockRetry() only called from tests

### DIFF
--- a/.pi/extensions/agent-harness/agent-harness.ts
+++ b/.pi/extensions/agent-harness/agent-harness.ts
@@ -25,6 +25,7 @@ import {
 	buildRedirectMessage,
 	MULTI_VERB_TOOLS,
 	loadDefaultRules,
+	shouldBlockRetry,
 } from "./lib/harness-rules.ts";
 import type { ResolvedHarnessRules, ToolMeta } from "./lib/harness-rules.ts";
 
@@ -207,7 +208,7 @@ export class AgentHarness {
 		if (!event.isError) {
 			// ── 3. Error retry blocking ──
 			const errors = this.state.errorTracker.getLastErrors(toolName);
-			if (errors.length >= 2) {
+			if (shouldBlockRetry(errors.length)) {
 				const lastErrorTurn = errors[errors.length - 1]?.turn ?? 0;
 				result = {
 					block: true,


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1283

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 56s | 26.1K | 33 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 23s | 10.5K | 5 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 36s | 42.6K | 16 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 47s | 25.9K | 15 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 38s | 33.1K | 14 | minimax-m3 |

**Total:** 5 agents · 5m 20s · 138.1K tokens · 83 tool calls · 6 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1283
Closes #1283