### PR TITLE
feat(#1331): [Feature] Replace pi-guardian daemon with on-demand shell scan in cheasee-pi clean

### DIFF
--- a/cmd/cheasee-pi/clean.go
+++ b/cmd/cheasee-pi/clean.go
@@ -1,9 +1,9 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"os/exec"
 
 	"github.com/spf13/cobra"
 )
@@ -12,15 +12,16 @@ var cleanName string
 
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
-	Short: "Kill all pi sessions inside container to free RAM",
-	Long: `Kill all pi processes inside the Cheasee-Pi Docker container.
+	Short: "Kill orphaned pi sessions inside container to free RAM",
+	Long: `Kill orphaned pi processes inside the Cheasee-Pi Docker container.
 
-Orphaned pi processes from disconnected docker exec sessions accumulate RAM.
-Run this when memory usage is high. Kills ALL pi processes — interactive
-sessions AND subagents. Use 'cheasee-pi start' to start a fresh session.
+Pi processes orphaned by disconnected docker exec sessions accumulate RAM.
+Run this when memory usage is high. Only kills processes reparented to PID 1
+(orphans) — interactive sessions are NOT affected.
+Use 'cheasee-pi start' to start a fresh session after cleaning.
 
 Examples:
-  cheasee-pi clean               # kill all pi in default container
+  cheasee-pi clean               # kill orphaned pi in default container
   cheasee-pi clean --name mypi   # specify container name`,
 	DisableAutoGenTag: true,
 	RunE:              runCleanE,
@@ -31,31 +32,20 @@ func init() {
 	cleanCmd.Flags().StringVar(&cleanName, "name", "cheasee-pi", "Container name")
 }
 
