### PR TITLE
feat(#1345): [Bug] agent-harness lacks force-bypass mechanism for legitimate blocked commands

### DIFF
--- a/.pi/extensions/agent-harness/README.md
+++ b/.pi/extensions/agent-harness/README.md
@@ -17,8 +17,9 @@ Plus deterministic read caching across turns — re-reading the same file return
 
 ## How it works
 
-Agent Harness hooks into pi's `tool_call` event and runs every call through a 7-step validation pipeline before execution:
+Agent Harness hooks into pi's `tool_call` event and runs every call through an 8-step validation pipeline before execution:
 
+0. **Force-bypass gate** — Per-call escape hatch: `input._harness.force: true` or `# bypass-harness` comment annotation skips all guards. Requires `hasUI: true` (interactive session).
 1. **Pass-through check** — Tools like `ask_user` pass through immediately (no validation overhead)
 2. **Error tracking** — Failed calls are recorded; after 2+ errors on same tool, further calls are blocked
 3. **Cache invalidation** — `write`/`edit` or file-modifying `bash` clears the read cache
@@ -48,7 +49,7 @@ Part of Cheasee-Pi monorepo. Activated automatically when the extension director
 
 ```
 ├── index.ts                  # Entry: session_start/tool_call/turn_start hooks, AgentHarness
-├── agent-harness.ts          # AgentHarness class: handleToolCall, 7-step decision tree
+├── agent-harness.ts          # AgentHarness class: handleToolCall, 8-step decision tree (step 0 = force-bypass)
 ├── lib/
 │   ├── harness-rules.ts      # Rule definitions: cascade thresholds, pass-through tools, mismatches
 │   ├── harness-state.ts      # Error tracking, cascade counter, read cache, turn tracking
@@ -56,29 +57,31 @@ Part of Cheasee-Pi monorepo. Activated automatically when the extension director
 │   ├── timed-map.ts          # Generic timed map with TTL-based eviction
 │   └── constants.ts          # Default thresholds, tool lists
 ├── test/                     # Extensive test suite
-└── bash-query.ts (../lib/)   # Bash classification: isBashSearch, isBashFileRead, isBashFileModify
+└── bash-query.ts (../lib/)   # Bash classification: isBashSearch, isBashFileRead, isBashFileModify, hasBypassAnnotation
 ```
 
 ### Validation Pipeline
 
 ```mermaid
 flowchart TD
-    A[tool_call event] --> B{Step 1: Pass-through?}
-    B -- ask_user, reg commands --> C[Allow]
-    B -- other tools --> D[Step 2: Error tracking]
-    D --> E[Record error count for tool]
-    E --> F{Step 3: Cache invalidation}
-    F -- write/edit --> G[Invalidate read cache for file]
-    F -- other --> H{Step 4: Error retry guard}
-    H -- 2+ consecutive errors --> I[Block: same tool, same args]
-    H -- < 2 errors --> J{Step 5: Read cache}
-    J -- same file read within 6 turns --> K[Return cached content]
-    J -- not cached --> L{Step 6: Cascade detection}
-    L -- 8+ consecutive same tool --> M[Block: cascade detected]
-    L -- below threshold --> N{Step 7: Tool mismatch}
-    N -- bash|grep --> O[Block: use ripgrep_search]
-    N -- bash cat --> P[Block: use read]
-    N -- no mismatch --> Q[Allow]
+    A[tool_call event] --> B{Step 0: Force-bypass?}
+    B -- "_harness.force OR # bypass-harness\n+ hasUI: true" --> C[Allow — record as real call]
+    B -- no bypass --> D{Step 1: Pass-through?}
+    D -- ask_user, reg commands --> C
+    D -- other tools --> E[Step 2: Error tracking]
+    E --> F[Record error count for tool]
+    F --> G{Step 3: Cache invalidation}
+    G -- write/edit --> H[Invalidate read cache for file]
+    G -- other --> I{Step 4: Error retry guard}
+    I -- 2+ consecutive errors --> J[Block: same tool, same args]
+    I -- < 2 errors --> K{Step 5: Read cache}
+    K -- same file read within 6 turns --> L[Return cached content]
+    K -- not cached --> M{Step 6: Cascade detection}
+    M -- 8+ consecutive same tool --> N[Block: cascade detected]
+    M -- below threshold --> O{Step 7: Tool mismatch}
+    O -- bash|grep --> P[Block: use ripgrep_search]
+    O -- bash cat --> Q[Block: use read]
+    O -- no mismatch --> C
 ```
 
 ### Tool Mismatch Detection
@@ -92,6 +95,7 @@ flowchart TD
 
 ### Key Design Decisions
 
+- **Force-bypass (Escape Hatch)** — Two per-call mechanisms: `input._harness.force: true` on any tool, or `# bypass-harness` comment annotation on bash commands. Both require `hasUI: true` (interactive session) to prevent automated abuse. `_harness` is consumed and stripped by the harness before the tool sees it. Force-bypassed calls count toward the cascade counter (recorded as real calls). Parsing for the bash annotation is token-aware (quoted-string immunity) and best-effort (heredocs/continuations fall through to false; use `_harness.force` for those edge cases).
 - **Configurable per-tool thresholds** — `.pi/harness-config.json` allows per-tool `cascadeThreshold` (default 8) and `passThrough` flags.
 - **Read caching with 6-turn TTL** — `TimedMap` stores file contents for 6 turns. Cache invalidated on write/edit to same file.
 - **Error retry guard caps at 2** — First retry reasonable (transient). Second+ consecutive same-tool same-args blocked. Counter resets on turn_start.
@@ -110,6 +114,33 @@ flowchart TD
   }
 }
 ```
+
+### Force-Bypass Details
+
+Two redundant signals for bypassing all guards on a per-call basis:
+
+| Signal | Scope | Example |
+|--------|-------|---------|
+| `_harness.force: true` | Any tool | `input: { _harness: { force: true }, command: "grep foo" }` |
+| `# bypass-harness` comment | Bash only | `command: "grep foo # bypass-harness"` |
+
+Both signals require `hasUI: true` context (interactive session). If `hasUI` is `false` or `undefined`, the bypass is silently ignored and normal guards apply.
+
+**`_harness` field contract:**
+- Namespace-prefixed (`_harness`) to avoid collision with tool schemas
+- Underscore prefix marks it as a reserved internal contract
+- Always consumed and stripped by the harness before the tool executes — tools never see it
+- Even on non-bypass paths (`force: false` or missing), `_harness` is still removed from input
+
+**`# bypass-harness` token parsing:**
+- Token-wise parser strips quoted-string literals before scanning
+- Only checks the first logical line (heredoc and `\` continuation content falls through to false)
+- Best-effort — for edge cases (heredocs, line continuations), use `_harness.force`
+
+**Cascade counter semantics:**
+- Force-bypassed calls **count as real calls** (inflate the cascade counter)
+- Blocked calls (non-bypassed) still do NOT inflate the counter (Bug 5 invariant preserved)
+- A bypassed call itself never triggers a cascade block (bypass gate runs before cascade check)
 
 ## License
 

--- a/.pi/extensions/agent-harness/agent-harness.ts
+++ b/.pi/extensions/agent-harness/agent-harness.ts
@@ -26,7 +26,7 @@ import {
 	loadDefaultRules,
 	shouldBlockRetry,
 } from "./lib/harness-rules.ts";
-import { isBashSearch, isBashFileRead, isBashFileModify } from "../lib/bash-query.ts";
+import { hasBypassAnnotation, isBashSearch, isBashFileRead, isBashFileModify } from "../lib/bash-query.ts";
 import type { ResolvedHarnessRules, ToolMeta } from "./lib/harness-rules.ts";
 
 // ── Types ──
@@ -171,6 +171,33 @@ export class AgentHarness {
 			return null;
 		}
 
+		// Extract bash command string for classification (used by bypass gate and later guards)
+		const bashCommand = (toolName === "bash" ? (args.command ?? "") : "") as string;
+		const bashSubKey =
+			toolName === "bash" ? getBashSubKey((args.command ?? "") as string) : undefined;
+
+		// ── Step 0: Force-bypass gate ──
+		// Per-call escape hatch: _harness.force: true or # bypass-harness comment annotation.
+		// Requires hasUI: true (deliberate intent — prevents headless/automated abuse).
+		// Force-bypassed calls are recorded as real calls (count toward cascade).
+		const forceField = args._harness as { force?: boolean } | undefined;
+		const forceBypass = forceField?.force === true;
+		const bypassAnnotation = toolName === "bash" && hasBypassAnnotation(bashCommand);
+
+		// Strip _harness from input to prevent leaking to tool layer (always, even if not bypassing)
+		if (args._harness !== undefined) {
+			delete (event.input as Record<string, unknown>)._harness;
+		}
+
+		if (forceBypass || bypassAnnotation) {
+			if (this.#hasUI) {
+				this.state.callCounter.record(toolName, sessionTurn, toolCallIndex, bashSubKey);
+				this.state.toolCallIndex++;
+				return null;
+			}
+			// hasUI is false → bypass rejected, fall through to normal guards
+		}
+
 		const meta = this.#getToolMeta(toolName);
 
 		// ── 1. Pass-through tools → always pass, but record for cascade reset ──
@@ -179,9 +206,6 @@ export class AgentHarness {
 			this.state.toolCallIndex++;
 			return null;
 		}
-
-		// Extract bash command string for classification
-		const bashCommand = (toolName === "bash" ? (args.command ?? "") : "") as string;
 
 		let result: ToolCallResult | null = null;
 
@@ -239,11 +263,6 @@ export class AgentHarness {
 				}
 			}
 		}
-
-		// ── Extract bash subKey for sub-command-aware cascade detection ──
-		// First 2 tokens of bash command become subKey. Empty/absent command → undefined.
-		const bashSubKey =
-			toolName === "bash" ? getBashSubKey((args.command ?? "") as string) : undefined;
 
 		// ── 5. Same-tool cascade detection (skip read — cache handles redundant reads) ──
 		// Cascade check uses count + 1 BEFORE recording, accounting for current call

--- a/.pi/extensions/agent-harness/lib/harness-rules.ts
+++ b/.pi/extensions/agent-harness/lib/harness-rules.ts
@@ -22,6 +22,14 @@ export const CACHE_TTL_TURNS = 6;
 export const CASCADE_THRESHOLD = 8;
 
 /**
+ * Force-bypass annotation for bash commands.
+ * When present as a standalone comment token (token-wise parsed, not in quoted strings),
+ * the agent-harness bypasses all guards for that call.
+ * Must be used deliberately — requires hasUI: true to activate.
+ */
+export const BYPASS_ANNOTATION = "# bypass-harness";
+
+/**
  * Resolved harness rules — the merged result of default rules + project-local config.
  * Used by AgentHarness for tool metadata lookup and cascade threshold.
  */

--- a/.pi/extensions/agent-harness/test/index.test.ts
+++ b/.pi/extensions/agent-harness/test/index.test.ts
@@ -18,6 +18,8 @@ import type { ToolCallResult } from "../index.ts";
 import agentHarness from "../index.ts";
 import { CASCADE_THRESHOLD, CACHE_TTL_TURNS } from "../lib/harness-rules.ts";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { hasBypassAnnotation } from "../../lib/bash-query.ts";
+import { BYPASS_ANNOTATION } from "../lib/harness-rules.ts";
 
 // ── Helpers ──
 
@@ -1059,5 +1061,339 @@ describe("AgentHarness — session_start config loading", () => {
 			assert.equal(results[i], undefined, `call ${i + 1} in session 2 should pass`);
 		}
 		assert.ok(results[2]?.block, "3rd call in session 2 should block (threshold 3)");
+	});
+});
+
+// ── Helpers for bypass tests ──
+
+function makeCtxWithUI(hasUI: boolean) {
+	return { hasUI } as any;
+}
+
+// ── Phase 1: hasBypassAnnotation pure function ──
+
+describe("hasBypassAnnotation — pure function", () => {
+	it("bare annotation → true", () => {
+		assert.equal(hasBypassAnnotation("# bypass-harness"), true);
+	});
+
+	it("command with trailing annotation → true", () => {
+		assert.equal(hasBypassAnnotation("echo hi # bypass-harness"), true);
+	});
+
+	it("piped command with annotation → true", () => {
+		assert.equal(hasBypassAnnotation("cat file | grep foo # bypass-harness"), true);
+	});
+
+	it("single-quoted annotation → false", () => {
+		assert.equal(hasBypassAnnotation("echo '# bypass-harness'"), false);
+	});
+
+	it("double-quoted annotation → false", () => {
+		assert.equal(hasBypassAnnotation('echo "# bypass-harness"'), false);
+	});
+
+	it("backtick-quoted annotation → false", () => {
+		assert.equal(hasBypassAnnotation("echo `# bypass-harness`"), false);
+	});
+
+	it("URL hash → false (not standalone comment token)", () => {
+		assert.equal(hasBypassAnnotation("curl http://example.com/#section"), false);
+	});
+
+	it("no space after hash → false", () => {
+		assert.equal(hasBypassAnnotation("echo hi #bypass-harness"), false);
+	});
+
+	it("empty string → false", () => {
+		assert.equal(hasBypassAnnotation(""), false);
+	});
+
+	it("whitespace only → false", () => {
+		assert.equal(hasBypassAnnotation("   "), false);
+	});
+
+	it("heredoc content → false (falls through)", () => {
+		assert.equal(hasBypassAnnotation("cat << EOF\n# bypass-harness\nEOF"), false);
+	});
+
+	it("line continuation → false (falls through)", () => {
+		assert.equal(hasBypassAnnotation("echo hi \\\n# bypass-harness"), false);
+	});
+
+	it("trailing whitespace → true", () => {
+		assert.equal(hasBypassAnnotation("echo hi # bypass-harness   "), true);
+	});
+
+	it("multiple annotations — still true", () => {
+		assert.equal(hasBypassAnnotation("# bypass-harness\n# bypass-harness"), true);
+	});
+
+	it("annotation with leading whitespace → true", () => {
+		assert.equal(hasBypassAnnotation("  # bypass-harness"), true);
+	});
+});
+
+// ── Phase 2: Bypass gate in handleToolCall (hasUI: true) ──
+
+describe("AgentHarness — force bypass gate", () => {
+	it("input._harness.force: true bypasses tool-mismatch guard (bash grep)", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "grep foo", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "bypass: grep with force → pass through");
+	});
+
+	it("input._harness.force: true bypasses error-retry guard", () => {
+		const h = new AgentHarness();
+		// Accumulate 2 errors
+		h.handleToolCall(makeEvent("read", { path: "a.ts" }, true), makeCtx());
+		h.handleToolCall(makeEvent("read", { path: "b.ts" }, true), makeCtx());
+		// Force-bypassed call should pass despite errors
+		const r = h.handleToolCall(
+			makeEvent("read", { path: "c.ts", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "bypass: errors ignored → pass through");
+	});
+
+	it("input._harness.force: true bypasses read-cache guard", () => {
+		const h = new AgentHarness();
+		h.handleToolCall(makeEvent("read", { path: "test.ts" }), makeCtx());
+		h.handleTurnStart();
+		const r = h.handleToolCall(
+			makeEvent("read", { path: "test.ts", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "bypass: cache hit → pass through");
+	});
+
+	it("input._harness.force: true bypasses cascade guard", () => {
+		const h = new AgentHarness();
+		// Make 7 consecutive bash calls, then 8th with force
+		for (let i = 0; i < 7; i++) {
+			h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtxWithUI(true));
+		}
+		const r = h.handleToolCall(
+			makeEvent("bash", { command: "echo hi", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "bypass: 8th call with force → pass through");
+	});
+
+	it("input._harness.force: true on pass-through tool — still passes through", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("ask_user", { question: "ok?", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "bypass + pass-through → pass through");
+	});
+
+	it("# bypass-harness annotation bypasses tool-mismatch guard", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "grep foo # bypass-harness" }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "annotation bypass: grep → pass through");
+	});
+
+	it("# bypass-harness annotation bypasses error-retry guard", () => {
+		const h = new AgentHarness();
+		h.handleToolCall(makeEvent("read", { path: "a.ts" }, true), makeCtx());
+		h.handleToolCall(makeEvent("read", { path: "b.ts" }, true), makeCtx());
+		// bash annotation doesn't apply to 'read' tool, but _harness.force on non-bash doesn't need annotation
+		// Use bash tool for annotation test
+		const r = h.handleToolCall(
+			makeEvent("bash", { command: "cat test.ts # bypass-harness" }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "annotation bypass: cat with annotation → pass through");
+	});
+
+	it("# bypass-harness annotation bypasses cascade guard (bash)", () => {
+		const h = new AgentHarness();
+		for (let i = 0; i < 7; i++) {
+			h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtxWithUI(true));
+		}
+		const r = h.handleToolCall(
+			makeEvent("bash", { command: "echo hi # bypass-harness" }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "annotation bypass: 8th call → pass through");
+	});
+
+	it("both signals present (force + annotation) — bypasses", () => {
+		const h = new AgentHarness();
+		const r = h.handleToolCall(
+			makeEvent("bash", {
+				command: "grep foo # bypass-harness",
+				_harness: { force: true },
+			}),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "both signals → pass through");
+	});
+
+	it("input._harness.force: false — no bypass, normal guards apply", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "grep foo", _harness: { force: false } }),
+			makeCtxWithUI(true),
+		);
+		assert.ok(r?.block, "force:false → mismatch guard still blocks");
+		assert.equal(r?.redirectTo, "ripgrep_search");
+	});
+
+	it("input._harness missing — no bypass, normal guards apply", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "grep foo" }),
+			makeCtxWithUI(true),
+		);
+		assert.ok(r?.block, "no _harness → mismatch guard still blocks");
+	});
+
+	it("input._harness.force: true but hasUI: false — bypass rejected", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "grep foo", _harness: { force: true } }),
+			makeCtxWithUI(false),
+		);
+		assert.ok(r?.block, "hasUI:false → bypass rejected, mismatch guard blocks");
+	});
+
+	it("# bypass-harness annotation but hasUI: false — bypass rejected", () => {
+		const r = new AgentHarness().handleToolCall(
+			makeEvent("bash", { command: "grep foo # bypass-harness" }),
+			makeCtxWithUI(false),
+		);
+		assert.ok(r?.block, "hasUI:false → annotation bypass rejected");
+	});
+
+	it("_harness field stripped from input after handleToolCall", () => {
+		const event = makeEvent("bash", {
+			command: "grep foo",
+			_harness: { force: true },
+		});
+		new AgentHarness().handleToolCall(event, makeCtxWithUI(true));
+		assert.equal((event.input as any)._harness, undefined, "_harness removed from input");
+	});
+
+	it("_harness stripped even on non-bypass path (force:false)", () => {
+		const event = makeEvent("bash", {
+			command: "grep foo",
+			_harness: { force: false },
+		});
+		new AgentHarness().handleToolCall(event, makeCtxWithUI(true));
+		assert.equal((event.input as any)._harness, undefined, "_harness removed even when force:false");
+	});
+});
+
+// ── Phase 3: Cascade counter semantics ──
+
+describe("AgentHarness — force bypass cascade counter semantics", () => {
+	it("bypassed call inflates cascade counter", () => {
+		const h = new AgentHarness();
+		// 7 passive calls
+		for (let i = 0; i < 7; i++) {
+			h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtxWithUI(true));
+		}
+		// 1 bypassed call (counts as real)
+		h.handleToolCall(
+			makeEvent("bash", { command: "echo hi", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		// Next passive call should trigger cascade (8 effective calls recorded)
+		const r = h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtxWithUI(true));
+		assert.ok(r?.block, "9th call blocks because bypassed 8th inflated counter");
+	});
+
+	it("bypassed call does NOT itself trigger cascade block", () => {
+		const h = new AgentHarness();
+		// 7 passive calls
+		for (let i = 0; i < 7; i++) {
+			h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtxWithUI(true));
+		}
+		// 8th with bypass — bypass gate runs before cascade check, should pass
+		const r = h.handleToolCall(
+			makeEvent("bash", { command: "echo hi", _harness: { force: true } }),
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, null, "8th with force: bypass runs before cascade check → passes");
+	});
+
+	it("Bug 5 invariant preserved — blocked calls still don't inflate counter", () => {
+		const h = new AgentHarness();
+		// Blocked tool mismatch doesn't inflate counter
+		h.handleToolCall(makeEvent("bash", { command: "cat README.md" }), makeCtx());
+		// 1 legit call
+		assert.equal(h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtx()), null);
+		// 6 more = 7 total legit
+		for (let i = 0; i < 6; i++) {
+			h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtx());
+		}
+		// 8th legit call should block
+		assert.ok(h.handleToolCall(makeEvent("bash", { command: "echo hi" }), makeCtx())?.block);
+	});
+});
+
+// ── Phase 4: Integration through dispatch ──
+
+describe("AgentHarness — force bypass through dispatch", () => {
+	it("Force bypass through dispatch", async () => {
+		const api = createMockAPI();
+		agentHarness(api);
+
+		const r = await api.fire(
+			"tool_call",
+			{ toolName: "bash", input: { command: "grep foo", _harness: { force: true } } },
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, undefined, "bypass through dispatch → pass through (undefined)");
+	});
+
+	it("_harness stripped through dispatch — tool never sees it", async () => {
+		const api = createMockAPI();
+		agentHarness(api);
+
+		await api.fire(
+			"tool_call",
+			{
+				toolName: "bash",
+				input: { command: "echo hi", _harness: { force: true } },
+			},
+			makeCtxWithUI(true),
+		);
+
+		// Verify subsequent non-bypass call still works (proves harness state intact)
+		const r2 = await api.fire(
+			"tool_call",
+			{ toolName: "bash", input: { command: "echo hi" } },
+			makeCtxWithUI(true),
+		);
+		assert.equal(r2, undefined, "subsequent call works after _harness strip");
+	});
+
+	it("Annotation through dispatch — bash grep with annotation passes", async () => {
+		const api = createMockAPI();
+		agentHarness(api);
+
+		const r = await api.fire(
+			"tool_call",
+			{ toolName: "bash", input: { command: "grep foo # bypass-harness" } },
+			makeCtxWithUI(true),
+		);
+		assert.equal(r, undefined, "annotation through dispatch → pass through");
+	});
+
+	it("Annotation through dispatch with empty ctx — passes (hasUI defaults true)", async () => {
+		const api = createMockAPI();
+		agentHarness(api);
+
+		const r = await api.fire(
+			"tool_call",
+			{ toolName: "bash", input: { command: "grep foo # bypass-harness" } },
+			{},
+		);
+		// _ctx.hasUI !== false → hasUI defaults to true → passes
+		assert.equal(r, undefined, "annotation with empty ctx → pass through");
 	});
 });

