### PR TITLE
feat(#1357): [Bug] Supervisor 'Pipeline Failed / Manual intervention required' drops the actual error message

### DIFF
--- a/.pi/extensions/agent-harness/test/index.test.ts
+++ b/.pi/extensions/agent-harness/test/index.test.ts
@@ -118,7 +118,6 @@ describe("AgentHarness — bash tool mismatch", () => {
 			null,
 		);
 	});
-	});
 
 	it("bash cat with redirect (cat > file) does NOT block", () => {
 		for (const cmd of [

--- a/.pi/extensions/supervisor/pipeline/notifications.ts
+++ b/.pi/extensions/supervisor/pipeline/notifications.ts
@@ -151,31 +151,32 @@ export function sendPipelineError(
 ): void {
 	ctx.ui.notify(`Supervisor error: ${msg}`, "error");
 
+	const overallStatus: "failed" = "failed";
+	const summaryMarkdown = buildPipelineSummary(
+		agentResults,
+		overallStatus,
+		issueNum,
+		issueTitle,
+		config,
+		undefined,
+		undefined,
+		gateFailureHistory,
+		packageSafetyResult,
+		msg,
+	);
+
+	pi.sendMessage({
+		customType: "supervisor-summary",
+		content: summaryMarkdown,
+		display: true,
+	});
+
 	if (agentResults.length > 0) {
-		const overallStatus: "failed" = "failed";
-		const summaryMarkdown = buildPipelineSummary(
-			agentResults,
-			overallStatus,
-			issueNum,
-			issueTitle,
-			config,
-			undefined,
-			undefined,
-			gateFailureHistory,
-			packageSafetyResult,
-		);
-
-		pi.sendMessage({
-			customType: "supervisor-summary",
-			content: summaryMarkdown,
-			display: true,
-		});
-
 		ctx.ui.setStatus("supervisor", ctx.ui.theme.fg("error", buildFailedStatusLine(agentResults)));
+	}
 
-		if (config?.bellOnComplete) {
-			process.stdout.write("\x07");
-		}
+	if (config?.bellOnComplete) {
+		process.stdout.write("\x07");
 	}
 	// Always clear supervisor status on error — avoids stale error text in footer
 	ctx.ui.setStatus("supervisor", undefined);

--- a/.pi/extensions/supervisor/pipeline/output.ts
+++ b/.pi/extensions/supervisor/pipeline/output.ts
@@ -43,6 +43,7 @@ export function buildPipelineSummary(
 	prCreationResult?: PrCreationResult,
 	gateFailureHistory?: string[],
 	packageSafetyResult?: PackageSafetyAuditResult | null,
+	errorMsg?: string,
 ): string {
 	const lines: string[] = [];
 
@@ -161,6 +162,11 @@ export function buildPipelineSummary(
 		if (failedAgent) {
 			lines.push("");
 			lines.push(`**Stopped at:** ${failedAgent.agentName} — agent failed`);
+		}
+		if (errorMsg !== undefined && errorMsg !== "") {
+			const truncated = errorMsg.length > 80 ? errorMsg.slice(0, 80) + "..." : errorMsg;
+			lines.push("");
+			lines.push(`**Error:** ${truncated}`);
 		}
 		lines.push("**Manual intervention required.**");
 	}

--- a/.pi/extensions/supervisor/test/output.test.mts
+++ b/.pi/extensions/supervisor/test/output.test.mts
@@ -717,3 +717,147 @@ describe("buildPipelineSummary — failed tool call rendering", () => {
 		assert.ok(output.includes("· 1 failed"), "failed count present");
 	});
 });
+
+// ─── Tests: buildPipelineSummary — errorMsg in failed branch ────────
+
+describe("buildPipelineSummary — errorMsg in failed branch", () => {
+	const makeAgent = (
+		name: string,
+		status: PipelineAgentResult["status"],
+		tokens: number,
+		duration: number,
+		tools: number,
+	): PipelineAgentResult => ({
+		agentName: name,
+		status,
+		tokenCount: tokens,
+		durationMs: duration,
+		toolCount: tools,
+	});
+
+	const successAgent = (): PipelineAgentResult => makeAgent("developer", "SUCCESS", 5000, 30000, 10);
+	const failedAgent = (): PipelineAgentResult =>
+		makeAgent("auditor", "FAILED", 0, 5000, 0);
+
+	it("failed without FAILED agent — errorMsg produces **Error:** line before manual intervention", () => {
+		const output = buildPipelineSummary(
+			[successAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"Something went wrong in dispatch",
+		);
+		assert.ok(output.includes("**Error:** Something went wrong in dispatch"), "should include error message");
+		assert.ok(output.includes("**Manual intervention required.**"), "should include manual intervention");
+		// Error line should appear before manual intervention
+		const errorIdx = output.indexOf("**Error:**");
+		const manualIdx = output.indexOf("**Manual intervention required.**");
+		assert.ok(errorIdx >= 0 && manualIdx >= 0 && errorIdx < manualIdx, "Error line before manual intervention");
+	});
+
+	it("failed WITH FAILED agent + errorMsg — both Stopped at and Error appear", () => {
+		const output = buildPipelineSummary(
+			[successAgent(), failedAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"Mid-dispatch exception",
+		);
+		assert.ok(output.includes("**Stopped at:** auditor"), "should include Stopped at for failed agent");
+		assert.ok(output.includes("**Error:** Mid-dispatch exception"), "should include error message");
+		// Stopped at should come before Error
+		const stoppedIdx = output.indexOf("**Stopped at:**");
+		const errorIdx = output.indexOf("**Error:**");
+		assert.ok(stoppedIdx >= 0 && errorIdx >= 0 && stoppedIdx < errorIdx, "Stopped at before Error");
+	});
+
+	it("errorMsg omitted (backward compat) — no Error line", () => {
+		const output = buildPipelineSummary(
+			[successAgent(), failedAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+		);
+		assert.ok(!output.includes("**Error:**"), "should not include Error line when errorMsg omitted");
+		assert.ok(output.includes("**Stopped at:** auditor"), "Stopped at still present");
+	});
+
+	it("errorMsg truncated at 80 chars", () => {
+		const longMsg = "x".repeat(100);
+		const output = buildPipelineSummary(
+			[successAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			longMsg,
+		);
+		assert.ok(output.includes("x".repeat(80) + "..."), "should truncate at 80 chars");
+		assert.ok(!output.includes("x".repeat(81)), "chars beyond 80 should not appear");
+	});
+
+	it("errorMsg exactly 80 chars — not truncated", () => {
+		const exactly80 = "a".repeat(80);
+		const output = buildPipelineSummary(
+			[successAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			exactly80,
+		);
+		assert.ok(output.includes(exactly80), "80-char message should not be truncated");
+	});
+
+	it("errorMsg empty string — no Error line", () => {
+		const output = buildPipelineSummary(
+			[successAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			"",
+		);
+		assert.ok(!output.includes("**Error:**"), "should not render Error line for empty string");
+	});
+
+	it("errorMsg with newlines — first line visible in Error line", () => {
+		const multiLineMsg = "First line error\nSecond line\nThird line";
+		const output = buildPipelineSummary(
+			[successAgent()],
+			"failed",
+			42,
+			"Test",
+			defaultConfig,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			multiLineMsg,
+		);
+		assert.ok(output.includes("**Error:** First line error"), "first line of multiline error should appear");
+	});
+});

--- a/.pi/extensions/supervisor/test/pipeline/notifications.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/notifications.test.mts
@@ -395,12 +395,48 @@ describe("buildFailedStatusLine — extracted helper", () => {
 		);
 	});
 
-	it("sendPipelineError with empty agent results → no status set (existing behavior preserved)", async () => {
+	it("sendPipelineError with empty agent results → supervisor-summary still sent with (none) row and errorMsg", async () => {
 		const pi = createMockPi();
 		const ctx = createMockCtx();
-		sendPipelineError(pi, ctx, [], 42, "Test issue", mockConfig as any, "Error message");
-		// sendPipelineError with empty results should not call setStatus with Failed text
+		sendPipelineError(pi, ctx, [], 42, "Test issue", mockConfig as any, "Dispatch error");
+		// Summary should be sent even with empty results
+		const summaryMsg = sentMessages.find((m) => m.customType === "supervisor-summary");
+		assert.ok(summaryMsg, "should send supervisor-summary even with empty agent results");
+		assert.ok(summaryMsg!.content.includes("(none)"), "should show (none) row for empty results");
+		assert.ok(summaryMsg!.content.includes("**Error:** Dispatch error"), "should include error message");
+		// Should not set failed status with empty agent results
 		const failedStatus = statusValues.find((s) => s.includes("Failed at"));
 		assert.ok(!failedStatus, "should NOT set failed status with empty agent results");
+	});
+});
+
+// ─── Tests: sendPipelineError — errorMsg forwarding to summary ────
+
+describe("sendPipelineError — errorMsg in summary", () => {
+	it("non-empty agentResults → errorMsg appears in summary content", async () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		const results: PipelineAgentResult[] = [
+			{ agentName: "developer", status: "SUCCESS", durationMs: 1000, tokenCount: 500, toolCount: 10 },
+		];
+		sendPipelineError(pi, ctx, results, 42, "Test issue", mockConfig as any, "Something broke");
+		const summaryMsg = sentMessages.find((m) => m.customType === "supervisor-summary");
+		assert.ok(summaryMsg, "should send summary message");
+		assert.ok(
+			summaryMsg!.content.includes("**Error:** Something broke"),
+			"error message should appear in summary content",
+		);
+	});
+
+	it("empty agentResults → errorMsg still appears in summary", async () => {
+		const pi = createMockPi();
+		const ctx = createMockCtx();
+		sendPipelineError(pi, ctx, [], 42, "Test issue", mockConfig as any, "Pre-dispatch failure");
+		const summaryMsg = sentMessages.find((m) => m.customType === "supervisor-summary");
+		assert.ok(summaryMsg, "should send summary message with empty results");
+		assert.ok(
+			summaryMsg!.content.includes("**Error:** Pre-dispatch failure"),
+			"error message should appear even with empty results",
+		);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1357

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 36s | 56.7K | 34 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 52s | 18.7K | 12 | minimax-m3 |
| test-designer | ✓ SUCCESS | 49s | 25.7K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 28s | 44.4K | 42 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 33s | 53.0K | 38 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 7m 54s | 51.5K | 32 | minimax-m3 |

**Total:** 6 agents · 17m 11s · 250.0K tokens · 173 tool calls · 7 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1357
Closes #1357

**Gate failures:**
- TypeScript Checkpoint gate failed on run 5 — developer restarted