### PR TITLE
feat(#1348): [Bug] agent-harness hardcoded JSON schemas in redirect messages drift from real tool schemas

### DIFF
--- a/.pi/extensions/agent-harness/lib/harness-rules.test.ts
+++ b/.pi/extensions/agent-harness/lib/harness-rules.test.ts
@@ -8,6 +8,7 @@ import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import {
 	buildRedirectMessage,
+	REDIRECT_GUIDANCE,
 	MULTI_VERB_TOOLS,
 	shouldBlockRetry,
 	isRedundantRead,
@@ -33,24 +34,75 @@ describe("BASH_SEARCH_SIGNALS", () => {
 // ── buildRedirectMessage ──
 
 describe("buildRedirectMessage", () => {
-	it("returns system override format for ripgrep_search", () => {
+	it("returns system override format for ripgrep_search (no schemaExample)", () => {
 		const msg = buildRedirectMessage("ripgrep_search");
 		assert.ok(msg.includes("[SYSTEM OVERRIDE]"));
 		assert.ok(msg.includes("grep"));
 		assert.ok(msg.includes("ripgrep_search"));
-		assert.ok(msg.includes("JSON Schema"));
+		assert.ok(!msg.includes("Example call"), "should NOT contain Example call line by default");
 	});
 
-	it("returns system override format for read", () => {
+	it("returns system override format for read (no schemaExample)", () => {
 		const msg = buildRedirectMessage("read");
 		assert.ok(msg.includes("[SYSTEM OVERRIDE]"));
 		assert.ok(msg.includes("cat"));
 		assert.ok(msg.includes("read"));
-		assert.ok(msg.includes("JSON Schema"));
+		assert.ok(!msg.includes("Example call"), "should NOT contain Example call line by default");
 	});
 
-	it("returns empty string for unknown tool", () => {
+	it("includes schemaExample line when provided for read", () => {
+		const msg = buildRedirectMessage("read", '{ "path": "/path/to/file" }');
+		assert.ok(msg.includes("[SYSTEM OVERRIDE]"));
+		assert.ok(msg.includes("Example call:"));
+		assert.ok(msg.includes("/path/to/file"));
+	});
+
+	it("includes schemaExample line when provided for ripgrep_search", () => {
+		const msg = buildRedirectMessage("ripgrep_search", '{ "query": "pattern" }');
+		assert.ok(msg.includes("[SYSTEM OVERRIDE]"));
+		assert.ok(msg.includes("Example call:"));
+		assert.ok(msg.includes("pattern"));
+	});
+
+	it("returns empty string for unknown tool regardless of schemaExample", () => {
 		assert.equal(buildRedirectMessage("unknown_tool"), "");
+		assert.equal(buildRedirectMessage("unknown_tool", "any example"), "");
+	});
+
+	it("handles empty string schemaExample without trailing empty line", () => {
+		const msg = buildRedirectMessage("read", "");
+		assert.ok(msg.includes("[SYSTEM OVERRIDE]"));
+		assert.ok(!msg.includes("Example call:"), "empty schemaExample should not add Example call line");
+		// Should not end with newline or extra whitespace
+		assert.equal(msg.trim(), msg);
+	});
+});
+
+// ── REDIRECT_GUIDANCE ──
+
+describe("REDIRECT_GUIDANCE", () => {
+	it("is a non-null object with read and ripgrep_search keys", () => {
+		assert.ok(REDIRECT_GUIDANCE !== null && typeof REDIRECT_GUIDANCE === "object");
+		assert.ok("read" in REDIRECT_GUIDANCE);
+		assert.ok("ripgrep_search" in REDIRECT_GUIDANCE);
+	});
+
+	it("read entry has shape { forbidden, tool } with tool === 'read'", () => {
+		const entry = REDIRECT_GUIDANCE["read"];
+		assert.ok(typeof entry?.forbidden === "string");
+		assert.ok(typeof entry?.tool === "string");
+		assert.equal(entry.tool, "read");
+	});
+
+	it("ripgrep_search entry has shape { forbidden, tool } with tool === 'ripgrep_search'", () => {
+		const entry = REDIRECT_GUIDANCE["ripgrep_search"];
+		assert.ok(typeof entry?.forbidden === "string");
+		assert.ok(typeof entry?.tool === "string");
+		assert.equal(entry.tool, "ripgrep_search");
+	});
+
+	it("unknown key returns undefined", () => {
+		assert.equal(REDIRECT_GUIDANCE["unknown"], undefined);
 	});
 });
 
@@ -212,6 +264,9 @@ describe("SEARCH_TOOLS removal", () => {
 			typeof m.TOOL_META === "object" && m.TOOL_META !== null,
 			"TOOL_META should be an object",
 		);
+
+		// Exports
+		assert.equal(typeof m.REDIRECT_GUIDANCE, "object", "REDIRECT_GUIDANCE should be an object");
 
 		// Functions
 		assert.equal(typeof m.loadDefaultRules, "function", "loadDefaultRules should be a function");

--- a/.pi/extensions/agent-harness/lib/harness-rules.ts
+++ b/.pi/extensions/agent-harness/lib/harness-rules.ts
@@ -45,6 +45,23 @@ export function loadDefaultRules(): ResolvedHarnessRules {
 }
 
 /**
+ * Redirect guidance for tool misuse — maps misused tool name to
+ * the forbidden CLI verbs and the dedicated pi tool to use instead.
+ *
+ * Keep in sync with actual bash-query classification in ../bash-query.ts.
+ */
+export const REDIRECT_GUIDANCE: Record<string, { forbidden: string; tool: string }> = {
+	read: {
+		forbidden: "'cat', 'head', or 'tail' in bash",
+		tool: "read",
+	},
+	ripgrep_search: {
+		forbidden: "'grep' or 'rg' in bash",
+		tool: "ripgrep_search",
+	},
+};
+
+/**
  * Multi-verb CLIs where first 2 tokens form the sub-key
  * (e.g., "git status" vs "git diff").
  * Single-verb commands use only the first token.
@@ -94,24 +111,29 @@ export function getToolMeta(toolName: string): ToolMeta {
 
 /**
  * Build a structured redirect message for the LLM.
- * Returns a [SYSTEM OVERRIDE] block with forbidden action and required JSON schema.
+ * Returns a [SYSTEM OVERRIDE] block with forbidden action and tool name.
+ *
+ * When `schemaExample` is provided, it is appended as an "Example call:" line.
+ * Without it, no schema example line is included (default).
+ *
+ * @param toolName — the pi tool to redirect to
+ * @param schemaExample — optional example call string (e.g., '{ "path": "/path/to/file" }')
+ * @returns formatted redirect message, or "" for unknown tools
  */
-export function buildRedirectMessage(toolName: string): string {
-	if (toolName === "ripgrep_search") {
-		return [
-			`[SYSTEM OVERRIDE] Action Blocked. Do not use 'grep' or 'rg' in bash.`,
-			`You MUST use the dedicated 'ripgrep_search' tool.`,
-			`Required JSON Schema: { "query": "your_search_pattern", "directory": "./target_dir" }`,
-		].join("\n");
+export function buildRedirectMessage(toolName: string, schemaExample?: string): string {
+	const guidance = REDIRECT_GUIDANCE[toolName];
+	if (!guidance) return "";
+
+	const lines = [
+		`[SYSTEM OVERRIDE] Action Blocked. Do not use ${guidance.forbidden}.`,
+		`You MUST use the dedicated '${guidance.tool}' tool.`,
+	];
+
+	if (schemaExample) {
+		lines.push(`Example call: ${schemaExample}`);
 	}
-	if (toolName === "read") {
-		return [
-			`[SYSTEM OVERRIDE] Action Blocked. Do not use 'cat', 'head', or 'tail' in bash.`,
-			`You MUST use the dedicated 'read' tool.`,
-			`Required JSON Schema: { "path": "./file.ts", "offset?": 0, "limit?": 100 }`,
-		].join("\n");
-	}
-	return "";
+
+	return lines.join("\n");
 }
 
 /**

--- a/.pi/extensions/agent-harness/lib/tool-schema-examples.test.ts
+++ b/.pi/extensions/agent-harness/lib/tool-schema-examples.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests for tool-schema-examples.ts — manually-synchronized schema examples.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { getToolSchemaExample } from "./tool-schema-examples.ts";
+
+describe("getToolSchemaExample", () => {
+	it("read returns string with absolute path and no false defaults for offset/limit", () => {
+		const example = getToolSchemaExample("read");
+		assert.ok(example, "should return a string for read");
+		assert.ok(example!.includes('"path"'), "should include path parameter");
+		assert.ok(example!.includes("/path/to/file"), "should show absolute path");
+		assert.ok(!example!.includes('"offset"'), "should not include offset (optional, no default shown)");
+		assert.ok(!example!.includes('"limit"'), "should not include limit (optional, no default shown)");
+	});
+
+	it("ripgrep_search returns string with all params and correct optionality", () => {
+		const example = getToolSchemaExample("ripgrep_search");
+		assert.ok(example, "should return a string for ripgrep_search");
+		assert.ok(example!.includes('"query"'), "should include query parameter");
+		assert.ok(example!.includes('"directory?"'), "should show directory as optional");
+		assert.ok(example!.includes('"max_count?"'), "should show max_count as optional");
+	});
+
+	it("unknown tool returns undefined", () => {
+		assert.equal(getToolSchemaExample("unknown_tool"), undefined);
+	});
+
+	it("single export — no side effects on import", async () => {
+		const mod = await import("./tool-schema-examples.ts");
+		const keys = Object.keys(mod).filter((k) => k !== "__esModule");
+		assert.deepEqual(keys, ["getToolSchemaExample"], "should export only getToolSchemaExample");
+	});
+});

--- a/.pi/extensions/agent-harness/lib/tool-schema-examples.ts
+++ b/.pi/extensions/agent-harness/lib/tool-schema-examples.ts
@@ -1,0 +1,44 @@
+/**
+ * tool-schema-examples.ts — Manually-synchronized tool schema examples.
+ *
+ * ⚠️  MUST be updated when tool parameter schemas change.
+ * This file is a manual-sync bridge — there is no compile-time link to the
+ * canonical TypeBox schema definitions in pi-coding-agent or ripgrep-search.
+ *
+ * When a tool's parameter shape, optionality, or defaults change, update both
+ * the example string AND this comment.
+ *
+ * Used by callers of `buildRedirectMessage(toolName, schemaExample)` who want
+ * the "Example call:" line in redirect messages. The default is to omit it.
+ *
+ * Exports:
+ *   getToolSchemaExample(toolName) — returns example string or undefined
+ */
+
+// ── Schema examples ──
+
+const TOOL_SCHEMA_EXAMPLES: Record<string, string> = {
+	/**
+	 * read(path: string, offset?: number, limit?: number)
+	 * - path: absolute or relative path to file
+	 * - offset: 1-indexed line to start from (default 0)
+	 * - limit: max lines to return (defaults to 2000 lines or 50KB truncation)
+	 */
+	read: '{ "path": "/path/to/file" }',
+
+	/**
+	 * ripgrep_search(query: string, directory?: string, max_count?: number)
+	 * - query: search pattern (regex or literal)
+	 * - directory: search root (default ".")
+	 * - max_count: max results to return (default 10)
+	 */
+	ripgrep_search: '{ "query": "pattern", "directory?": ".", "max_count?": 10 }',
+};
+
+/**
+ * Get a schema example string for a tool, for use in redirect messages.
+ * Returns undefined for unknown tools (no example available).
+ */
+export function getToolSchemaExample(toolName: string): string | undefined {
+	return TOOL_SCHEMA_EXAMPLES[toolName];
+}


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1348

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 4m 26s | 66.2K | 64 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 18s | 28.4K | 21 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 12s | 34.3K | 17 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 39s | 46.7K | 17 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 41s | 65.9K | 32 | minimax-m3 |

**Total:** 5 agents · 10m 16s · 241.5K tokens · 151 tool calls · 10 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1348
Closes #1348