### PR TITLE
feat(#1363): SIMPLIFY: Severity label chained ternary → lookup object

### DIFF
--- a/.pi/extensions/supervisor/checks/osv-scanner.ts
+++ b/.pi/extensions/supervisor/checks/osv-scanner.ts
@@ -296,6 +296,16 @@ export function bucketBySeverity(findings: OsvFinding[]): OsvScanResult["counts"
 	return counts;
 }
 
+// ─── Severity Label Lookup ────────────────────────────────────────
+
+/** Presentation labels for severity levels with emoji indicators. */
+const SEV_LABELS: Record<string, string> = {
+	CRITICAL: "🔴 Critical",
+	HIGH: "🟠 High",
+	MEDIUM: "🟡 Medium",
+	LOW: "🟢 Low",
+} as const;
+
 // ─── Pure Function: buildVulnContext ───────────────────────────────
 
 /**
@@ -344,11 +354,7 @@ export function buildVulnContext(result: OsvScanResult): string {
 		const sevFindings = result.findings.filter((f) => f.severity === sev);
 		if (sevFindings.length === 0) continue;
 
-		const sevLabel = sev === "CRITICAL" ? "🔴 Critical" :
-			sev === "HIGH" ? "🟠 High" :
-			sev === "MEDIUM" ? "🟡 Medium" :
-			sev === "LOW" ? "🟢 Low" :
-			"⚪ Unknown";
+		const sevLabel = SEV_LABELS[sev] ?? "⚪ Unknown";
 
 		lines.push(`### ${sevLabel}`);
 		lines.push("");

--- a/.pi/extensions/supervisor/test/checks/osv-scanner.test.mts
+++ b/.pi/extensions/supervisor/test/checks/osv-scanner.test.mts
@@ -428,6 +428,30 @@ describe("buildVulnContext()", () => {
 		assert.ok(ctx.includes("C/C++"));
 		assert.ok(ctx.includes("less reliable"));
 	});
+
+	it("UNKNOWN severity finding renders as ⚪ Unknown via ?? fallback", () => {
+		const findings: OsvFinding[] = [
+			{
+				id: "GHSA-unknown-1111-1111",
+				aliases: ["CVE-2024-9999"],
+				severity: "UNKNOWN",
+				packageName: "some-package",
+				packageVersion: "1.0.0",
+				ecosystem: "npm",
+				sourceFile: "/worktrees/test/package-lock.json",
+				summary: "Unspecified vulnerability",
+				isCcCommitMatch: false,
+			},
+		];
+		const result: OsvScanResult = {
+			status: "vulns_found",
+			findings,
+			counts: { critical: 0, high: 0, medium: 0, low: 0, unknown: 1 },
+			ccFindingsFlagged: false,
+		};
+		const ctx = buildVulnContext(result);
+		assert.ok(ctx.includes("⚪ Unknown"), `Expected ⚪ Unknown in context, got: ${ctx}`);
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1363

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 1m 39s | 28.3K | 29 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 28s | 11.3K | 5 | minimax-m3 |
| test-designer | ✓ SUCCESS | 42s | 16.8K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 11s | 32.0K | 17 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 22s | 31.0K | 51 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 13s | 48.3K | 24 | minimax-m3 |

**Total:** 6 agents · 8m 36s · 167.7K tokens · 140 tool calls · 5 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1363
Closes #1363

**Gate failures:**
- TypeScript Checkpoint gate failed on run 4 — developer restarted