### PR TITLE
feat(#1360): Add .initremove file for configurable post-clone cleanup

### DIFF
--- a/.initremove
+++ b/.initremove
@@ -1,0 +1,7 @@
+# Files and directories to remove after clone
+# This file uses gitignore-style pattern syntax.
+# Lines starting with # are comments.
+# Patterns are relative to repository root.
+
+.github/
+test.md

--- a/cmd/cheasee-pi/helpers_test.go
+++ b/cmd/cheasee-pi/helpers_test.go
@@ -369,6 +369,25 @@ func (m *mockGitInitializer) Init(ctx context.Context, workdir string) error {
 }
 
 // ──────────────────────────────────────────────
+// Mock: InitRemover
+// ──────────────────────────────────────────────
+
+type mockInitRemover struct {
+	removeFunc func(workdir string) error
+	called     bool
+	calledWith string
+}
+
+func (m *mockInitRemover) Remove(workdir string) error {
+	m.called = true
+	m.calledWith = workdir
+	if m.removeFunc != nil {
+		return m.removeFunc(workdir)
+	}
+	return nil
+}
+
+// ──────────────────────────────────────────────
 // Compile-time interface checks
 // ──────────────────────────────────────────────
 
@@ -386,4 +405,5 @@ var (
 	_ GitIdentity      = (*mockGitIdentity)(nil)
 	_ SettingsScaffold = (*mockSettingsScaffold)(nil)
 	_ GitInitializer   = (*mockGitInitializer)(nil)
+	_ InitRemover      = (*mockInitRemover)(nil)
 )

--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -52,7 +52,7 @@ type SourceForkInput struct {
 	ForkURL    string
 }
 
-// InitPorts bundles the 12 injected port interfaces used by runInit.
+// InitPorts bundles the injected port interfaces used by runInit.
 type InitPorts struct {
 	Docker    Checker
 	Cfg       Repository
@@ -66,6 +66,7 @@ type InitPorts struct {
 	GitID     GitIdentity
 	Scaffold  SettingsScaffold
 	GitInit   GitInitializer
+	Remover   InitRemover
 }
 
 // InitDeps bundles all dependencies, flags, and callbacks for runInit.
@@ -235,6 +236,8 @@ func runInitE(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
+	initRemover := NewInitRemover()
+
 	return runInit(ctx, InitDeps{
 		Ports: InitPorts{
 			Docker:    dockerChecker,
@@ -249,6 +252,7 @@ func runInitE(cmd *cobra.Command, _ []string) error {
 			GitID:     gitIdentity,
 			Scaffold:  scaffold,
 			GitInit:   gitInit,
+			Remover:   initRemover,
 		},
 		APIKey:           initAPIKey,
 		NoDockerCheck:    initNoDockerCheck,
@@ -394,6 +398,13 @@ func runInit(ctx context.Context, deps InitDeps) error {
 				if !ok {
 					fmt.Fprintln(os.Stderr, "Init cancelled.")
 					return nil
+				}
+			}
+
+			// Post-clone cleanup: remove files listed in .initremove
+			if deps.SourceFork.Mode != ModeSkipFork && deps.Ports.Remover != nil {
+				if err := deps.Ports.Remover.Remove(deps.Workdir); err != nil {
+					return fmt.Errorf("post-clone cleanup: %w", err)
 				}
 			}
 

--- a/cmd/cheasee-pi/init_test.go
+++ b/cmd/cheasee-pi/init_test.go
@@ -42,6 +42,7 @@ func defaultMocks() InitPorts {
 		GitID:    &mockGitIdentity{},
 		Scaffold: &mockSettingsScaffold{},
 		GitInit:  &mockGitInitializer{},
+		Remover:  &mockInitRemover{},
 	}
 }
 
@@ -2359,4 +2360,388 @@ func TestExtract_SkipsPiSubtree(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(workdir, "pi")); err == nil {
 		t.Error("pi/ should not be extracted to workspace")
 	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 5: InitRemover adapter tests
+// ──────────────────────────────────────────────
+
+func TestInitRemove_NoFile(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+
+	if err := r.Remove(workdir); err != nil {
+		t.Fatalf("Remove with no .initremove should return nil: %v", err)
+	}
+}
+
+func TestInitRemove_OnlyComments(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), []byte("# comment\n\n  # another\n"), 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+
+	if err := r.Remove(workdir); err != nil {
+		t.Fatalf("Remove with only comments should return nil: %v", err)
+	}
+}
+
+func TestInitRemove_SingleFile(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte("test.md")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+	target := filepath.Join(workdir, "test.md")
+	if err := os.WriteFile(target, []byte("data"), 0644); err != nil {
+		t.Fatalf("write test.md: %v", err)
+	}
+
+	// Capture stderr
+	stderr := captureStderr(t, func() {
+		if err := r.Remove(workdir); err != nil {
+			t.Fatalf("Remove failed: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Error("test.md should be removed")
+	}
+	if !strings.Contains(stderr, "  ✓ Removed test.md") {
+		t.Errorf("expected removal log line, got: %s", stderr)
+	}
+}
+
+func TestInitRemove_Directory(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte(".github/")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+	dir := filepath.Join(workdir, ".github")
+	if err := os.MkdirAll(filepath.Join(dir, "workflows"), 0755); err != nil {
+		t.Fatalf("create .github dir: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := r.Remove(workdir); err != nil {
+			t.Fatalf("Remove failed: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error(".github/ should be removed")
+	}
+	if !strings.Contains(stderr, "  ✓ Removed .github") {
+		t.Errorf("expected removal log line, got: %s", stderr)
+	}
+}
+
+func TestInitRemove_MultiplePatterns(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte("a.md\nb.md")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "a.md"), []byte("a"), 0644); err != nil {
+		t.Fatalf("write a.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "b.md"), []byte("b"), 0644); err != nil {
+		t.Fatalf("write b.md: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := r.Remove(workdir); err != nil {
+			t.Fatalf("Remove failed: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(filepath.Join(workdir, "a.md")); !os.IsNotExist(err) {
+		t.Error("a.md should be removed")
+	}
+	if _, err := os.Stat(filepath.Join(workdir, "b.md")); !os.IsNotExist(err) {
+		t.Error("b.md should be removed")
+	}
+	if !strings.Contains(stderr, "  ✓ Removed a.md") {
+		t.Errorf("expected a.md removal log line, got: %s", stderr)
+	}
+	if !strings.Contains(stderr, "  ✓ Removed b.md") {
+		t.Errorf("expected b.md removal log line, got: %s", stderr)
+	}
+}
+
+func TestInitRemove_GitmodulesProtected(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte(".gitmodules")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, ".gitmodules"), []byte("[submodule \"test\"]\n\tpath = test\n\turl = https://github.com/x/test.git"), 0644); err != nil {
+		t.Fatalf("write .gitmodules: %v", err)
+	}
+
+	if err := r.Remove(workdir); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(workdir, ".gitmodules")); os.IsNotExist(err) {
+		t.Error(".gitmodules should be preserved")
+	}
+}
+
+func TestInitRemove_NonExistentPattern(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte("nonexistent.md")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+
+	// Should not error — pattern with zero matches is silently skipped
+	if err := r.Remove(workdir); err != nil {
+		t.Fatalf("Remove with non-existent pattern should return nil: %v", err)
+	}
+}
+
+func TestInitRemove_InvalidGlob(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte("unmatched[brackets")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+
+	err := r.Remove(workdir)
+	if err == nil {
+		t.Fatal("expected error for invalid glob syntax")
+	}
+	if !strings.Contains(err.Error(), "invalid glob pattern") {
+		t.Errorf("error should mention invalid glob: %v", err)
+	}
+}
+
+func TestInitRemove_DeepGlob(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte("**/node_modules/")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+	subdir := filepath.Join(workdir, "a", "b", "node_modules")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatalf("create nested node_modules: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "pkg"), []byte("lib"), 0644); err != nil {
+		t.Fatalf("write pkg: %v", err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := r.Remove(workdir); err != nil {
+			t.Fatalf("Remove failed: %v", err)
+		}
+	})
+
+	if _, err := os.Stat(subdir); !os.IsNotExist(err) {
+		t.Error("nested node_modules/ should be removed")
+	}
+	if !strings.Contains(stderr, "  ✓ Removed a/b/node_modules") {
+		t.Errorf("expected removal log line, got: %s", stderr)
+	}
+}
+
+func TestInitRemove_TrailingWhitespaceStripped(t *testing.T) {
+	r := &initRemover{}
+	workdir := t.TempDir()
+	content := []byte("test.md   ")
+	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), content, 0644); err != nil {
+		t.Fatalf("write .initremove: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, "test.md"), []byte("data"), 0644); err != nil {
+		t.Fatalf("write test.md: %v", err)
+	}
+
+	if err := r.Remove(workdir); err != nil {
+		t.Fatalf("Remove failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(workdir, "test.md")); !os.IsNotExist(err) {
+		t.Error("test.md should be removed")
+	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 6: Orchestrator tests for InitRemover
+// ──────────────────────────────────────────────
+
+func TestRunInit_RemoverCalled(t *testing.T) {
+	mockDocker := &mockDockerChecker{
+		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
+	}
+	mockCfg := &mockRepository{}
+
+	removerCalled := false
+	var calledWith string
+	remover := &mockInitRemover{
+		removeFunc: func(workdir string) error {
+			removerCalled = true
+			calledWith = workdir
+			return nil
+		},
+	}
+
+	ports := defaultMocks()
+	ports.Docker = mockDocker
+	ports.Cfg = mockCfg
+	ports.Remover = remover
+
+	workdir := t.TempDir()
+	err := runInit(context.Background(), InitDeps{
+		Ports:          ports,
+		NoDockerCheck:  false,
+		NoGitHub:       false,
+		NoInput:        true,
+		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
+		Workdir:        workdir,
+		ConfirmFn:      mockConfirmFn(true, nil),
+		InputFn:        mockInputFn("", nil),
+	})
+	if err != nil {
+		t.Fatalf("full flow with remover failed: %v", err)
+	}
+	if !removerCalled {
+		t.Error("Remover.Remove should be called")
+	}
+	if calledWith != workdir {
+		t.Errorf("expected workdir %q, got %q", workdir, calledWith)
+	}
+}
+
+func TestRunInit_RemoverNil(t *testing.T) {
+	mockDocker := &mockDockerChecker{
+		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
+	}
+	mockCfg := &mockRepository{}
+
+	ports := defaultMocks()
+	ports.Docker = mockDocker
+	ports.Cfg = mockCfg
+	ports.Remover = nil // explicitly nil
+
+	workdir := t.TempDir()
+	err := runInit(context.Background(), InitDeps{
+		Ports:          ports,
+		NoDockerCheck:  false,
+		NoGitHub:       false,
+		NoInput:        true,
+		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
+		Workdir:        workdir,
+		ConfirmFn:      mockConfirmFn(true, nil),
+		InputFn:        mockInputFn("", nil),
+	})
+	if err != nil {
+		t.Fatalf("flow with nil remover should work: %v", err)
+	}
+}
+
+func TestRunInit_RemoverError(t *testing.T) {
+	mockDocker := &mockDockerChecker{
+		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
+	}
+	mockCfg := &mockRepository{}
+
+	remover := &mockInitRemover{
+		removeFunc: func(workdir string) error {
+			return fmt.Errorf("permission denied: test.md")
+		},
+	}
+
+	ports := defaultMocks()
+	ports.Docker = mockDocker
+	ports.Cfg = mockCfg
+	ports.Remover = remover
+
+	workdir := t.TempDir()
+	err := runInit(context.Background(), InitDeps{
+		Ports:          ports,
+		NoDockerCheck:  false,
+		NoGitHub:       false,
+		NoInput:        true,
+		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
+		Workdir:        workdir,
+		ConfirmFn:      mockConfirmFn(true, nil),
+		InputFn:        mockInputFn("", nil),
+	})
+	if err == nil {
+		t.Fatal("expected error when remover fails")
+	}
+	if !strings.Contains(err.Error(), "post-clone cleanup") {
+		t.Errorf("error should wrap with phase prefix: %v", err)
+	}
+}
+
+func TestRunInit_RemoverSkipFork(t *testing.T) {
+	mockDocker := &mockDockerChecker{
+		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
+	}
+	mockCfg := &mockRepository{}
+
+	removerCalled := false
+	remover := &mockInitRemover{
+		removeFunc: func(workdir string) error {
+			removerCalled = true
+			return nil
+		},
+	}
+
+	ports := defaultMocks()
+	ports.Docker = mockDocker
+	ports.Cfg = mockCfg
+	ports.Remover = remover
+
+	workdir := t.TempDir()
+	err := runInit(context.Background(), InitDeps{
+		Ports:          ports,
+		NoDockerCheck:  false,
+		NoGitHub:       false,
+		NoInput:        true,
+		SourceFork:     SourceForkInput{Mode: ModeSkipFork},
+		Workdir:        workdir,
+		ConfirmFn:      mockConfirmFn(true, nil),
+		InputFn:        mockInputFn("", nil),
+	})
+	if err != nil {
+		t.Fatalf("skip-fork flow failed: %v", err)
+	}
+	if removerCalled {
+		t.Error("Remover.Remove should NOT be called in skip-fork mode (no clone)")
+	}
+}
+
+// captureStderr runs fn and returns any output written to stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+
+	out := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		out <- buf.String()
+	}()
+
+	fn()
+
+	os.Stderr = orig
+	w.Close()
+	return <-out
 }

--- a/cmd/cheasee-pi/initremove.go
+++ b/cmd/cheasee-pi/initremove.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+)
+
+// InitRemover handles post-clone cleanup by reading .initremove
+// and deleting listed files/directories.
+type InitRemover interface {
+	Remove(workdir string) error
+}
+
+type initRemover struct{}
+
+// NewInitRemover creates a new InitRemover adapter.
+func NewInitRemover() InitRemover {
+	return &initRemover{}
+}
+
+// Remove reads .initremove at workdir root, expands gitignore-style patterns,
+// and removes matching files/directories. Returns nil if no .initremove file exists.
+func (r *initRemover) Remove(workdir string) error {
+	path := filepath.Join(workdir, ".initremove")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read .initremove: %w", err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Validate glob syntax
+		if !doublestar.ValidatePattern(line) {
+			return fmt.Errorf("invalid glob pattern in .initremove: %q", line)
+		}
+
+		// Use Glob to find matching files
+		// The pattern is relative to workdir
+		fsys := os.DirFS(workdir)
+		matches, err := doublestar.Glob(fsys, line)
+		if err != nil {
+			return fmt.Errorf("glob pattern %q: %w", line, err)
+		}
+
+		for _, match := range matches {
+			// Protect .gitmodules
+			if match == ".gitmodules" {
+				continue
+			}
+
+			fullPath := filepath.Join(workdir, match)
+
+			// Stat the path — ENOENT = skip silently (no error)
+			if _, err := os.Stat(fullPath); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return fmt.Errorf("stat %q: %w", match, err)
+			}
+
+			if err := os.RemoveAll(fullPath); err != nil {
+				return fmt.Errorf("remove %q: %w", match, err)
+			}
+			fmt.Fprintf(os.Stderr, "  ✓ Removed %s\n", match)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.2 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260205113103-524a6607adb8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-udiff v0.4.1 h1:OEIrQ8maEeDBXQDoGCbbTTXYJMYRCRO1fnodZ12Gv5o=
 github.com/aymanbagabas/go-udiff v0.4.1/go.mod h1:0L9PGwj20lrtmEMeyw4WKJ/TMyDtvAoK9bf2u/mNo3w=
+github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
+github.com/bmatcuk/doublestar/v4 v4.10.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/catppuccin/go v0.2.0 h1:ktBeIrIP42b/8FGiScP9sgrWOss3lw0Z5SktRoithGA=
 github.com/catppuccin/go v0.2.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/colorprofile v0.4.2 h1:BdSNuMjRbotnxHSfxy+PCSa4xAmz7szw70ktAtWRYrY=


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1360

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 39s | 90.2K | 37 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 1s | 32.1K | 21 | minimax-m3 |
| test-designer | ✓ SUCCESS | 1m 11s | 41.6K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 36s | 52.9K | 45 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 35s | 61.9K | 42 | minimax-m3 |

**Total:** 5 agents · 12m 3s · 278.8K tokens · 163 tool calls · 3 failed (2%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1360
Closes #1360