--- a/.pi/extensions/lib/bash-query.ts
+++ b/.pi/extensions/lib/bash-query.ts
@@ -67,6 +67,67 @@ function firstToken(s: string): string | undefined {
  *  - find (handled by isBashSearchOrRead)
  *  - Empty string
  */
+/**
+ * True when a bash command contains a `# bypass-harness` annotation
+ * as a standalone comment token (not inside quoted strings).
+ *
+ * Token-wise parsing: strips single-quoted, double-quoted, and backtick-quoted
+ * segments before scanning for the annotation as a standalone token.
+ * Returns false on any ambiguity (heredocs, line continuations, empty/missing).
+ *
+ * This is a best-effort parser, not a full bash parser. For edge cases
+ * (heredocs, \ continuations), use `input._harness.force` instead.
+ *
+ * @param cmd — raw bash command string (before shell evaluation)
+ * @returns true if the unquoted portion contains standalone `# bypass-harness`
+ */
+export function hasBypassAnnotation(cmd: string): boolean {
+	if (!cmd) return false;
+
+	// Only check the first logical line (before any newline) to avoid
+	// false positives from heredoc content and line continuations.
+	// Heredocs and \ continuations fall through to false per architecture.
+	const firstLine = cmd.split("\n")[0];
+	if (!firstLine) return false;
+
+	// Strip quoted segments to avoid false positives from annotation inside strings
+	let stripped = firstLine;
+
+	// Strip backtick-quoted segments: `...`
+	stripped = stripped.replace(/`[^`]*`/g, "");
+
+	// Strip double-quoted segments: "..."
+	stripped = stripped.replace(/("(?:[^"\\]|\\.)*")/g, "");
+
+	// Strip single-quoted segments: '...'
+	stripped = stripped.replace(/('(?:[^'\\]|\\.)*')/g, "");
+
+	// After stripping quotes, tokenize and look for standalone "# bypass-harness"
+	const tokens = stripped.split(/\s+/);
+	for (let i = 0; i < tokens.length; i++) {
+		if (tokens[i] === "#" && i + 1 < tokens.length && tokens[i + 1] === "bypass-harness") {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * True when a bash command is a search operation that should use
+ * `ripgrep_search` tool instead.
+ *
+ * Returns true for:
+ *  - Standalone grep/rg as first token (backtick variants included)
+ *  - Piped file→grep: file-read command (cat/head/tail/less/more) piped to grep/rg
+ *
+ * Returns false for:
+ *  - grep/rg chained with && or ;
+ *  - Non-file pipe output piped to grep (e.g., ls | grep foo)
+ *  - grep in quoted args, not first token
+ *  - find (handled by isBashSearchOrRead)
+ *  - Empty string
+ */
 export function isBashSearch(cmd: string): boolean {
 	if (!cmd) return false;
 	const lower = cmd.toLowerCase().trim();

--- a/.pi/extensions/lib/bash-query.ts
+++ b/.pi/extensions/lib/bash-query.ts
@@ -19,6 +19,15 @@
 
 const READ_CMDS = ["cat", "tail", "less", "more"] as const;
 
+/**
+ * Import the single source of truth for the bypass annotation literal.
+ * Defined in agent-harness rules module; consumed here as token parts.
+ */
+import { BYPASS_ANNOTATION } from "../agent-harness/lib/harness-rules.ts";
+
+/** Hash token and annotation token derived from BYPASS_ANNOTATION constant. */
+const [HASH_TOKEN, ANNOTATION_TOKEN] = BYPASS_ANNOTATION.split(/\s+/);
+
 /** Bash commands that modify files — triggers read cache invalidation. */
 const FILE_MODIFY_SIGNALS: readonly string[] = Object.freeze([
 	"sed",
@@ -52,21 +61,6 @@ function firstToken(s: string): string | undefined {
 
 // ── Public API ──
 
-/**
- * True when a bash command is a search operation that should use
- * `ripgrep_search` tool instead.
- *
- * Returns true for:
- *  - Standalone grep/rg as first token (backtick variants included)
- *  - Piped file→grep: file-read command (cat/head/tail/less/more) piped to grep/rg
- *
- * Returns false for:
- *  - grep/rg chained with && or ;
- *  - Non-file pipe output piped to grep (e.g., ls | grep foo)
- *  - grep in quoted args, not first token
- *  - find (handled by isBashSearchOrRead)
- *  - Empty string
- */
 /**
  * True when a bash command contains a `# bypass-harness` annotation
  * as a standalone comment token (not inside quoted strings).
@@ -105,7 +99,7 @@ export function hasBypassAnnotation(cmd: string): boolean {
 	// After stripping quotes, tokenize and look for standalone "# bypass-harness"
 	const tokens = stripped.split(/\s+/);
 	for (let i = 0; i < tokens.length; i++) {
-		if (tokens[i] === "#" && i + 1 < tokens.length && tokens[i + 1] === "bypass-harness") {
+		if (tokens[i] === HASH_TOKEN && i + 1 < tokens.length && tokens[i + 1] === ANNOTATION_TOKEN) {
 			return true;
 		}
 	}


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1345

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 21s | 73.9K | 46 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 0s | 23.3K | 14 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 4s | 35.3K | 13 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 0s | 76.2K | 33 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 5m 42s | 76.0K | 43 | minimax-m3 |
| developer | ✓ SUCCESS | 1m 11s | 44.2K | 15 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 19s | 68.5K | 24 | minimax-m3 |

**Total:** 7 agents · 17m 36s · 397.4K tokens · 188 tool calls · 10 failed (5%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1345
Closes #1345