### PR TITLE
feat(#1346): [Bug] agent-harness blocks head — read loads entire file, head stops at N lines

### DIFF
--- a/.pi/extensions/agent-harness/agent-harness.ts
+++ b/.pi/extensions/agent-harness/agent-harness.ts
@@ -283,7 +283,7 @@ export class AgentHarness {
 				};
 			}
 
-			// File read in bash (cat/head/tail) → redirect to read
+			// File read in bash (cat/tail) → redirect to read
 			else if (isBashFileRead(bashCommand)) {
 				result = {
 					block: true,

--- a/.pi/extensions/agent-harness/test/index.test.ts
+++ b/.pi/extensions/agent-harness/test/index.test.ts
@@ -103,13 +103,20 @@ describe("AgentHarness — bash tool mismatch", () => {
 		assert.equal(r?.redirectTo, "read");
 	});
 
-	it("standalone head/tail → block with redirectTo read", () => {
-		const h = new AgentHarness();
-		for (const cmd of ["head -5 file", "tail -10 file"]) {
-			const r = h.handleToolCall(makeEvent("bash", { command: cmd }), makeCtx());
-			assert.ok(r?.block, cmd);
-			assert.equal(r?.redirectTo, "read", cmd);
-		}
+	it("standalone head -5 file → pass through (head no longer in READ_CMDS)", () => {
+		assert.equal(
+			new AgentHarness().handleToolCall(makeEvent("bash", { command: "head -5 file" }), makeCtx()),
+			null,
+		);
+	});
+
+	it("standalone tail -10 file → block with redirectTo read", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "tail -10 file" }),
+			makeCtx(),
+		);
+		assert.ok(r?.block);
+		assert.equal(r?.redirectTo, "read");
 	});
 
 	it("bash cat with redirect (cat > file) does NOT block", () => {

--- a/.pi/extensions/lib/bash-query.test.ts
+++ b/.pi/extensions/lib/bash-query.test.ts
@@ -36,8 +36,8 @@ describe("isBashSearch", () => {
 		assert.strictEqual(isBashSearch("cat file | grep foo"), true);
 	});
 
-	it("piped file→rg: head -n 5 file | rg pattern → true", () => {
-		assert.strictEqual(isBashSearch("head -n 5 file | rg pattern"), true);
+	it("piped file→rg: head -n 5 file | rg pattern → false (head no longer in READ_CMDS)", () => {
+		assert.strictEqual(isBashSearch("head -n 5 file | rg pattern"), false);
 	});
 
 	it("piped file→rg: cat file | rg foo → true", () => {
@@ -140,8 +140,8 @@ describe("isBashFileRead", () => {
 		assert.strictEqual(isBashFileRead("cat file.ts"), true);
 	});
 
-	it("head -5 file.ts → true", () => {
-		assert.strictEqual(isBashFileRead("head -5 file.ts"), true);
+	it("head -5 file.ts → false (head no longer in READ_CMDS)", () => {
+		assert.strictEqual(isBashFileRead("head -5 file.ts"), false);
 	});
 
 	it("tail -10 file.ts → true", () => {
@@ -328,8 +328,8 @@ describe("isBashSearchOrRead", () => {
 		assert.strictEqual(isBashSearchOrRead("tail -f log | grep error"), true);
 	});
 
-	it("head -5 file.ts → true (read)", () => {
-		assert.strictEqual(isBashSearchOrRead("head -5 file.ts"), true);
+	it("head -5 file.ts → false (head no longer in READ_CMDS)", () => {
+		assert.strictEqual(isBashSearchOrRead("head -5 file.ts"), false);
 	});
 
 	it("less file.ts → true (read)", () => {

--- a/.pi/extensions/lib/bash-query.ts
+++ b/.pi/extensions/lib/bash-query.ts
@@ -17,7 +17,7 @@
 
 // ── Constants ──
 
-const READ_CMDS = ["cat", "head", "tail", "less", "more"] as const;
+const READ_CMDS = ["cat", "tail", "less", "more"] as const;
 
 /** Bash commands that modify files — triggers read cache invalidation. */
 const FILE_MODIFY_SIGNALS: readonly string[] = Object.freeze([


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1346

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 39s | 73.9K | 32 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 29s | 13.0K | 8 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 37s | 33.0K | 22 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 26s | 53.6K | 22 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 5m 12s | 52.7K | 24 | minimax-m3 |

**Total:** 5 agents · 11m 22s · 226.1K tokens · 108 tool calls · 4 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1346
Closes #1346