### PR TITLE
feat(#1294): Bug: agent-harness — cat and echo in FILE_MODIFY_SIGNALS cause false-positive read cache invalidation

### DIFF
--- a/.pi/extensions/agent-harness/lib/bash-command.test.ts
+++ b/.pi/extensions/agent-harness/lib/bash-command.test.ts
@@ -79,7 +79,7 @@ describe("BashCommand.isFileModify", () => {
 	});
 
 	it("detects tee command", () => {
-		assert.equal(new BashCommand("echo 'x' | tee file.ts").isFileModify(), true);
+		assert.equal(new BashCommand("tee f.ts").isFileModify(), true);
 	});
 
 	it("detects mv command", () => {
@@ -109,15 +109,15 @@ describe("BashCommand.isFileModify", () => {
 	});
 
 	it("echo triggers isFileModify (characterization)", () => {
-		// echo alone triggers isFileModify because "echo" is in FILE_MODIFY_SIGNALS
-		assert.equal(new BashCommand("echo hi").isFileModify(), true);
+		// echo without redirect is stdout-only; redirect cases caught by > check
+		assert.equal(new BashCommand("echo hi").isFileModify(), false);
 		assert.equal(new BashCommand("echo hi > f.ts").isFileModify(), true);
 	});
 
 	it("cat triggers isFileModify (characterization)", () => {
-		// cat is in FILE_MODIFY_SIGNALS (used with redirect), so even plain cat returns true
+		// cat without redirect is read-only; redirect cases caught by > check
 		assert.equal(new BashCommand("cat > f.ts").isFileModify(), true);
-		assert.equal(new BashCommand("cat file.ts").isFileModify(), true);
+		assert.equal(new BashCommand("cat file.ts").isFileModify(), false);
 	});
 
 	it("tee triggers isFileModify (characterization)", () => {
@@ -142,6 +142,14 @@ describe("BashCommand.isFileModify", () => {
 
 	it("dd triggers isFileModify (characterization)", () => {
 		assert.equal(new BashCommand("dd if=/dev/zero of=f bs=1M count=1").isFileModify(), true);
+	});
+
+	it("bare cat does not flag isFileModify (regression)", () => {
+		assert.equal(new BashCommand("cat file.ts").isFileModify(), false);
+	});
+
+	it("bare echo does not flag isFileModify (regression)", () => {
+		assert.equal(new BashCommand("echo hello").isFileModify(), false);
 	});
 
 	it("does not flag read-only commands", () => {

--- a/.pi/extensions/agent-harness/lib/bash-command.ts
+++ b/.pi/extensions/agent-harness/lib/bash-command.ts
@@ -138,8 +138,6 @@ export class BashCommand {
 	 */
 	private static readonly FILE_MODIFY_SIGNALS: readonly string[] = Object.freeze([
 		"sed",
-		"echo",
-		"cat",
 		"tee",
 		"mv",
 		"cp",


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1294

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 49s | 76.1K | 33 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 47s | 25.2K | 15 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 3s | 29.8K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 0s | 31.3K | 14 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 4m 6s | 30.4K | 34 | minimax-m3 |

**Total:** 5 agents · 9m 45s · 192.8K tokens · 110 tool calls · 4 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1294
Closes #1294