### PR TITLE
feat(#1292): ICA: Duplicated port types across extensions

### DIFF
--- a/.pi/extensions/agent-harness/lib/harness-state.ts
+++ b/.pi/extensions/agent-harness/lib/harness-state.ts
@@ -14,7 +14,7 @@
 
 // ── Types ──
 
-export interface CacheEntry {
+export interface ReadCacheEntry {
 	turn: number;
 	timestamp: number;
 }
@@ -34,7 +34,7 @@ export interface ConsecutiveInfo {
 
 export interface ReadCache {
 	/** Get cached entry. Returns null on miss or TTL expiry. */
-	get(key: string, currentTurn: number): CacheEntry | null;
+	get(key: string, currentTurn: number): ReadCacheEntry | null;
 	/** Set cached entry with current turn and timestamp. */
 	set(key: string, turn: number): void;
 	/** Clear all cache entries. */
@@ -120,13 +120,13 @@ export const CACHE_TTL_MS = 30_000;
 export function createHarnessState(): HarnessState {
 	// ── Read Cache (TimedMap with dual TTL) ──
 
-	const cacheMap = new TimedMap<string, CacheEntry>({
+	const cacheMap = new TimedMap<string, ReadCacheEntry>({
 		ttlTurns: CACHE_TTL_TURNS,
 		ttlMs: CACHE_TTL_MS,
 	});
 
 	const readCache: ReadCache = {
-		get(key: string, currentTurn: number): CacheEntry | null {
+		get(key: string, currentTurn: number): ReadCacheEntry | null {
 			return cacheMap.get(key, currentTurn);
 		},
 

--- a/.pi/extensions/agent-harness/lib/timed-map.ts
+++ b/.pi/extensions/agent-harness/lib/timed-map.ts
@@ -11,7 +11,7 @@
  *
  * ```ts
  * // Turn-based TTL (6 turns)
- * const cache = new TimedMap<string, CacheEntry>({ ttlTurns: 6, ttlMs: 30_000 });
+ * const cache = new TimedMap<string, ReadCacheEntry>({ ttlTurns: 6, ttlMs: 30_000 });
  * cache.turn = currentTurn; // synchronize turn before get/set
  * cache.set("key", value);
  * cache.get("key");          // null if expired

--- a/.pi/extensions/check-extensions/ast-scanner.ts
+++ b/.pi/extensions/check-extensions/ast-scanner.ts
@@ -43,6 +43,7 @@ export interface ASTScanningResult {
 }
 
 /** Exec function type for ast-grep subprocess calls */
+// Diverges from lib/port-types.ExecFn: return adds killed: boolean for ast-grep signal detection
 export type ExecFn = (
 	command: string,
 	args: string[],

--- a/.pi/extensions/lib/ensureVenv.test.ts
+++ b/.pi/extensions/lib/ensureVenv.test.ts
@@ -23,7 +23,8 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { ensureVenv, EnsureVenvError } from "./ensureVenv.ts";
-import type { ExecFn, EnsureVenvConfig } from "./ensureVenv.ts";
+import type { ExecFn } from "./port-types.ts";
+import type { EnsureVenvConfig } from "./ensureVenv.ts";
 import lockfile from "proper-lockfile";
 
 /**

--- a/.pi/extensions/lib/ensureVenv.ts
+++ b/.pi/extensions/lib/ensureVenv.ts
@@ -23,28 +23,9 @@
 import { mkdirSync } from "node:fs";
 import { join } from "node:path";
 import lockfile from "proper-lockfile";
+import type { ExecFn, OnUpdateCallback } from "./port-types.ts";
 
 // ── Public Types ──
-
-export interface ExecFn {
-	(
-		cmd: string,
-		args: string[],
-		opts?: { timeout?: number; signal?: AbortSignal },
-	): Promise<{ code: number; stdout: string; stderr: string }>;
-}
-
-/**
- * Callback for structured progress updates.
- *
- * Callers must tolerate `text` starting with `'Lock compromised: …'` and
- * `details.warning === true` — these are non-fatal warnings emitted by the
- * `onCompromised` handler when proper-lockfile's lock update timer detects
- * staleness or filesystem error. See #1136 for rationale.
- */
-interface OnUpdateCallback {
-	(u: { content: Array<{ type: "text"; text: string }>; details: unknown }): void;
-}
 
 export interface EnsureVenvConfig {
 	/** Exec function (typically pi.exec). */
@@ -98,7 +79,7 @@ export class EnsureVenvError extends Error {
 
 // ── In-memory retry cache ──
 
-interface CacheEntry {
+interface RetryCacheEntry {
 	ready: boolean;
 	timestamp: number;
 	retries: number;
@@ -107,13 +88,13 @@ interface CacheEntry {
 const CACHE_TTL_MS = 30_000;
 const CACHE_MAX_RETRIES = 3;
 
-const cache = new Map<string, CacheEntry>();
+const cache = new Map<string, RetryCacheEntry>();
 
 function cacheKey(cwd: string, venvName: string): string {
 	return `${cwd}::${venvName}`;
 }
 
-function cacheGet(key: string): { entry: CacheEntry | undefined; shouldRetry: boolean } {
+function cacheGet(key: string): { entry: RetryCacheEntry | undefined; shouldRetry: boolean } {
 	const entry = cache.get(key);
 	if (!entry) return { entry: undefined, shouldRetry: false };
 	if (entry.ready) return { entry, shouldRetry: false };

--- a/.pi/extensions/lib/port-types.ts
+++ b/.pi/extensions/lib/port-types.ts
@@ -1,0 +1,39 @@
+/**
+ * port-types.ts — Canonical cross-extension port types.
+ *
+ * Single home for structural types shared by multiple extensions:
+ *  - ExecResult / ExecFn   (subprocess execution, unified 3-field return)
+ *  - OnUpdateCallback      (progress-report callback)
+ *
+ * Every extension that needs one of these shapes should import from here
+ * instead of defining a local copy.  The one exception is an extension
+ * whose type has deliberately diverged — keep the local copy and add
+ * a `// Diverges from lib/port-types.ExecFn: <reason>` comment so the
+ * next dedup attempt doesn't re-investigate.
+ *
+ * Layer: domain — zero pi dependencies.  Pure types only.
+ */
+
+/** 3-field subprocess result (code / stdout / stderr). */
+export type ExecResult = {
+	code: number;
+	stdout: string;
+	stderr: string;
+};
+
+/**
+ * Subprocess exec function (no killed/signal fields — those are divergence-only).
+ *
+ * opts.cwd is the only addition over the narrowest (web-search/ensureVenv) shape
+ * and is what supervisor/checks callers already pass.
+ */
+export type ExecFn = (
+	cmd: string,
+	args: string[],
+	opts?: { timeout?: number; signal?: AbortSignal; cwd?: string },
+) => Promise<ExecResult>;
+
+/** Structured progress callback. */
+export type OnUpdateCallback = (
+	u: { content: Array<{ type: "text"; text: string }>; details: unknown },
+) => void;

--- a/.pi/extensions/ripgrep-search/internal.ts
+++ b/.pi/extensions/ripgrep-search/internal.ts
@@ -101,13 +101,13 @@ export async function cleanupTrackedTempDirs(
 // ═══════════════════════════════════════════════════════════════════════
 
 /** Cache entry stored for each unique query+directory */
-export interface CacheEntry {
+export interface RgCacheEntry {
 	result: RgResult;
 	rawStdout: string;
 }
 
 /** @internal Exported for testability */
-export const resultCache = new Map<string, CacheEntry>();
+export const resultCache = new Map<string, RgCacheEntry>();
 
 const MAX_CACHE_ENTRIES = 100;
 
@@ -122,7 +122,7 @@ export function buildCacheKey(query: string, directory: string): string {
 }
 
 /** Look up a cached search result. Returns undefined on miss. */
-export function getCachedResult(query: string, directory: string): CacheEntry | undefined {
+export function getCachedResult(query: string, directory: string): RgCacheEntry | undefined {
 	return resultCache.get(buildCacheKey(query, directory));
 }
 
@@ -130,7 +130,7 @@ export function getCachedResult(query: string, directory: string): CacheEntry | 
  * Store a search result in the cache.
  * Evicts oldest entry (by insertion order) when at max capacity and key is new.
  */
-export function setCachedResult(query: string, directory: string, entry: CacheEntry): void {
+export function setCachedResult(query: string, directory: string, entry: RgCacheEntry): void {
 	const key = buildCacheKey(query, directory);
 
 	// If at max capacity and this is a new key, evict oldest by insertion order

--- a/.pi/extensions/scrapling/test/types.test.ts
+++ b/.pi/extensions/scrapling/test/types.test.ts
@@ -105,14 +105,18 @@ describe("types.ts exports — shared ExecResult/ExecFn", () => {
 		assert.equal(isExecFailure({ code: 1, stdout: "", stderr: "", killed: true }), true);
 	});
 
-	it("(D) CrawlParams and OnUpdateCallback remain exported", () => {
+	it("(D) CrawlParams remains exported", () => {
 		assert.ok(
 			/export\s+interface\s+CrawlParams/.test(typesSource),
 			"CrawlParams should remain exported",
 		);
+	});
+
+	it("(D) OnUpdateCallback re-exported from lib/port-types.ts", () => {
+		const reexport = /export\s+type\s*\{[^}]*\bOnUpdateCallback\b[^}]*\}\s*from\s+["']\.\.\/lib\/port-types\.ts["']/;
 		assert.ok(
-			/export\s+interface\s+OnUpdateCallback/.test(typesSource),
-			"OnUpdateCallback should remain exported",
+			reexport.test(typesSource),
+			"types.ts should re-export OnUpdateCallback from lib/port-types.ts",
 		);
 	});
 });

--- a/.pi/extensions/scrapling/types.ts
+++ b/.pi/extensions/scrapling/types.ts
@@ -2,6 +2,7 @@
  * Shared types for scrapling extension
  */
 
+// Diverges from lib/port-types.ExecResult: adds killed/signal for killed-process detection
 export interface ExecResult {
 	code: number;
 	stdout: string;
@@ -27,6 +28,8 @@ export function isExecFailure(result: ExecResult): boolean {
 	return result.code !== 0 || result.killed;
 }
 
+// Diverges from lib/port-types.ExecFn: opts adds maxBuffer, return uses divergent ExecResult
+// Diverges from lib/port-types.ExecResult: adds killed/signal
 export interface ExecFn {
 	(
 		cmd: string,
@@ -35,9 +38,7 @@ export interface ExecFn {
 	): Promise<ExecResult>;
 }
 
-export interface OnUpdateCallback {
-	(u: { content: Array<{ type: "text"; text: string }>; details: unknown }): void;
-}
+export type { OnUpdateCallback } from "../lib/port-types.ts";
 
 export interface CrawlParams {
 	url: string;

--- a/.pi/extensions/supervisor/checks/package-safety.ts
+++ b/.pi/extensions/supervisor/checks/package-safety.ts
@@ -1,12 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-
-/** Exec function type for subprocess calls (3-field return — code, stdout, stderr) */
-type ExecFn = (
-	cmd: string,
-	args: string[],
-	opts?: Record<string, unknown>,
-) => Promise<{ code: number; stdout: string; stderr: string }>;
+import type { ExecFn } from "../../lib/port-types.ts";
 
 // ─── Package Safety Check ──────────────────────────────────────────
 // Deterministic package age validation for npm install safety.

--- a/.pi/extensions/supervisor/checks/shared.ts
+++ b/.pi/extensions/supervisor/checks/shared.ts
@@ -8,12 +8,8 @@
 
 // ─── Exec function type
 
-/** Exec function type for subprocess calls (3-field return — code, stdout, stderr) */
-export type ExecFn = (
-	cmd: string,
-	args: string[],
-	opts?: Record<string, unknown>,
-) => Promise<{ code: number; stdout: string; stderr: string }>;
+import type { ExecFn } from "../../lib/port-types.ts";
+export type { ExecFn };
 
 // ─── Git diff helper ───────────────────────────────────────────────
 

--- a/.pi/extensions/supervisor/pipeline/helpers.ts
+++ b/.pi/extensions/supervisor/pipeline/helpers.ts
@@ -16,6 +16,7 @@ import { parseAgentFile } from "../agent/loader.ts";
 import type { ErrorCollector } from "./error-collector.ts";
 
 /** Exec function type for subprocess calls — port matching the real dependency. */
+// Diverges from lib/port-types.ExecFn: opts use @earendil-works/pi-coding-agent ExecOptions
 export type ExecFn = (cmd: string, args: string[], opts?: ExecOptions) => Promise<ExecResult>;
 
 /**

--- a/.pi/extensions/supervisor/test/checks/shared.test.mts
+++ b/.pi/extensions/supervisor/test/checks/shared.test.mts
@@ -16,11 +16,7 @@ import { getChangedFilesFromGitDiff, isExecutableNotFound } from "../../checks/s
 // Helpers
 // ═══════════════════════════════════════════════════════════════════════
 
-type ExecFn = (
-	cmd: string,
-	args: string[],
-	opts?: Record<string, unknown>,
-) => Promise<{ code: number; stdout: string; stderr: string }>;
+import type { ExecFn } from "../../../lib/port-types.ts";
 
 function makeExec(results: Array<{ code: number; stdout: string; stderr: string }>): ExecFn {
 	let idx = 0;

--- a/.pi/extensions/tsc-checkpoint/types.ts
+++ b/.pi/extensions/tsc-checkpoint/types.ts
@@ -5,16 +5,9 @@
  * Zero dependencies — importable from any module without side effects.
  */
 
-export interface TscDiagnostic {
-	file: string;
-	line: number;
-	column: number;
-	severity: "Error";
-	message: string;
-	code?: string;
-	/** Absolute path to the file (resolved from tsconfig dir) */
-	filePath: string;
-}
+import type { TscDiagnostic } from "../lib/tsc-types.ts";
+
+export type { TscDiagnostic };
 
 export interface TscWatchOptions {
 	/** Polling interval in ms (reserved for future polling mode) */

--- a/.pi/extensions/web-search/test/types.test.ts
+++ b/.pi/extensions/web-search/test/types.test.ts
@@ -75,31 +75,27 @@ describe("types.ts exports — SearchResult, SearchParams, SearchCacheEntry", ()
 		);
 	});
 
-	it("(D) types.ts exports ExecResult with code, stdout, stderr fields", () => {
+	it("(D) types.ts re-exports ExecResult from lib/port-types.ts", () => {
+		const reexport = /export\s+type\s*\{[^}]*\bExecResult\b[^}]*\}\s*from\s+["']\.\.\/lib\/port-types\.ts["']/;
 		assert.ok(
-			/export\s+interface\s+ExecResult/.test(typesSource),
-			"types.ts should export interface ExecResult",
-		);
-		assert.ok(/^\s*code:\s*number;/m.test(typesSource), "ExecResult should have code: number");
-		assert.ok(/^\s*stdout:\s*string;/m.test(typesSource), "ExecResult should have stdout: string");
-		assert.ok(/^\s*stderr:\s*string;/m.test(typesSource), "ExecResult should have stderr: string");
-	});
-
-	it("(D) types.ts exports ExecFn with correct signature", () => {
-		assert.ok(
-			/export\s+interface\s+ExecFn/.test(typesSource),
-			"types.ts should export interface ExecFn",
-		);
-		assert.ok(
-			typesSource.includes("Promise<ExecResult>"),
-			"ExecFn should return Promise<ExecResult>",
+			reexport.test(typesSource),
+			"types.ts should re-export ExecResult from lib/port-types.ts",
 		);
 	});
 
-	it("(D) types.ts exports OnUpdateCallback", () => {
+	it("(D) types.ts re-exports ExecFn from lib/port-types.ts", () => {
+		const reexport = /export\s+type\s*\{[^}]*\bExecFn\b[^}]*\}\s*from\s+["']\.\.\/lib\/port-types\.ts["']/;
 		assert.ok(
-			/export\s+interface\s+OnUpdateCallback/.test(typesSource),
-			"OnUpdateCallback should remain exported",
+			reexport.test(typesSource),
+			"types.ts should re-export ExecFn from lib/port-types.ts",
+		);
+	});
+
+	it("(D) types.ts re-exports OnUpdateCallback from lib/port-types.ts", () => {
+		const reexport = /export\s+type\s*\{[^}]*\bOnUpdateCallback\b[^}]*\}\s*from\s+["']\.\.\/lib\/port-types\.ts["']/;
+		assert.ok(
+			reexport.test(typesSource),
+			"types.ts should re-export OnUpdateCallback from lib/port-types.ts",
 		);
 	});
 });

--- a/.pi/extensions/web-search/types.ts
+++ b/.pi/extensions/web-search/types.ts
@@ -6,23 +6,7 @@
  * SearchCacheEntry provides in-session caching
  */
 
-export interface ExecResult {
-	code: number;
-	stdout: string;
-	stderr: string;
-}
-
-export interface ExecFn {
-	(
-		cmd: string,
-		args: string[],
-		opts?: { timeout?: number; signal?: AbortSignal },
-	): Promise<ExecResult>;
-}
-
-export interface OnUpdateCallback {
-	(u: { content: Array<{ type: "text"; text: string }>; details: unknown }): void;
-}
+export type { ExecResult, ExecFn, OnUpdateCallback } from "../lib/port-types.ts";
 
 export interface SearchResult {
 	title: string;


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1292

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 14s | 38.8K | 43 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 45s | 39.6K | 28 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 9s | 53.9K | 28 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 33s | 78.5K | 67 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 6m 43s | 88.1K | 68 | minimax-m3 |

**Total:** 5 agents · 15m 25s · 299.0K tokens · 234 tool calls · 11 failed (5%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1292
Closes #1292