-func runCleanE(_ *cobra.Command, _ []string) error {
-	name := cleanName
+func runCleanE(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
-	// Check container exists and is running
-	cmd := exec.Command("docker", "ps", "--filter", fmt.Sprintf("name=%s", name), "--format", "{{.Names}}")
-	out, err := cmd.Output()
+	killed, err := scanOrphans(ctx, cleanName)
 	if err != nil {
-		return fmt.Errorf("docker ps: %w", err)
+		return fmt.Errorf("clean: %w", err)
 	}
-	if string(out) == "" {
-		fmt.Fprintf(os.Stderr, "  ℹ Container %q is not running\n", name)
-		return nil
+	if killed > 0 {
+		fmt.Fprintf(os.Stderr, "  ✓ Killed %d orphaned pi process(es)\n", killed)
+	} else {
+		fmt.Fprintf(os.Stderr, "  ℹ No orphaned pi processes found\n")
 	}
-
-	// Kill all pi processes (any stdin state, any PPid)
-	killCmd := exec.Command("docker", "exec", name, "sh", "-c",
-		`for d in /proc/[0-9]*/cmdline; do
-			[ -r "$d" ] || continue
-			grep -aq "^pi" "$d" 2>/dev/null || continue
-			kill "$(basename "$(dirname "$d")")" 2>/dev/null
-		done`,
-	)
-	if out, err := killCmd.CombinedOutput(); err == nil && len(out) > 0 {
-		fmt.Fprintf(os.Stderr, "  ✓ Cleaned stale pi sessions\n")
-	}
-	fmt.Fprintf(os.Stderr, "  ✓ All pi sessions killed in container %q\n", name)
 	return nil
 }

--- a/cmd/cheasee-pi/orphan.go
+++ b/cmd/cheasee-pi/orphan.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// orphanScanBash is the shell script that scans /proc for orphaned pi processes.
+// Targets processes with PPid=1 (reparented to tini after parent disconnects)
+// and cmdline matching /usr/bin/pi or pi (anchored — no *pi* substring to avoid
+// false positives on python/pipewire). TOCTOU races between stat read and kill
+// are tolerated — ESRCH is silently swallowed by 2>/dev/null.
+const orphanScanBash = `for pid in /proc/*/stat; do
+  ppid=$(awk '{print $4}' "$pid" 2>/dev/null)
+  cmdline=$(tr '\0' ' ' < "${pid%/stat}/cmdline" 2>/dev/null)
+  [ "$ppid" = "1" ] && { [[ "$cmdline" == "/usr/bin/pi"* ]] || [[ "$cmdline" == "pi "* ]] || [[ "$cmdline" == "pi" ]]; } && \
+    echo "killing $(basename "$(dirname "$pid")")" && \
+    kill "$(basename "$(dirname "$pid")")" 2>/dev/null
+done`
+
+// cmdIface is the subset of *exec.Cmd used by scanOrphans.
+type cmdIface interface {
+	Output() ([]byte, error)
+	CombinedOutput() ([]byte, error)
+}
+
+// execCommand is os/exec.Command wrapped in cmdIface, overridable in tests.
+var execCommand = func(name string, arg ...string) cmdIface {
+	return exec.Command(name, arg...)
+}
+
+// scanOrphans runs the orphan-scan bash inside the container and returns the
+// number of PIDs that were signalled. Returns (0, nil) if the container is
+// not running (graceful skip). Best-effort: TOCTOU races are tolerated.
+func scanOrphans(ctx context.Context, name string) (int, error) {
+	// Check container is running
+	cmd := execCommand("docker", "ps", "--filter", fmt.Sprintf("name=%s", name), "--format", "{{.Names}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, fmt.Errorf("docker ps: %w", err)
+	}
+	if strings.TrimSpace(string(out)) != name {
+		return 0, nil
+	}
+
+	execCmd := execCommand("docker", "exec", name, "sh", "-c", orphanScanBash)
+	output, err := execCmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("orphan scan: %w", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	count := 0
+	for _, line := range lines {
+		if strings.HasPrefix(line, "killing ") {
+			count++
+		}
+	}
+	return count, nil
+}

--- a/cmd/cheasee-pi/root.go
+++ b/cmd/cheasee-pi/root.go
@@ -7,7 +7,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "cheasee-pi",
 	Short: "Cheasee-PI — Token-saving Pi agent harness with Docker setup",
-th	Long: `Cheasee-PI is a Pi agent harness built on the Pi coding agent (pi.dev).
+	Long: `Cheasee-PI is a Pi agent harness built on the Pi coding agent (pi.dev).
 Its init command authenticates with GitHub, clones your fork, configures
 submodules, and extracts Docker compose files for containerized deployment.
 

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -109,7 +109,16 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Phase 3: Build env flags from auth.json + gh token + --api-key
+	// Phase 3: Run pre-start orphan scan (best-effort)
+	killed, err := scanOrphans(ctx, upName)
+	if err != nil {
+		return fmt.Errorf("pre-start orphan scan: %w", err)
+	}
+	if killed > 0 {
+		fmt.Fprintf(os.Stderr, "  ✓ Killed %d orphaned pi process(es)\n", killed)
+	}
+
+	// Phase 4: Build env flags from auth.json + gh token + --api-key
 	envFlags, err := buildEnvFlags(ctx)
 	if err != nil {
 		return fmt.Errorf("build env vars: %w", err)
@@ -120,7 +129,7 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(os.Stderr, "  ℹ Use: cheasee-pi auth add <provider>\n")
 	}
 
-	// Phase 4: Print env flags or exec pi
+	// Phase 5: Print env flags or exec pi
 	if upDryRun {
 		fmt.Fprintf(os.Stderr, "Env vars to be injected:\n")
 		for i := 0; i < len(envFlags); i += 2 {
@@ -265,9 +274,9 @@ func extractGHToken() (string, error) {
 
 // execArgs builds docker exec args with a stdin-EOF cleanup wrapper.
 // When docker exec disconnects (close tab, network drop), stdin
-// returns EOF → the wrapper kills pi instead of orphaning it.
-// Uses bash wait -n to handle all exit paths: normal pi exit,
-// Ctrl+C, Ctrl+D, or terminal close — no orphan detection needed.
+// returns EOF → the wrapper kills the entire pi process group instead
+// of orphaning it. Uses setsid so pi gets its own process group, then
+// kill -- -$P1 kills the whole group (pi and all its children).
 func execArgs(envFlags []string, name string) []string {
 	args := append([]string{"exec"}, envFlags...)
 	args = append(args,
@@ -276,13 +285,15 @@ func execArgs(envFlags []string, name string) []string {
 		"-w", "/workspaces/main",
 		name,
 		"bash", "-c",
-		// trap kills child on Ctrl+C; cat & reads stdin for EOF detection;
-		// wait -n returns when either pi or cat exits; kill the other.
-		`trap "kill $P1 $P2 2>/dev/null; exit 0" INT TERM HUP
-/usr/bin/pi --approve & P1=$!
+		// set -m enables job control so background jobs get their own PGID.
+		// setsid makes pi a new session/process-group leader (PGID = PID).
+		// kill -- -$P1 sends signal to the whole process group.
+		`set -m
+trap "kill -- -$P1 -- -$P2 2>/dev/null; exit 0" INT TERM HUP
+setsid /usr/bin/pi --approve & P1=$!
 cat > /dev/null & P2=$!
 wait -n $P1 $P2 2>/dev/null
-kill $P1 $P2 2>/dev/null
+kill -- -$P1 -- -$P2 2>/dev/null
 wait 2>/dev/null`,
 	)
 	return args

--- a/cmd/cheasee-pi/up_test.go
+++ b/cmd/cheasee-pi/up_test.go
@@ -1,0 +1,389 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ──────────────────────────────────────────────
+// execArgs tests — Phase 1
+// ──────────────────────────────────────────────
+
+func TestExecArgs_containsHardenedBash(t *testing.T) {
+	args := execArgs(nil, "cheasee-pi")
+	script := args[len(args)-1]
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"enables job control", "set -m"},
+		{"uses setsid for pi", "setsid /usr/bin/pi"},
+		{"kills PGID on trap", "kill -- -$P1 -- -$P2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !strings.Contains(script, tt.want) {
+				t.Errorf("execArgs bash missing %q\nscript:\n%s", tt.want, script)
+			}
+		})
+	}
+}
+
+func TestExecArgs_omitsOldKillPattern(t *testing.T) {
+	args := execArgs(nil, "cheasee-pi")
+	script := args[len(args)-1]
+
+	// The old pattern used bare kill $P1 $P2 (no --, no - prefix)
+	// The new pattern uses kill -- -$P1 -- -$P2
+	if strings.Contains(script, "kill $P1") && !strings.Contains(script, "kill -- -$P1") {
+		t.Errorf("execArgs still uses unadorned kill $P1")
+	}
+}
+
+func TestExecArgs_containsExpectedOrder(t *testing.T) {
+	args := execArgs(nil, "cheasee-pi")
+	joined := strings.Join(args, " ")
+
+	checks := []string{
+		"exec",
+		"-it",
+		"--user agentuser",
+		"-w /workspaces/main",
+		"cheasee-pi",
+		"bash -c",
+	}
+	for _, want := range checks {
+		if !strings.Contains(joined, want) {
+			t.Errorf("execArgs missing %q", want)
+		}
+	}
+}
+
+func TestExecArgs_envFlagsInCorrectPosition(t *testing.T) {
+	envFlags := []string{"-e", "FOO=bar", "-e", "BAZ=qux"}
+	args := execArgs(envFlags, "cheasee-pi")
+
+	execIdx := indexOf(args, "exec")
+	nameIdx := indexOf(args, "cheasee-pi")
+	envEIdx := indexOf(args, "-e")
+
+	if envEIdx < execIdx {
+		t.Errorf("-e flag at %d before exec at %d", envEIdx, execIdx)
+	}
+	if envEIdx > nameIdx {
+		t.Errorf("-e flag at %d after container name at %d", envEIdx, nameIdx)
+	}
+
+	hasFoo := false
+	hasBaz := false
+	for i, a := range args {
+		if a == "-e" && i+1 < len(args) {
+			if args[i+1] == "FOO=bar" {
+				hasFoo = true
+			}
+			if args[i+1] == "BAZ=qux" {
+				hasBaz = true
+			}
+		}
+	}
+	if !hasFoo {
+		t.Error("execArgs missing env FOO=bar")
+	}
+	if !hasBaz {
+		t.Error("execArgs missing env BAZ=qux")
+	}
+}
+
+func TestExecArgs_emptyEnvFlags(t *testing.T) {
+	args := execArgs(nil, "cheasee-pi")
+	if len(args) < 6 {
+		t.Fatalf("execArgs returned too few args: %v", args)
+	}
+	if args[0] != "exec" {
+		t.Errorf("expected first arg exec, got %q", args[0])
+	}
+}
+
+func TestExecArgs_manyEnvFlags(t *testing.T) {
+	var envFlags []string
+	for i := 0; i < 20; i++ {
+		envFlags = append(envFlags, "-e", fmt.Sprintf("KEY_%d=val_%d", i, i))
+	}
+	args := execArgs(envFlags, "cheasee-pi")
+
+	namePos := -1
+	for i, a := range args {
+		if a == "cheasee-pi" {
+			namePos = i
+			break
+		}
+	}
+	if namePos < 0 {
+		t.Fatal("container name not found")
+	}
+
+	for i := 0; i < len(envFlags); i += 2 {
+		if envFlags[i] != "-e" {
+			continue
+		}
+		found := false
+		for j := 0; j < namePos; j++ {
+			if args[j] == envFlags[i] && j+1 < namePos && args[j+1] == envFlags[i+1] {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("env flag %s=%s not found before container name", envFlags[i], envFlags[i+1])
+		}
+	}
+}
+
+// ──────────────────────────────────────────────
+// orphanScanBash tests — Phase 2
+// ──────────────────────────────────────────────
+
+func TestOrphanScanBash_filtersByPPid(t *testing.T) {
+	if !strings.Contains(orphanScanBash, `"1"`) {
+		t.Error("orphanScanBash missing PPid=1 filter")
+	}
+	if !strings.Contains(orphanScanBash, `$ppid`) {
+		t.Error("orphanScanBash missing ppid variable")
+	}
+	if !strings.Contains(orphanScanBash, `awk '{print $4}'`) {
+		t.Error("orphanScanBash should use awk to extract PPID from /proc/*/stat")
+	}
+}
+
+func TestOrphanScanBash_anchoredCmdline(t *testing.T) {
+	if strings.Contains(orphanScanBash, `*pi*`) {
+		t.Error("orphanScanBash uses dangerous *pi* substring match")
+	}
+	if !strings.Contains(orphanScanBash, `/usr/bin/pi`) && !strings.Contains(orphanScanBash, `"pi `) {
+		t.Error("orphanScanBash missing anchored /usr/bin/pi or pi pattern")
+	}
+}
+
+func TestOrphanScanBash_iteratesProcStat(t *testing.T) {
+	if !strings.Contains(orphanScanBash, "/proc/*/stat") {
+		t.Error("orphanScanBash should iterate /proc/*/stat")
+	}
+}
+
+func TestOrphanScanBash_swallowsESRCH(t *testing.T) {
+	if !strings.Contains(orphanScanBash, "2>/dev/null") {
+		t.Error("orphanScanBash should swallow errors on kill (ESRCH)")
+	}
+}
+
+func TestOrphanScanBash_echoesKilledPIDs(t *testing.T) {
+	if !strings.Contains(orphanScanBash, "echo ") {
+		t.Error("orphanScanBash should echo killed PIDs for user feedback")
+	}
+}
+
+// ──────────────────────────────────────────────
+// scanOrphans tests — Phase 3
+// ──────────────────────────────────────────────
+
+type mockCmd struct {
+	outputFn   func() ([]byte, error)
+	combinedFn func() ([]byte, error)
+}
+
+func (m *mockCmd) Output() ([]byte, error) {
+	if m.outputFn != nil {
+		return m.outputFn()
+	}
+	return nil, nil
+}
+
+func (m *mockCmd) CombinedOutput() ([]byte, error) {
+	if m.combinedFn != nil {
+		return m.combinedFn()
+	}
+	return nil, nil
+}
+
+func TestScanOrphans_containerNotRunning(t *testing.T) {
+	saved := execCommand
+	execCommand = func(_ string, _ ...string) cmdIface {
+		return &mockCmd{
+			outputFn: func() ([]byte, error) {
+				return []byte(""), nil
+			},
+		}
+	}
+	defer func() { execCommand = saved }()
+
+	count, err := scanOrphans(context.Background(), "cheasee-pi")
+	if err != nil {
+		t.Fatalf("scanOrphans returned error for not-running container: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 killed for not-running container, got %d", count)
+	}
+}
+
+func TestScanOrphans_noOrphans(t *testing.T) {
+	saved := execCommand
+	step := 0
+	execCommand = func(_ string, _ ...string) cmdIface {
+		step++
+		if step == 1 {
+			return &mockCmd{
+				outputFn: func() ([]byte, error) {
+					return []byte("cheasee-pi"), nil
+				},
+			}
+		}
+		return &mockCmd{
+			combinedFn: func() ([]byte, error) {
+				return []byte(""), nil
+			},
+		}
+	}
+	defer func() { execCommand = saved }()
+
+	count, err := scanOrphans(context.Background(), "cheasee-pi")
+	if err != nil {
+		t.Fatalf("scanOrphans returned error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 killed, got %d", count)
+	}
+}
+
+func TestScanOrphans_countsKilled(t *testing.T) {
+	saved := execCommand
+	step := 0
+	execCommand = func(_ string, _ ...string) cmdIface {
+		step++
+		if step == 1 {
+			return &mockCmd{
+				outputFn: func() ([]byte, error) {
+					return []byte("cheasee-pi"), nil
+				},
+			}
+		}
+		return &mockCmd{
+			combinedFn: func() ([]byte, error) {
+				return []byte("killing 42\nkilling 99\n"), nil
+			},
+		}
+	}
+	defer func() { execCommand = saved }()
+
+	count, err := scanOrphans(context.Background(), "cheasee-pi")
+	if err != nil {
+		t.Fatalf("scanOrphans returned error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected 2 killed, got %d", count)
+	}
+}
+
+func TestScanOrphans_dockerExecFails(t *testing.T) {
+	saved := execCommand
+	step := 0
+	execCommand = func(_ string, _ ...string) cmdIface {
+		step++
+		if step == 1 {
+			return &mockCmd{
+				outputFn: func() ([]byte, error) {
+					return []byte("cheasee-pi"), nil
+				},
+			}
+		}
+		return &mockCmd{
+			combinedFn: func() ([]byte, error) {
+				return nil, fmt.Errorf("container stopped")
+			},
+		}
+	}
+	defer func() { execCommand = saved }()
+
+	_, err := scanOrphans(context.Background(), "cheasee-pi")
+	if err == nil {
+		t.Fatal("expected error when docker exec fails, got nil")
+	}
+}
+
+func TestScanOrphans_constructsDockerExecCommand(t *testing.T) {
+	saved := execCommand
+	var capturedName string
+	var capturedArgs []string
+	step := 0
+	execCommand = func(name string, arg ...string) cmdIface {
+		step++
+		if step == 1 {
+			return &mockCmd{
+				outputFn: func() ([]byte, error) {
+					return []byte("cheasee-pi"), nil
+				},
+			}
+		}
+		capturedName = name
+		capturedArgs = arg
+		return &mockCmd{
+			combinedFn: func() ([]byte, error) {
+				return []byte(""), nil
+			},
+		}
+	}
+	defer func() { execCommand = saved }()
+
+	scanOrphans(context.Background(), "cheasee-pi")
+
+	if capturedName != "docker" {
+		t.Errorf("expected docker, got %q", capturedName)
+	}
+	if len(capturedArgs) < 4 {
+		t.Fatalf("too few args: %v", capturedArgs)
+	}
+	if capturedArgs[0] != "exec" {
+		t.Errorf("expected exec, got %q", capturedArgs[0])
+	}
+	if capturedArgs[1] != "cheasee-pi" {
+		t.Errorf("expected container name, got %q", capturedArgs[1])
+	}
+	if capturedArgs[2] != "sh" || capturedArgs[3] != "-c" {
+		t.Errorf("expected sh -c, got %v", capturedArgs[2:4])
+	}
+	if capturedArgs[4] != orphanScanBash {
+		t.Errorf("expected orphanScanBash as script argument")
+	}
+}
+
+func TestScanOrphans_dockerPsFails(t *testing.T) {
+	saved := execCommand
+	execCommand = func(_ string, _ ...string) cmdIface {
+		return &mockCmd{
+			outputFn: func() ([]byte, error) {
+				return nil, fmt.Errorf("docker daemon not running")
+			},
+		}
+	}
+	defer func() { execCommand = saved }()
+
+	_, err := scanOrphans(context.Background(), "cheasee-pi")
+	if err == nil {
+		t.Fatal("expected error when docker ps fails, got nil")
+	}
+}
+
+// ──────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────
+
+func indexOf(slice []string, val string) int {
+	for i, s := range slice {
+		if s == val {
+			return i
+		}
+	}
+	return -1
+}

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -128,15 +128,21 @@ docker exec -it --user agentuser -w /workspaces/main cheasee-pi pi
 
 ### Stale process cleanup
 
-Pi processes can become orphaned if a session crashes or the network disconnects.
-These accumulate across parallel sessions. As an optional but recommended cleanup:
+Pi processes can become orphaned if a `docker exec` session disconnects or the
+wrapper is killed before cleanup runs. These accumulate RAM (150–280 MB each).
+
+**Cleanup command:**
 
 ```bash
-docker exec cheasee-pi bash -c \
-  'for f in /tmp/pi-active-*; do
-     [ -f "$f" ] && pid=$(cat "$f") && ! kill -0 "$pid" 2>/dev/null && rm -f "$f";
-   done'
+cheasee-pi clean
 ```
+
+This scans for processes reparented to PID 1 and kills them. It only targets
+orphans — interactive sessions are **not** affected.
+
+**Automatic pre-start cleanup:** `cheasee-pi start` / `cheasee-pi up` runs the
+same orphan scan before launching pi, so orphans are always cleaned between
+sessions.
 
 ## Stop
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -86,7 +86,7 @@ cheasee-pi
 ```
 
 `cheasee-pi` starts the container (builds image ~2 min first time), injects keys
-from `~/.config/cheasee-pi/auth.json`, and opens pi TUI. `cheasee-pi start` also works.
+from `~/.config/cheasee-pi/auth.json`, and opens pi TUI.
 
 Stop the container when done:
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1331

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 4m 37s | 70.0K | 34 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 17s | 23.8K | 16 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 45s | 36.2K | 21 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 14s | 63.9K | 55 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 13s | 64.4K | 47 | minimax-m3 |

**Total:** 5 agents · 15m 6s · 258.4K tokens · 173 tool calls · 12 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1331
Closes #1331