### PR TITLE
feat(#1389): ICA: Local-substitutable CLI/file ports — four single-impl exec/file seams

### DIFF
--- a/cmd/cheasee-pi/auth.go
+++ b/cmd/cheasee-pi/auth.go
@@ -142,7 +142,7 @@ func runAuthAddE(cmd *cobra.Command, args []string) error {
 	}
 
 	// Save to auth.json
-	repo := NewRepository()
+	repo := &fileRepository{}
 	if err := repo.AddProvider(ctx, provider, key); err != nil {
 		return fmt.Errorf("save provider key: %w", err)
 	}
@@ -180,7 +180,7 @@ func runAuthRemoveE(cmd *cobra.Command, args []string) error {
 
 	provider := args[0]
 
-	repo := NewRepository()
+	repo := &fileRepository{}
 	if err := repo.RemoveProvider(ctx, provider); err != nil {
 		return fmt.Errorf("remove provider: %w", err)
 	}
@@ -200,7 +200,7 @@ func runAuthListE(cmd *cobra.Command, _ []string) error {
 		ctx = context.Background()
 	}
 
-	repo := NewRepository()
+	repo := &fileRepository{}
 	providers, err := repo.ListProviders(ctx)
 	if err != nil {
 		return fmt.Errorf("list providers: %w", err)

--- a/cmd/cheasee-pi/build.go
+++ b/cmd/cheasee-pi/build.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/spf13/cobra"
 )
@@ -57,8 +56,7 @@ func runBuildE(cmd *cobra.Command, _ []string) error {
 	}
 
 	if !buildNoDockerCheck {
-		checker := NewChecker(5 * time.Second)
-		if err := runInitDockerCheck(ctx, checker); err != nil {
+		if err := runInitDockerCheck(ctx); err != nil {
 			return err
 		}
 	}

--- a/cmd/cheasee-pi/config.go
+++ b/cmd/cheasee-pi/config.go
@@ -88,28 +88,8 @@ func (a *Auth) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Repository persists and loads Auth config.
-type Repository interface {
-	Load(ctx context.Context) (*Auth, error)
-	Save(ctx context.Context, auth *Auth) error
-	Path() (string, error)
-	// AddProvider adds or updates a provider API key in the auth config.
-	// Other providers and GitHub token are preserved.
-	AddProvider(ctx context.Context, provider, key string) error
-	// RemoveProvider deletes a provider entry from the auth config.
-	RemoveProvider(ctx context.Context, provider string) error
-	// ListProviders returns all configured provider API keys.
-	ListProviders(ctx context.Context) (map[string]string, error)
-}
-
-// fileRepository implements Repository using a JSON file on disk.
+// fileRepository persists and loads Auth config as a JSON file on disk.
 type fileRepository struct{}
-
-// NewRepository creates a file-based Repository that stores auth.json
-// under the OS user config directory (e.g. ~/.config/cheasee-pi/ on Linux).
-func NewRepository() Repository {
-	return &fileRepository{}
-}
 
 func (r *fileRepository) configPath() (string, error) {
 	userConfigDir, err := os.UserConfigDir()

--- a/cmd/cheasee-pi/config_test.go
+++ b/cmd/cheasee-pi/config_test.go
@@ -13,7 +13,7 @@ func TestConfigSave_Load(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{APIKey: "sk-abc123"}
 
 	ctx := context.Background()
@@ -34,7 +34,7 @@ func TestConfigSave_CreatesDirectory(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{APIKey: "sk-abc123"}
 
 	if err := cfg.Save(context.Background(), auth); err != nil {
@@ -56,7 +56,7 @@ func TestConfigSave_ValidJSON(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{APIKey: "sk-abc123"}
 
 	if err := cfg.Save(context.Background(), auth); err != nil {
@@ -86,7 +86,7 @@ func TestConfigSave_AtomicWrite(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{APIKey: "sk-abc123"}
 
 	if err := cfg.Save(context.Background(), auth); err != nil {
@@ -108,7 +108,7 @@ func TestConfigLoad_FileNotExists(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	loaded, err := cfg.Load(context.Background())
 	if err != nil {
 		t.Fatalf("Load of non-existent file should return empty Auth, got error: %v", err)
@@ -130,7 +130,7 @@ func TestConfigLoad_InvalidJSON(t *testing.T) {
 	os.MkdirAll(filepath.Dir(path), 0700)
 	os.WriteFile(path, []byte("{invalid json}"), 0600)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	_, err := cfg.Load(context.Background())
 	if err == nil {
 		t.Fatal("expected error for invalid JSON")
@@ -145,7 +145,7 @@ func TestConfigLoad_PathIsDirectory(t *testing.T) {
 	path := filepath.Join(dir, "cheasee-pi", "auth.json")
 	os.MkdirAll(path, 0700)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	_, err := cfg.Load(context.Background())
 	if err == nil {
 		t.Fatal("expected error when auth.json is a directory")
@@ -156,7 +156,7 @@ func TestConfigPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	path, err := cfg.Path()
 	if err != nil {
 		t.Fatalf("Path() failed: %v", err)
@@ -172,7 +172,7 @@ func TestConfigSave_EmptyAPIKey(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{APIKey: ""}
 
 	if err := cfg.Save(context.Background(), auth); err != nil {
@@ -192,7 +192,7 @@ func TestConfigSave_SpecialChars(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
 	specialKey := `sk-"quoted"-with\backslash and ünicode`
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{APIKey: specialKey}
 
 	if err := cfg.Save(context.Background(), auth); err != nil {

--- a/cmd/cheasee-pi/docker_check.go
+++ b/cmd/cheasee-pi/docker_check.go
@@ -10,11 +10,6 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// Checker checks Docker Engine availability and version.
-type Checker interface {
-	Check(ctx context.Context) (*CheckResult, error)
-}
-
 // CheckResult contains Docker Engine status information.
 type CheckResult struct {
 	Installed bool
@@ -23,21 +18,27 @@ type CheckResult struct {
 	Err       error
 }
 
-// execChecker implements Checker by shelling out to the docker CLI.
-type execChecker struct {
-	timeout time.Duration
+// dockerCheckTimeout is the per-command timeout applied to docker info/version.
+const dockerCheckTimeout = 5 * time.Second
+
+// lookPath is exec.LookPath wrapped for test substitution (the "docker binary
+// present?" branch sits outside the runCommand seam).
+var lookPath = func(file string) (string, error) {
+	return exec.LookPath(file)
 }
 
-// NewChecker creates a Checker with the given per-command timeout.
-func NewChecker(timeout time.Duration) Checker {
-	return &execChecker{timeout: timeout}
-}
-
-func (c *execChecker) Check(ctx context.Context) (*CheckResult, error) {
+// dockerCheck verifies Docker Engine availability and version.
+func dockerCheck(ctx context.Context, timeout time.Duration) (*CheckResult, error) {
 	res := &CheckResult{}
 
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	// 1. Check if docker binary exists.
-	if _, err := exec.LookPath("docker"); err != nil {
+	if _, err := lookPath("docker"); err != nil {
 		res.Installed = false
 		res.Running = false
 		res.Err = fmt.Errorf("docker not found: %w", err)
@@ -46,10 +47,10 @@ func (c *execChecker) Check(ctx context.Context) (*CheckResult, error) {
 	res.Installed = true
 
 	// 2. Check if Docker daemon is responsive.
-	infoCtx, cancel := context.WithTimeout(ctx, c.timeout)
+	infoCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	infoCmd := exec.CommandContext(infoCtx, "docker", "info")
+	infoCmd := runCommandContext(infoCtx, "docker", "info")
 	if err := infoCmd.Run(); err != nil {
 		res.Running = false
 		res.Err = fmt.Errorf("Docker daemon not running: %w", err)
@@ -58,10 +59,10 @@ func (c *execChecker) Check(ctx context.Context) (*CheckResult, error) {
 	res.Running = true
 
 	// 3. Get Docker Engine version.
-	verCtx, cancel2 := context.WithTimeout(ctx, c.timeout)
+	verCtx, cancel2 := context.WithTimeout(ctx, timeout)
 	defer cancel2()
 
-	verCmd := exec.CommandContext(verCtx, "docker", "version", "--format", "{{.Server.Version}}")
+	verCmd := runCommandContext(verCtx, "docker", "version", "--format", "{{.Server.Version}}")
 	output, err := verCmd.Output()
 	if err != nil {
 		res.Err = fmt.Errorf("failed to get Docker Engine version: %w", err)

--- a/cmd/cheasee-pi/docker_check_test.go
+++ b/cmd/cheasee-pi/docker_check_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -98,5 +100,203 @@ func TestDockerVersionParsing(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// ──────────────────────────────────────────────
+// dockerCheck adapter tests (seam-level)
+// ──────────────────────────────────────────────
+
+func TestDockerCheck_NotInstalled(t *testing.T) {
+	saved := lookPath
+	lookPath = func(_ string) (string, error) { return "", fmt.Errorf("executable not found in $PATH") }
+	defer func() { lookPath = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if res.Installed {
+		t.Error("Installed should be false")
+	}
+	if res.Running {
+		t.Error("Running should be false")
+	}
+	if !strings.Contains(res.Err.Error(), "docker not found") {
+		t.Errorf("Err should mention docker not found: %v", res.Err)
+	}
+}
+
+func TestDockerCheck_DaemonNotRunning(t *testing.T) {
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+		return &mockCmd{runFn: func() error { return fmt.Errorf("Cannot connect to the Docker daemon") }}
+	}
+	defer func() { runCommandContext = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if !res.Installed {
+		t.Error("Installed should be true")
+	}
+	if res.Running {
+		t.Error("Running should be false")
+	}
+	if !strings.Contains(res.Err.Error(), "Docker daemon not running") {
+		t.Errorf("Err should mention daemon not running: %v", res.Err)
+	}
+}
+
+func TestDockerCheck_VersionOutputError(t *testing.T) {
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return nil, fmt.Errorf("connection refused") }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if !strings.Contains(res.Err.Error(), "failed to get Docker Engine version") {
+		t.Errorf("Err should mention version fetch failure: %v", res.Err)
+	}
+}
+
+func TestDockerCheck_EmptyVersion(t *testing.T) {
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("  \n"), nil }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if res.Version != "" {
+		t.Errorf("expected empty Version, got %q", res.Version)
+	}
+	if !strings.Contains(res.Err.Error(), "not reachable") {
+		t.Errorf("Err should mention not reachable: %v", res.Err)
+	}
+}
+
+func TestDockerCheck_TooOld(t *testing.T) {
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("23.0.0"), nil }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if !strings.Contains(res.Err.Error(), "too old, need >= 24.0.0") {
+		t.Errorf("Err should mention minimum version: %v", res.Err)
+	}
+}
+
+func TestDockerCheck_InvalidVersion(t *testing.T) {
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("not-a-version"), nil }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if !strings.Contains(res.Err.Error(), "invalid Docker Engine version") {
+		t.Errorf("Err should mention invalid version: %v", res.Err)
+	}
+}
+
+func TestDockerCheck_Healthy(t *testing.T) {
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("25.0.0-rc1"), nil }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
+	if err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if !res.Installed || !res.Running {
+		t.Errorf("expected installed+running, got %+v", res)
+	}
+	if res.Version != "25.0.0-rc1" {
+		t.Errorf("expected Version 25.0.0-rc1, got %q", res.Version)
+	}
+	if res.Err != nil {
+		t.Errorf("expected nil Err, got %v", res.Err)
+	}
+}
+
+func TestDockerCheck_ArgsCaptured(t *testing.T) {
+	stubDockerLookPath(t)
+	var infoArgs, versionArgs []string
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "info" {
+			infoArgs = arg
+			return &mockCmd{}
+		}
+		versionArgs = arg
+		return &mockCmd{outputFn: func() ([]byte, error) { return []byte("24.0.9"), nil }}
+	}
+	defer func() { runCommandContext = saved }()
+
+	if _, err := dockerCheck(context.Background(), dockerCheckTimeout); err != nil {
+		t.Fatalf("dockerCheck returned error: %v", err)
+	}
+	if strings.Join(infoArgs, " ") != "info" {
+		t.Errorf("Run() should get (docker, info), got %v", infoArgs)
+	}
+	wantVersion := strings.Join([]string{"version", "--format", "{{.Server.Version}}"}, " ")
+	if strings.Join(versionArgs, " ") != wantVersion {
+		t.Errorf("Output() should get %q, got %v", wantVersion, versionArgs)
+	}
+}
+
+func TestDockerCheck_CtxCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	res, err := dockerCheck(ctx, dockerCheckTimeout)
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+	if !strings.Contains(err.Error(), "context") {
+		t.Errorf("error should mention context: %v", err)
+	}
+	if res != nil {
+		t.Errorf("expected nil result for cancelled context, got %+v", res)
 	}
 }

--- a/cmd/cheasee-pi/git_init.go
+++ b/cmd/cheasee-pi/git_init.go
@@ -4,35 +4,12 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 )
 
-// ──────────────────────────────────────────────
-// Port: GitInitializer
-// ──────────────────────────────────────────────
-
-// GitInitializer creates a git repository in the given working directory.
-// It is idempotent: calling Init on a directory that already has a .git
-// directory returns nil (no error).
-type GitInitializer interface {
-	Init(ctx context.Context, workdir string) error
-}
-
-// ──────────────────────────────────────────────
-// Adapter: osGitInitializer
-// ──────────────────────────────────────────────
-
-type osGitInitializer struct{}
-
-// NewGitInitializer creates a GitInitializer that shells out to git init.
-func NewGitInitializer() GitInitializer {
-	return &osGitInitializer{}
-}
-
-// Init runs git init in the given workdir. It is a no-op if .git already
-// exists. The adapter respects context cancellation.
-func (g *osGitInitializer) Init(ctx context.Context, workdir string) error {
+// gitInit runs git init in the given workdir. It is a no-op if .git already
+// exists. It respects context cancellation.
+func gitInit(ctx context.Context, workdir string) error {
 	// Idempotent: skip if .git already exists.
 	if _, err := os.Stat(filepath.Join(workdir, ".git")); err == nil {
 		return nil
@@ -44,7 +21,7 @@ func (g *osGitInitializer) Init(ctx context.Context, workdir string) error {
 	default:
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "init", workdir)
+	cmd := runCommandContext(ctx, "git", "init", workdir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("git init %s: %s: %w", workdir, string(output), err)

--- a/cmd/cheasee-pi/github.go
+++ b/cmd/cheasee-pi/github.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -43,11 +42,11 @@ type Submodule struct {
 	URL  string
 }
 
-// Cloner handles git clone and submodule operations.
-type Cloner interface {
-	Clone(ctx context.Context, token, repoURL, destPath string) error
-	// CloneWorktree clones bare and creates a worktree at workdir.
-	CloneWorktree(ctx context.Context, token, repoURL, workdir string) error
+// submoduleOps performs submodule operations on a local git checkout.
+// The go-git backed ops run directly against the working tree; AddSubmodule
+// shells out to git. Kept as a narrow parameter so runInit orchestration
+// tests can inject a fake — there is no second production adapter.
+type submoduleOps interface {
 	// ListSubmodules returns all submodules defined in .gitmodules.
 	ListSubmodules(ctx context.Context, repoPath string) ([]Submodule, error)
 	// SetSubmoduleURL rewrites the URL for a named submodule in .gitmodules
@@ -232,17 +231,11 @@ func (c *httpGitHubClient) WaitForkReady(ctx context.Context, token, owner, repo
 }
 
 // ──────────────────────────────────────────────
-// Cloner: goGitCloner
+// Clone/submodule ops: free funcs + gitSubmoduleOps (no port)
 // ──────────────────────────────────────────────
 
-type goGitCloner struct{}
-
-// NewCloner creates a git cloner backed by go-git.
-func NewCloner() Cloner {
-	return &goGitCloner{}
-}
-
-func (cl *goGitCloner) Clone(ctx context.Context, token, repoURL, destPath string) error {
+// gitClone clones a repo with go-git using HTTPS BasicAuth token auth.
+func gitClone(ctx context.Context, token, repoURL, destPath string) error {
 	auth := &goGitHTTP.BasicAuth{
 		Username: "",     // Must be empty for GitHub token auth
 		Password: token,
@@ -258,8 +251,8 @@ func (cl *goGitCloner) Clone(ctx context.Context, token, repoURL, destPath strin
 	return nil
 }
 
-// CloneWorktree clones bare and creates a worktree.
-func (cl *goGitCloner) CloneWorktree(ctx context.Context, token, repoURL, workdir string) error {
+// gitCloneWorktree clones bare and creates a worktree.
+func gitCloneWorktree(ctx context.Context, token, repoURL, workdir string) error {
 	sourceOwner, sourceRepoName := ParseGitHubURL(repoURL)
 	if sourceOwner == "" || sourceRepoName == "" {
 		return fmt.Errorf("invalid repo URL: %s", repoURL)
@@ -277,14 +270,14 @@ func (cl *goGitCloner) CloneWorktree(ctx context.Context, token, repoURL, workdi
 	}
 
 	// Clone bare
-	cmd := exec.CommandContext(ctx, "git", "clone", "--bare", authRepoURL, bareDir)
+	cmd := runCommandContext(ctx, "git", "clone", "--bare", authRepoURL, bareDir)
 	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("bare clone failed: %w\n%s", err, string(out))
+		return fmt.Errorf("bare clone failed: %w\n%s", err, redactToken(string(out), token))
 	}
 
 	// Detect default branch
 	defaultBranch := "main"
-	branchCmd := exec.CommandContext(ctx, "git", "--git-dir", bareDir, "symbolic-ref", "refs/remotes/origin/HEAD")
+	branchCmd := runCommandContext(ctx, "git", "--git-dir", bareDir, "symbolic-ref", "refs/remotes/origin/HEAD")
 	if out, err := branchCmd.Output(); err == nil {
 		ref := strings.TrimSpace(string(out))
 		if parts := strings.Split(ref, "/"); len(parts) > 0 {
@@ -295,16 +288,39 @@ func (cl *goGitCloner) CloneWorktree(ctx context.Context, token, repoURL, workdi
 	}
 
 	// Create worktree
-	wtCmd := exec.CommandContext(ctx, "git", "--git-dir", bareDir, "worktree", "add", "--detach", workdir, defaultBranch)
+	wtCmd := runCommandContext(ctx, "git", "--git-dir", bareDir, "worktree", "add", "--detach", workdir, defaultBranch)
 	if out, err := wtCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("worktree add failed: %w\n%s", err, string(out))
+		return fmt.Errorf("worktree add failed: %w\n%s", err, redactToken(string(out), token))
 	}
 
 	fmt.Fprintf(os.Stderr, "  ✓ Cloned (bare + worktree) to %s\n", workdir)
 	return nil
 }
 
-func (cl *goGitCloner) ListSubmodules(ctx context.Context, repoPath string) ([]Submodule, error) {
+// redactToken replaces occurrences of token in text with "***" so CLI error
+// output never echoes the credential. No-op for an empty token.
+func redactToken(text, token string) string {
+	if token == "" {
+		return text
+	}
+	return strings.ReplaceAll(text, token, "***")
+}
+
+// gitAddSubmodule runs git submodule add for a new submodule.
+func gitAddSubmodule(ctx context.Context, repoPath, name, url string) error {
+	cmd := runCommandContext(ctx, "git", "submodule", "add", url, name)
+	cmd.SetDir(repoPath)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git submodule add %s %s: %w\nOutput: %s", url, name, err, string(output))
+	}
+	return nil
+}
+
+// gitSubmoduleOps implements submoduleOps backed by go-git.
+type gitSubmoduleOps struct{}
+
+func (gitSubmoduleOps) ListSubmodules(ctx context.Context, repoPath string) ([]Submodule, error) {
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return nil, fmt.Errorf("open repo: %w", err)
@@ -332,7 +348,7 @@ func (cl *goGitCloner) ListSubmodules(ctx context.Context, repoPath string) ([]S
 	return result, nil
 }
 
-func (cl *goGitCloner) SetSubmoduleURL(ctx context.Context, repoPath, name, newURL string) error {
+func (gitSubmoduleOps) SetSubmoduleURL(ctx context.Context, repoPath, name, newURL string) error {
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return fmt.Errorf("open repo: %w", err)
@@ -382,7 +398,7 @@ func (cl *goGitCloner) SetSubmoduleURL(ctx context.Context, repoPath, name, newU
 	return nil
 }
 
-func (cl *goGitCloner) InitAndUpdateSubmodules(ctx context.Context, repoPath string) error {
+func (gitSubmoduleOps) InitAndUpdateSubmodules(ctx context.Context, repoPath string) error {
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return fmt.Errorf("open repo: %w", err)
@@ -412,14 +428,8 @@ func (cl *goGitCloner) InitAndUpdateSubmodules(ctx context.Context, repoPath str
 	return nil
 }
 
-func (cl *goGitCloner) AddSubmodule(ctx context.Context, repoPath, name, url string) error {
-	cmd := exec.CommandContext(ctx, "git", "submodule", "add", url, name)
-	cmd.Dir = repoPath
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git submodule add %s %s: %w\nOutput: %s", url, name, err, string(output))
-	}
-	return nil
+func (gitSubmoduleOps) AddSubmodule(ctx context.Context, repoPath, name, url string) error {
+	return gitAddSubmodule(ctx, repoPath, name, url)
 }
 
 // ParseGitHubURL parses "owner/repo" from various GitHub URL formats.

--- a/cmd/cheasee-pi/github_test.go
+++ b/cmd/cheasee-pi/github_test.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -212,5 +215,283 @@ func TestParseGitHubURL_Empty(t *testing.T) {
 	owner, repo := ParseGitHubURL("")
 	if owner != "" || repo != "" {
 		t.Errorf("expected empty/empty, got %s/%s", owner, repo)
+	}
+}
+
+// ──────────────────────────────────────────────
+// gitCloneWorktree / gitAddSubmodule / redactToken (runner-seam) tests
+// ──────────────────────────────────────────────
+
+func TestRedactToken_ReplacesOccurrences(t *testing.T) {
+	got := redactToken("fatal: https://oauth2:gho_secret@github.com/a/b.git\nremote: gho_secret", "gho_secret")
+	if strings.Contains(got, "gho_secret") {
+		t.Errorf("token should be redacted: %q", got)
+	}
+	if !strings.Contains(got, "***") {
+		t.Errorf("redaction marker missing: %q", got)
+	}
+}
+
+func TestRedactToken_EmptyTokenNoOp(t *testing.T) {
+	text := "no token here"
+	if got := redactToken(text, ""); got != text {
+		t.Errorf("empty token should no-op, got %q", got)
+	}
+}
+
+func TestGitCloneWorktree_InvalidURL(t *testing.T) {
+	saved := runCommandContext
+	called := false
+	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+		called = true
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitCloneWorktree(context.Background(), "gho_token", "not-a-url", t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+	if !strings.Contains(err.Error(), "invalid repo URL") {
+		t.Errorf("error should mention invalid repo URL: %v", err)
+	}
+	if called {
+		t.Error("seam should not be called for invalid URL")
+	}
+}
+
+func TestGitCloneWorktree_HappyPath(t *testing.T) {
+	var calls [][]string
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		calls = append(calls, arg)
+		if arg[0] == "clone" {
+			return &mockCmd{}
+		}
+		if len(arg) > 2 && arg[2] == "symbolic-ref" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("refs/remotes/origin/master"), nil }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	workdir := filepath.Join(t.TempDir(), "repo")
+	err := gitCloneWorktree(context.Background(), "gho_token", "https://github.com/owner/repo.git", workdir)
+	if err != nil {
+		t.Fatalf("gitCloneWorktree failed: %v", err)
+	}
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 seam calls, got %d: %v", len(calls), calls)
+	}
+	// bare clone: git clone --bare <authURL> <parent>/.bare
+	clone := calls[0]
+	if strings.Join(clone[:2], " ") != "clone --bare" {
+		t.Errorf("expected clone --bare, got %v", clone)
+	}
+	if clone[2] != "https://oauth2:gho_token@github.com/owner/repo.git" {
+		t.Errorf("expected tokenized URL, got %q", clone[2])
+	}
+	if !strings.HasSuffix(clone[3], "/.bare") {
+		t.Errorf("expected .bare dest, got %q", clone[3])
+	}
+	// worktree add: git --git-dir <bare> worktree add --detach <workdir> master
+	wt := calls[2]
+	if strings.Join(wt[2:5], " ") != "worktree add --detach" {
+		t.Errorf("expected worktree add --detach, got %v", wt)
+	}
+	if wt[5] != workdir || wt[6] != "master" {
+		t.Errorf("expected worktree add %s master, got %v", workdir, wt)
+	}
+}
+
+func TestGitCloneWorktree_DefaultBranchFallback(t *testing.T) {
+	var worktreeArgs []string
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 2 && arg[2] == "symbolic-ref" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return nil, fmt.Errorf("HEAD not found") }}
+		}
+		if arg[0] == "clone" {
+			return &mockCmd{}
+		}
+		worktreeArgs = arg
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitCloneWorktree(context.Background(), "gho_token", "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo"))
+	if err != nil {
+		t.Fatalf("gitCloneWorktree failed: %v", err)
+	}
+	if len(worktreeArgs) == 0 || worktreeArgs[len(worktreeArgs)-1] != "main" {
+		t.Errorf("expected fallback branch 'main', got %v", worktreeArgs)
+	}
+}
+
+func TestGitCloneWorktree_BareCloneError(t *testing.T) {
+	const token = "gho_secret_token"
+	// Output echoes the token as git would when echoing the URL.
+	output := []byte("fatal: unable to access 'https://oauth2:" + token + "@github.com/owner/repo.git/': Could not resolve host")
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+		return &mockCmd{combinedFn: func() ([]byte, error) { return output, fmt.Errorf("exit status 128") }}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitCloneWorktree(context.Background(), token, "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "bare clone failed") {
+		t.Errorf("error should mention bare clone failed: %v", err)
+	}
+	if strings.Contains(err.Error(), token) {
+		t.Errorf("token must be redacted from error: %v", err)
+	}
+}
+
+func TestGitCloneWorktree_WorktreeAddError(t *testing.T) {
+	saved := runCommandContext
+	step := 0
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		step++
+		if step == 1 { // bare clone
+			return &mockCmd{}
+		}
+		if len(arg) > 2 && arg[2] == "symbolic-ref" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("refs/remotes/origin/main"), nil }}
+		}
+		return &mockCmd{combinedFn: func() ([]byte, error) { return []byte("fatal: worktree error"), fmt.Errorf("exit status 128") }}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitCloneWorktree(context.Background(), "gho_token", "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "worktree add failed") {
+		t.Errorf("error should mention worktree add failed: %v", err)
+	}
+}
+
+func TestGitAddSubmodule_CapturesArgsAndDir(t *testing.T) {
+	var capturedArgs []string
+	var captured *mockCmd
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		capturedArgs = arg
+		captured = &mockCmd{}
+		return captured
+	}
+	defer func() { runCommandContext = saved }()
+
+	repoPath := t.TempDir()
+	if err := gitAddSubmodule(context.Background(), repoPath, "flask_blogs", "https://github.com/user/flask_blogs"); err != nil {
+		t.Fatalf("gitAddSubmodule failed: %v", err)
+	}
+	want := strings.Join([]string{"submodule", "add", "https://github.com/user/flask_blogs", "flask_blogs"}, " ")
+	if strings.Join(capturedArgs, " ") != want {
+		t.Errorf("expected (%s), got %v", want, capturedArgs)
+	}
+	if captured.dir != repoPath {
+		t.Errorf("expected Dir=%q, got %q", repoPath, captured.dir)
+	}
+}
+
+func TestGitAddSubmodule_ErrorWrapsOutput(t *testing.T) {
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+		return &mockCmd{combinedFn: func() ([]byte, error) {
+			return []byte("fatal: path 'x' is already tracked"), fmt.Errorf("exit status 128")
+		}}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitAddSubmodule(context.Background(), t.TempDir(), "x", "https://github.com/a/b.git")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "git submodule add") {
+		t.Errorf("error should mention git submodule add: %v", err)
+	}
+	if !strings.Contains(err.Error(), "already tracked") {
+		t.Errorf("error should include output: %v", err)
+	}
+}
+
+// ──────────────────────────────────────────────
+// go-git backed ops (no git binary needed for error paths)
+// ──────────────────────────────────────────────
+
+func TestGitListSubmodules_NotARepo(t *testing.T) {
+	_, err := (gitSubmoduleOps{}).ListSubmodules(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for non-repo dir")
+	}
+	if !strings.Contains(err.Error(), "open repo") {
+		t.Errorf("error should mention open repo: %v", err)
+	}
+}
+
+func TestGitSetSubmoduleURL_NotARepo(t *testing.T) {
+	err := (gitSubmoduleOps{}).SetSubmoduleURL(context.Background(), t.TempDir(), "x", "https://a/b.git")
+	if err == nil {
+		t.Fatal("expected error for non-repo dir")
+	}
+	if !strings.Contains(err.Error(), "open repo") {
+		t.Errorf("error should mention open repo: %v", err)
+	}
+}
+
+func TestGitInitAndUpdateSubmodules_NotARepo(t *testing.T) {
+	err := (gitSubmoduleOps{}).InitAndUpdateSubmodules(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for non-repo dir")
+	}
+	if !strings.Contains(err.Error(), "open repo") {
+		t.Errorf("error should mention open repo: %v", err)
+	}
+}
+
+func TestGitClone_LocalBareRepo(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	src := t.TempDir()
+	runGit := func(args ...string) error {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = src
+		return cmd.Run()
+	}
+	if err := runGit("init", "-q"); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "file.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := runGit("add", "file.txt"); err != nil {
+		t.Fatalf("git add: %v", err)
+	}
+	if err := runGit("-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-q", "-m", "init"); err != nil {
+		t.Fatalf("git commit: %v", err)
+	}
+
+	// Bogus token: go-git BasicAuth is ignored for local paths, clone succeeds.
+	dest := filepath.Join(t.TempDir(), "clone")
+	if err := gitClone(context.Background(), "gho_bogus_token", src, dest); err != nil {
+		t.Fatalf("gitClone failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "file.txt")); err != nil {
+		t.Errorf("expected cloned file: %v", err)
+	}
+}
+
+func TestGitClone_UnreadableSource(t *testing.T) {
+	err := gitClone(context.Background(), "gho_token", filepath.Join(t.TempDir(), "nonexistent"), filepath.Join(t.TempDir(), "clone"))
+	if err == nil {
+		t.Fatal("expected error for unreadable source")
+	}
+	if !strings.Contains(err.Error(), "clone failed") {
+		t.Errorf("error should mention clone failed: %v", err)
 	}
 }

--- a/cmd/cheasee-pi/helpers_test.go
+++ b/cmd/cheasee-pi/helpers_test.go
@@ -2,102 +2,11 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/cli/oauth/api"
 	"github.com/cli/oauth/device"
 )
-
-// ──────────────────────────────────────────────
-// Mock: Docker
-// ──────────────────────────────────────────────
-
-// mockDockerChecker simulates Docker check results without real Docker.
-type mockDockerChecker struct {
-	result *CheckResult
-	err    error
-}
-
-func (m *mockDockerChecker) Check(_ context.Context) (*CheckResult, error) {
-	return m.result, m.err
-}
-
-// mockCheckerCtx wraps a Checker but returns context.Canceled when context is done.
-type mockCheckerCtx struct {
-	orig Checker
-}
-
-func (m *mockCheckerCtx) Check(ctx context.Context) (*CheckResult, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
-		return m.orig.Check(ctx)
-	}
-}
-
-// ──────────────────────────────────────────────
-// Mock: Repository
-// ──────────────────────────────────────────────
-
-// mockRepository implements Repository for testing.
-type mockRepository struct {
-	saved          bool
-	savedKey       string
-	savedProvider  string
-	savedAuth      *Auth
-	saveErr        error
-	loadErr        error
-	loadAuth       *Auth
-	path           string
-	providers      map[string]string // returned by ListProviders
-}
-
-func (m *mockRepository) Load(_ context.Context) (*Auth, error) {
-	if m.loadErr != nil {
-		return nil, m.loadErr
-	}
-	if m.loadAuth != nil {
-		return m.loadAuth, nil
-	}
-	return &Auth{}, nil
-}
-
-func (m *mockRepository) Save(_ context.Context, auth *Auth) error {
-	if m.saveErr != nil {
-		return m.saveErr
-	}
-	m.saved = true
-	m.savedKey = auth.APIKey
-	m.savedProvider = auth.Provider
-	m.savedAuth = auth
-	return nil
-}
-
-func (m *mockRepository) Path() (string, error) {
-	if m.path != "" {
-		return m.path, nil
-	}
-	return "/mock/path/auth.json", nil
-}
-
-func (m *mockRepository) AddProvider(_ context.Context, provider, key string) error {
-	m.savedProvider = provider
-	m.savedKey = key
-	return nil
-}
-
-func (m *mockRepository) RemoveProvider(_ context.Context, provider string) error {
-	return nil
-}
-
-func (m *mockRepository) ListProviders(_ context.Context) (map[string]string, error) {
-	if m.providers != nil {
-		return m.providers, nil
-	}
-	return nil, nil
-}
 
 // ──────────────────────────────────────────────
 // Mock: Authenticator
@@ -160,44 +69,26 @@ func (m *mockGitHubClient) WaitForkReady(ctx context.Context, token, owner, repo
 }
 
 // ──────────────────────────────────────────────
-// Mock: Cloner
+// Mock: submoduleOps (go-git submodule ops)
 // ──────────────────────────────────────────────
 
-type mockCloner struct {
-	cloneFunc                func(ctx context.Context, token, repoURL, destPath string) error
-	cloneWorktreeFunc        func(ctx context.Context, token, repoURL, workdir string) error
-	listSubmodulesFunc       func(ctx context.Context, repoPath string) ([]Submodule, error)
-	setSubmoduleURLFunc      func(ctx context.Context, repoPath, name, newURL string) error
-	initAndUpdateSubmodFunc  func(ctx context.Context, repoPath string) error
-	addSubmoduleFunc         func(ctx context.Context, repoPath, name, url string) error
+type mockSubmoduleOps struct {
+	listSubmodulesFunc      func(ctx context.Context, repoPath string) ([]Submodule, error)
+	setSubmoduleURLFunc     func(ctx context.Context, repoPath, name, newURL string) error
+	initAndUpdateSubmodFunc func(ctx context.Context, repoPath string) error
+	addSubmoduleFunc        func(ctx context.Context, repoPath, name, url string) error
 
 	// Tracking fields for test assertions
-	listSubmodulesCalled    bool
-	setSubmoduleURLCalled   bool
-	setSubmoduleURLName     string
-	setSubmoduleURLURL      string
-	setSubmoduleURLCalls    []struct{ Name, URL string }
-	initAndUpdateCalled     bool
-	addSubmoduleCalls       []struct{ Name, URL string }
+	listSubmodulesCalled  bool
+	setSubmoduleURLCalled bool
+	setSubmoduleURLName   string
+	setSubmoduleURLURL    string
+	setSubmoduleURLCalls  []struct{ Name, URL string }
+	initAndUpdateCalled   bool
+	addSubmoduleCalls     []struct{ Name, URL string }
 }
 
-func (m *mockCloner) Clone(ctx context.Context, token, repoURL, destPath string) error {
-	if m.cloneFunc != nil {
-		return m.cloneFunc(ctx, token, repoURL, destPath)
-	}
-	return nil
-}
-
-func (m *mockCloner) CloneWorktree(ctx context.Context, token, repoURL, workdir string) error {
-	if m.cloneWorktreeFunc != nil {
-		return m.cloneWorktreeFunc(ctx, token, repoURL, workdir)
-	}
-	// Create the workdir so tests that check for it pass
-	os.MkdirAll(workdir, 0755)
-	return nil
-}
-
-func (m *mockCloner) ListSubmodules(ctx context.Context, repoPath string) ([]Submodule, error) {
+func (m *mockSubmoduleOps) ListSubmodules(ctx context.Context, repoPath string) ([]Submodule, error) {
 	m.listSubmodulesCalled = true
 	if m.listSubmodulesFunc != nil {
 		return m.listSubmodulesFunc(ctx, repoPath)
@@ -205,7 +96,7 @@ func (m *mockCloner) ListSubmodules(ctx context.Context, repoPath string) ([]Sub
 	return nil, nil
 }
 
-func (m *mockCloner) SetSubmoduleURL(ctx context.Context, repoPath, name, newURL string) error {
+func (m *mockSubmoduleOps) SetSubmoduleURL(ctx context.Context, repoPath, name, newURL string) error {
 	m.setSubmoduleURLCalled = true
 	m.setSubmoduleURLName = name
 	m.setSubmoduleURLURL = newURL
@@ -216,7 +107,7 @@ func (m *mockCloner) SetSubmoduleURL(ctx context.Context, repoPath, name, newURL
 	return nil
 }
 
-func (m *mockCloner) InitAndUpdateSubmodules(ctx context.Context, repoPath string) error {
+func (m *mockSubmoduleOps) InitAndUpdateSubmodules(ctx context.Context, repoPath string) error {
 	m.initAndUpdateCalled = true
 	if m.initAndUpdateSubmodFunc != nil {
 		return m.initAndUpdateSubmodFunc(ctx, repoPath)
@@ -224,7 +115,7 @@ func (m *mockCloner) InitAndUpdateSubmodules(ctx context.Context, repoPath strin
 	return nil
 }
 
-func (m *mockCloner) AddSubmodule(ctx context.Context, repoPath, name, url string) error {
+func (m *mockSubmoduleOps) AddSubmodule(ctx context.Context, repoPath, name, url string) error {
 	m.addSubmoduleCalls = append(m.addSubmoduleCalls, struct{ Name, URL string }{name, url})
 	if m.addSubmoduleFunc != nil {
 		return m.addSubmoduleFunc(ctx, repoPath, name, url)
@@ -246,7 +137,6 @@ func (m *mockExtractor) Extract(ctx context.Context, destDir string) error {
 	}
 	return nil
 }
-
 
 // ──────────────────────────────────────────────
 // Mock: EnvRenderer
@@ -354,21 +244,6 @@ func (m *mockSettingsScaffold) Scaffold(ctx context.Context, workdir string, val
 }
 
 // ──────────────────────────────────────────────
-// Mock: GitInitializer
-// ──────────────────────────────────────────────
-
-type mockGitInitializer struct {
-	initFunc func(ctx context.Context, workdir string) error
-}
-
-func (m *mockGitInitializer) Init(ctx context.Context, workdir string) error {
-	if m.initFunc != nil {
-		return m.initFunc(ctx, workdir)
-	}
-	return nil
-}
-
-// ──────────────────────────────────────────────
 // Mock: InitRemover
 // ──────────────────────────────────────────────
 
@@ -392,18 +267,14 @@ func (m *mockInitRemover) Remove(workdir string) error {
 // ──────────────────────────────────────────────
 
 var (
-	_ Checker          = (*mockDockerChecker)(nil)
-	_ Checker          = (*mockCheckerCtx)(nil)
-	_ Repository       = (*mockRepository)(nil)
 	_ Authenticator    = (*mockAuthenticator)(nil)
 	_ GitHubClient     = (*mockGitHubClient)(nil)
-	_ Cloner           = (*mockCloner)(nil)
+	_ submoduleOps     = (*mockSubmoduleOps)(nil)
 	_ Extractor        = (*mockExtractor)(nil)
 	_ EnvRenderer      = (*mockEnvRenderer)(nil)
 	_ WorkingDirProbe  = (*mockWorkingDirProbe)(nil)
 	_ UIDResolver      = (*mockUIDResolver)(nil)
 	_ GitIdentity      = (*mockGitIdentity)(nil)
 	_ SettingsScaffold = (*mockSettingsScaffold)(nil)
-	_ GitInitializer   = (*mockGitInitializer)(nil)
 	_ InitRemover      = (*mockInitRemover)(nil)
 )

--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -53,25 +53,24 @@ type SourceForkInput struct {
 }
 
 // InitPorts bundles the injected port interfaces used by runInit.
+// The docker/git CLI seams (dockerCheck, gitInit, gitCloneWorktree) and the
+// auth config (fileRepository) are package-level now and need no injection.
 type InitPorts struct {
-	Docker    Checker
-	Cfg       Repository
 	Auth      Authenticator
 	GitHub    GitHubClient
-	Cloner    Cloner
 	Extractor Extractor
 	Env       EnvRenderer
 	Probe     WorkingDirProbe
 	UID       UIDResolver
 	GitID     GitIdentity
 	Scaffold  SettingsScaffold
-	GitInit   GitInitializer
 	Remover   InitRemover
 }
 
 // InitDeps bundles all dependencies, flags, and callbacks for runInit.
 type InitDeps struct {
 	Ports            InitPorts
+	SubmoduleOps     submoduleOps // go-git submodule ops; nil → gitSubmoduleOps
 	APIKey           string
 	NoDockerCheck    bool
 	NoGitHub         bool
@@ -88,9 +87,6 @@ type InitDeps struct {
 // Validate checks that all required dependencies for the active path are non-nil.
 func (d InitDeps) Validate() error {
 	var missing []string
-	if d.Ports.Cfg == nil {
-		missing = append(missing, "Ports.Cfg")
-	}
 	if d.Ports.Probe == nil {
 		missing = append(missing, "Ports.Probe")
 	}
@@ -109,22 +105,12 @@ func (d InitDeps) Validate() error {
 	if d.Ports.Scaffold == nil {
 		missing = append(missing, "Ports.Scaffold")
 	}
-	if !d.NoDockerCheck && d.Ports.Docker == nil {
-		missing = append(missing, "Ports.Docker")
-	}
 	if !d.NoGitHub {
 		if d.Ports.Auth == nil {
 			missing = append(missing, "Ports.Auth")
 		}
 		if d.Ports.GitHub == nil {
 			missing = append(missing, "Ports.GitHub")
-		}
-		if d.Ports.Cloner == nil {
-			missing = append(missing, "Ports.Cloner")
-		}
-	} else {
-		if d.Ports.GitInit == nil {
-			missing = append(missing, "Ports.GitInit")
 		}
 	}
 	if len(missing) > 0 {
@@ -198,20 +184,15 @@ func runInitE(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("parse submodule URLs: %w", err)
 	}
 
-	dockerChecker := NewChecker(5 * time.Second)
-	configRepo := NewRepository()
-
-	// Wire up new ports
+	// Wire up remaining ports (docker/git CLI and auth config are package-level)
 	authenticator := NewAuthenticator(initClientID)
 	gitHubClient := NewGitHubClient()
-	cloner := NewCloner()
 	extractor := NewExtractor()
 	envRenderer := NewEnvRenderer()
 	workdirProbe := NewWorkingDirProbe()
 	uidResolver := NewUIDResolver()
 	gitIdentity := NewGitIdentity()
 	scaffold := NewSettingsScaffold()
-	gitInit := NewGitInitializer()
 	confirmFn := promptConfirm
 	inputFn := promptInput
 
@@ -240,18 +221,14 @@ func runInitE(cmd *cobra.Command, _ []string) error {
 
 	return runInit(ctx, InitDeps{
 		Ports: InitPorts{
-			Docker:    dockerChecker,
-			Cfg:       configRepo,
 			Auth:      authenticator,
 			GitHub:    gitHubClient,
-			Cloner:    cloner,
 			Extractor: extractor,
 			Env:       envRenderer,
 			Probe:     workdirProbe,
 			UID:       uidResolver,
 			GitID:     gitIdentity,
 			Scaffold:  scaffold,
-			GitInit:   gitInit,
 			Remover:   initRemover,
 		},
 		APIKey:           initAPIKey,
@@ -275,7 +252,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 	}
 	// Phase 1: Docker check (unless --no-docker-check)
 	if !deps.NoDockerCheck {
-		if err := runInitDockerCheck(ctx, deps.Ports.Docker); err != nil {
+		if err := runInitDockerCheck(ctx); err != nil {
 			return err
 		}
 	}
@@ -290,13 +267,16 @@ func runInit(ctx context.Context, deps InitDeps) error {
 		return nil
 	}
 
+	// Auth config is file I/O under the OS user config dir — no port.
+	cfg := &fileRepository{}
+
 	// Phase 3-8: Authentication and repository setup
 	var auth *Auth
 	if deps.NoGitHub {
 		// Legacy path: API key only
 		fmt.Fprintf(os.Stderr, "  ℹ Using API-key-only mode.\n")
 		fmt.Fprintf(os.Stderr, "  ℹ Provider: %s\n", initProvider)
-		auth, err = runInitLegacy(ctx, deps.Ports.Cfg, deps.APIKey, initProvider)
+		auth, err = runInitLegacy(ctx, cfg, deps.APIKey, initProvider)
 		if err != nil {
 			return err
 		}
@@ -308,7 +288,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 			if errors.Is(err, device.ErrUnsupported) {
 				fmt.Fprintf(os.Stderr, "  ⚠ GitHub OAuth device flow unavailable (the configured OAuth app may be invalid).\n")
 				fmt.Fprintf(os.Stderr, "  ℹ Falling back to API-key-only mode. Use --client-id to provide your own GitHub OAuth app.\n\n")
-				auth, err = runInitLegacy(ctx, deps.Ports.Cfg, deps.APIKey, initProvider)
+				auth, err = runInitLegacy(ctx, cfg, deps.APIKey, initProvider)
 				if err != nil {
 					return err
 				}
@@ -338,7 +318,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 			case ModeUseForkURL:
 				// Use user-supplied fork URL directly — skip fork and wait
 				cloneURL = deps.SourceFork.ForkURL
-				if err := runInitCloneSubmodule(ctx, deps.Ports.Cloner, token, cloneURL, deps.Workdir); err != nil {
+				if err := runInitCloneSubmodule(ctx, token, cloneURL, deps.Workdir); err != nil {
 					return err
 				}
 
@@ -384,7 +364,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 					cloneURL = fmt.Sprintf("https://github.com/%s/%s.git", sourceOwner, sourceRepoName)
 				}
 
-				if err := runInitCloneSubmodule(ctx, deps.Ports.Cloner, token, cloneURL, deps.Workdir); err != nil {
+				if err := runInitCloneSubmodule(ctx, token, cloneURL, deps.Workdir); err != nil {
 					return err
 				}
 			}
@@ -410,7 +390,11 @@ func runInit(ctx context.Context, deps InitDeps) error {
 
 			// Configure submodules for non-skip modes
 			if deps.SourceFork.Mode != ModeSkipFork {
-				if err := runInitSubmodule(ctx, deps.Ports.Cloner, deps.Workdir, deps.SubmoduleURLs, deps.SkipSubmodules, deps.SubmodulePromptFn, deps.NoInput, deps.ConfirmFn, deps.InputFn); err != nil {
+				ops := deps.SubmoduleOps
+				if ops == nil {
+					ops = gitSubmoduleOps{}
+				}
+				if err := runInitSubmodule(ctx, ops, deps.Workdir, deps.SubmoduleURLs, deps.SkipSubmodules, deps.SubmodulePromptFn, deps.NoInput, deps.ConfirmFn, deps.InputFn); err != nil {
 					return fmt.Errorf("submodule config: %w", err)
 				}
 			}
@@ -435,7 +419,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 
 	// Phase 11: Scaffold workspace — git init (no-github only) + .pi/settings.json (always)
 	if deps.NoGitHub {
-		if err := runInitGitInit(ctx, deps.Ports.GitInit, deps.Workdir); err != nil {
+		if err := runInitGitInit(ctx, deps.Workdir); err != nil {
 			return fmt.Errorf("git init: %w", err)
 		}
 	}
@@ -444,16 +428,16 @@ func runInit(ctx context.Context, deps InitDeps) error {
 	}
 
 	// Phase 12: Save auth config
-	if err := deps.Ports.Cfg.Save(ctx, auth); err != nil {
+	if err := cfg.Save(ctx, auth); err != nil {
 		return fmt.Errorf("save auth config: %w", err)
 	}
 
-	path, _ := deps.Ports.Cfg.Path()
+	path, _ := cfg.Path()
 	fmt.Fprintf(os.Stderr, "  ✓ Auth config saved to %s\n", path)
 
 	// Phase 13: API key setup for pi providers (interactive only)
 	if !deps.NoInput {
-		if err := runInitAPIKeys(ctx, deps.Ports.Cfg, deps.Workdir, deps.ConfirmFn); err != nil {
+		if err := runInitAPIKeys(ctx, cfg, deps.Workdir, deps.ConfirmFn); err != nil {
 			return fmt.Errorf("API key setup: %w", err)
 		}
 	}
@@ -463,8 +447,8 @@ func runInit(ctx context.Context, deps InitDeps) error {
 	return nil
 }
 // runInitDockerCheck verifies Docker Engine is installed and running.
-func runInitDockerCheck(ctx context.Context, docker Checker) error {
-	result, err := docker.Check(ctx)
+func runInitDockerCheck(ctx context.Context) error {
+	result, err := dockerCheck(ctx, dockerCheckTimeout)
 	if err != nil {
 		return fmt.Errorf("docker check failed: %w", err)
 	}
@@ -553,7 +537,7 @@ func runInitAuth(ctx context.Context, authenticator Authenticator) (token, user 
 // Called after the main init flow (GitHub auth + scaffold), only in interactive mode.
 // Each provider key is saved to auth.json. Last provider added becomes default in
 // workspace settings. Skips if Docker Engine check failed or workspace has no .pi dir.
-func runInitAPIKeys(ctx context.Context, cfg Repository, workdir string, confirmFn func(string) (bool, error)) error {
+func runInitAPIKeys(ctx context.Context, cfg *fileRepository, workdir string, confirmFn func(string) (bool, error)) error {
 	ok, err := confirmFn("Configure API keys for pi providers?")
 	if err != nil {
 		return err
@@ -624,7 +608,7 @@ func runInitAPIKeys(ctx context.Context, cfg Repository, workdir string, confirm
 
 // runInitLegacy is an auth-only helper that returns an *Auth with the API key.
 // It does NOT save, extract, or render — the orchestrator handles those.
-func runInitLegacy(ctx context.Context, cfg Repository, apiKey string, provider string) (*Auth, error) {
+func runInitLegacy(ctx context.Context, cfg *fileRepository, apiKey string, provider string) (*Auth, error) {
 	if apiKey == "" {
 		key, err := promptAPIKey()
 		if err != nil {
@@ -641,7 +625,7 @@ func runInitLegacy(ctx context.Context, cfg Repository, apiKey string, provider 
 // Non-interactive flow (noInput=true or confirmFn nil): reads .gitmodules, applies CLI overrides.
 func runInitSubmodule(
 	ctx context.Context,
-	cloner Cloner,
+	ops submoduleOps,
 	workdir string,
 	urlOverrides map[string]string,
 	skipAll bool,
@@ -711,13 +695,13 @@ func runInitSubmodule(
 			}
 
 			fmt.Fprintf(os.Stderr, "  ℹ Adding submodule %s → %s\n", name, url)
-			if err := cloner.AddSubmodule(ctx, workdir, name, url); err != nil {
+			if err := ops.AddSubmodule(ctx, workdir, name, url); err != nil {
 				return fmt.Errorf("add submodule %q: %w", name, err)
 			}
 		}
 
 		if count > 0 {
-			if err := cloner.InitAndUpdateSubmodules(ctx, workdir); err != nil {
+			if err := ops.InitAndUpdateSubmodules(ctx, workdir); err != nil {
 				return fmt.Errorf("update submodules: %w", err)
 			}
 		}
@@ -729,7 +713,7 @@ func runInitSubmodule(
 	// Non-interactive flow: read from .gitmodules, apply overrides
 	fmt.Fprintf(os.Stderr, "  ℹ Configuring submodules...\n")
 
-	submodules, err := cloner.ListSubmodules(ctx, workdir)
+	submodules, err := ops.ListSubmodules(ctx, workdir)
 	if err != nil {
 		return fmt.Errorf("list submodules: %w", err)
 	}
@@ -757,13 +741,13 @@ func runInitSubmodule(
 	// Apply URL changes
 	for name, url := range overrides {
 		fmt.Fprintf(os.Stderr, "  ℹ Setting submodule %q URL to %s\n", name, url)
-		if err := cloner.SetSubmoduleURL(ctx, workdir, name, url); err != nil {
+		if err := ops.SetSubmoduleURL(ctx, workdir, name, url); err != nil {
 			return fmt.Errorf("set submodule %q URL: %w", name, err)
 		}
 	}
 
 	// Init and update all submodules
-	if err := cloner.InitAndUpdateSubmodules(ctx, workdir); err != nil {
+	if err := ops.InitAndUpdateSubmodules(ctx, workdir); err != nil {
 		return fmt.Errorf("update submodules: %w", err)
 	}
 
@@ -961,9 +945,9 @@ func promptGitIdentity() (name, email string, err error) {
 
 // runInitGitInit initializes a git repository in the working directory.
 // This is only called on the --no-github path (clone creates .git otherwise).
-func runInitGitInit(ctx context.Context, gitInit GitInitializer, workdir string) error {
+func runInitGitInit(ctx context.Context, workdir string) error {
 	fmt.Fprintf(os.Stderr, "  ℹ Initializing git repository...\n")
-	if err := gitInit.Init(ctx, workdir); err != nil {
+	if err := gitInit(ctx, workdir); err != nil {
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "  ✓ Git repository initialized\n")
@@ -1066,7 +1050,7 @@ func runInitPromptSource(sfi SourceForkInput) (string, error) {
 }
 
 // runInitCloneSubmodule clones a repo and configures its submodule.
-func runInitCloneSubmodule(ctx context.Context, cloner Cloner, token, cloneURL, workdir string) error {
+func runInitCloneSubmodule(ctx context.Context, token, cloneURL, workdir string) error {
 	sourceOwner, sourceRepoName := ParseGitHubURL(cloneURL)
 	if sourceOwner == "" || sourceRepoName == "" {
 		return fmt.Errorf("invalid clone URL: %s", cloneURL)
@@ -1086,7 +1070,7 @@ func runInitCloneSubmodule(ctx context.Context, cloner Cloner, token, cloneURL, 
 		}
 	}
 
-	if err := cloner.CloneWorktree(ctx, token, cloneURL, workdir); err != nil {
+	if err := gitCloneWorktree(ctx, token, cloneURL, workdir); err != nil {
 		return fmt.Errorf("clone fork: %w", err)
 	}
 	fmt.Fprintf(os.Stderr, "  ✓ Cloned %s/%s to %s\n", sourceOwner, sourceRepoName, workdir)

--- a/cmd/cheasee-pi/init_test.go
+++ b/cmd/cheasee-pi/init_test.go
@@ -30,7 +30,6 @@ func defaultMocks() InitPorts {
 				return nil
 			},
 		},
-		Cloner:    &mockCloner{},
 		Extractor: &mockExtractor{},
 		Env:       &mockEnvRenderer{},
 		Probe: &mockWorkingDirProbe{
@@ -41,27 +40,83 @@ func defaultMocks() InitPorts {
 		UID:      &mockUIDResolver{},
 		GitID:    &mockGitIdentity{},
 		Scaffold: &mockSettingsScaffold{},
-		GitInit:  &mockGitInitializer{},
 		Remover:  &mockInitRemover{},
 	}
 }
 
 // ──────────────────────────────────────────────
-// Phase 1: Docker check tests (legacy, preserved)
+// Seam stubs for docker/git CLI tests
+// ──────────────────────────────────────────────
+
+// stubDockerLookPath makes the docker binary appear installed until test end.
+func stubDockerLookPath(t *testing.T) {
+	t.Helper()
+	saved := lookPath
+	lookPath = func(_ string) (string, error) { return "/usr/bin/docker", nil }
+	t.Cleanup(func() { lookPath = saved })
+}
+
+// stubDockerCheck stubs the docker seams. daemonErr, when non-nil, makes
+// `docker info` fail; version is the docker version output (versionErr wins
+// over version when set).
+func stubDockerCheck(t *testing.T, daemonErr error, version string, versionErr error) {
+	t.Helper()
+	stubDockerLookPath(t)
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) {
+				if versionErr != nil {
+					return nil, versionErr
+				}
+				return []byte(version), nil
+			}}
+		}
+		return &mockCmd{runFn: func() error { return daemonErr }}
+	}
+	t.Cleanup(func() { runCommandContext = saved })
+}
+
+// redirectConfigDir points the auth config dir at a fresh temp dir so no test
+// touches the real $HOME/.config.
+func redirectConfigDir(t *testing.T) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+}
+
+// authJSONExists reports whether auth.json was written to the config dir.
+func authJSONExists(t *testing.T) bool {
+	t.Helper()
+	cfg := &fileRepository{}
+	p, err := cfg.Path()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(p)
+	return err == nil
+}
+
+// loadAuthJSON reads the saved auth.json back via fileRepository.
+func loadAuthJSON(t *testing.T) *Auth {
+	t.Helper()
+	cfg := &fileRepository{}
+	auth, err := cfg.Load(context.Background())
+	if err != nil {
+		t.Fatalf("load auth.json: %v", err)
+	}
+	return auth
+}
+
+// ──────────────────────────────────────────────
+// Phase 1: Docker check tests
 // ──────────────────────────────────────────────
 
 func TestInitUseCase_DockerNotInstalled(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: false,
-			Running:   false,
-			Err:       fmt.Errorf("docker not found"),
-		},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	saved := lookPath
+	lookPath = func(_ string) (string, error) { return "", fmt.Errorf("executable not found in $PATH") }
+	defer func() { lookPath = saved }()
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -79,23 +134,15 @@ func TestInitUseCase_DockerNotInstalled(t *testing.T) {
 	if !strings.Contains(err.Error(), "Docker is not installed") {
 		t.Errorf("error should mention Docker is not installed: %v", err)
 	}
-	if mockCfg.saved {
+	if authJSONExists(t) {
 		t.Error("Save should not be called when Docker check fails")
 	}
 }
 
 func TestInitUseCase_DockerNotRunning(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: true,
-			Running:   false,
-			Err:       fmt.Errorf("Docker daemon not running"),
-		},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, fmt.Errorf("Cannot connect to the Docker daemon"), "", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -113,24 +160,15 @@ func TestInitUseCase_DockerNotRunning(t *testing.T) {
 	if !strings.Contains(err.Error(), "not running") {
 		t.Errorf("error should mention Docker not running: %v", err)
 	}
-	if mockCfg.saved {
+	if authJSONExists(t) {
 		t.Error("Save should not be called when Docker check fails")
 	}
 }
 
 func TestInitUseCase_DockerVersionTooOld(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: true,
-			Running:   true,
-			Version:   "23.0.0",
-			Err:       fmt.Errorf("Docker Engine 23.0.0 is too old, need >= 24.0.0"),
-		},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "23.0.0", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -148,24 +186,15 @@ func TestInitUseCase_DockerVersionTooOld(t *testing.T) {
 	if !strings.Contains(err.Error(), "Docker") {
 		t.Errorf("error should mention Docker: %v", err)
 	}
-	if mockCfg.saved {
+	if authJSONExists(t) {
 		t.Error("Save should not be called when Docker check fails")
 	}
 }
 
 func TestInitUseCase_DockerCheckReturnsErr(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: true,
-			Running:   true,
-			Version:   "24.0.9",
-			Err:       fmt.Errorf("version check failed"),
-		},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "", fmt.Errorf("version check failed"))
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -178,20 +207,16 @@ func TestInitUseCase_DockerCheckReturnsErr(t *testing.T) {
 		InputFn:        mockInputFn("", nil),
 	})
 	if err == nil {
-		t.Fatal("expected error when Docker CheckResult.Err is set")
+		t.Fatal("expected error when Docker version fetch fails")
+	}
+	if !strings.Contains(err.Error(), "Docker version check") {
+		t.Errorf("error should mention Docker version check: %v", err)
 	}
 }
 
 func TestInitUseCase_NoDockerCheckFlag(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: false,
-		},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -207,26 +232,18 @@ func TestInitUseCase_NoDockerCheckFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error with --no-docker-check: %v", err)
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called when --no-docker-check is set")
 	}
-	if mockCfg.savedKey != "sk-abc123" {
-		t.Errorf("expected saved key 'sk-abc123', got %q", mockCfg.savedKey)
+	if got := loadAuthJSON(t).APIKey; got != "sk-abc123" {
+		t.Errorf("expected saved key 'sk-abc123', got %q", got)
 	}
 }
 
 func TestInitUseCase_HappyPathWithAPIKeyFlag(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: true,
-			Running:   true,
-			Version:   "24.0.9",
-		},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -242,26 +259,25 @@ func TestInitUseCase_HappyPathWithAPIKeyFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error on happy path: %v", err)
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called on happy path")
 	}
-	if mockCfg.savedKey != "sk-abc123" {
-		t.Errorf("expected API key 'sk-abc123', got %q", mockCfg.savedKey)
+	if got := loadAuthJSON(t).APIKey; got != "sk-abc123" {
+		t.Errorf("expected API key 'sk-abc123', got %q", got)
 	}
 }
 
 func TestInitUseCase_ConfigSaveError(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{
-			Installed: true,
-			Running:   true,
-			Version:   "24.0.9",
-		},
-	}
-	mockCfg := &mockRepository{saveErr: fmt.Errorf("disk full")}
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
+
+	// Block the config dir path with a regular file so MkdirAll fails
+	// deterministically (real file I/O, no mock error injection).
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if err := os.WriteFile(filepath.Join(dir, "cheasee-pi"), []byte("block"), 0644); err != nil {
+		t.Fatalf("block config dir: %v", err)
+	}
 
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -277,22 +293,18 @@ func TestInitUseCase_ConfigSaveError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when Save fails")
 	}
-	if !strings.Contains(err.Error(), "disk full") {
-		t.Errorf("error should propagate Save error: %v", err)
+	if !strings.Contains(err.Error(), "save auth config") {
+		t.Errorf("error should wrap with 'save auth config': %v", err)
 	}
 }
 
 func TestInitUseCase_ContextCancelled(t *testing.T) {
+	redirectConfigDir(t)
+	stubDockerLookPath(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancelled
 
-	mockDocker := &mockCheckerCtx{orig: &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}}
-	mockCfg := &mockRepository{}
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err := runInit(ctx, InitDeps{
 		Ports:          ports,
@@ -511,17 +523,14 @@ func TestRunInitAuth_RequestCodeError(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_FullFlow(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -533,17 +542,15 @@ func TestRunInit_FullFlow(t *testing.T) {
 	if err != nil {
 		t.Fatalf("full flow failed: %v", err)
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called after full flow")
 	}
 }
 
 func TestRunInit_NoGitHubFlag(t *testing.T) {
 	// --no-github flag: extract + env + save all run after auth
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
 	extractCalled := false
 	ext := &mockExtractor{
@@ -562,7 +569,6 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 	}
 
 	scaffold := &mockSettingsScaffold{}
-	gitInit := &mockGitInitializer{}
 
 	probe := &mockWorkingDirProbe{
 		inspectFunc: func(path string) (WorkdirState, error) {
@@ -573,15 +579,12 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports: InitPorts{
-			Docker:    mockDocker,
-			Cfg:       mockCfg,
 			Extractor: ext,
 			Env:       env,
 			Probe:     probe,
 			UID:       &mockUIDResolver{},
 			GitID:     &mockGitIdentity{},
 			Scaffold:  scaffold,
-			GitInit:   gitInit,
 		},
 		APIKey:         "sk-abc123",
 		NoDockerCheck:  false,
@@ -601,20 +604,21 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 	if !renderCalled {
 		t.Error("Env render should be called on legacy path")
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called on legacy path")
 	}
-	if mockCfg.savedKey != "sk-abc123" {
-		t.Errorf("expected API key 'sk-abc123', got %q", mockCfg.savedKey)
+	auth := loadAuthJSON(t)
+	if auth.APIKey != "sk-abc123" {
+		t.Errorf("expected API key 'sk-abc123', got %q", auth.APIKey)
 	}
-	if mockCfg.savedAuth == nil || mockCfg.savedAuth.RepoPath != workdir {
-		t.Errorf("expected RepoPath %q, got %q", workdir, mockCfg.savedAuth.RepoPath)
+	if auth.RepoPath != workdir {
+		t.Errorf("expected RepoPath %q, got %q", workdir, auth.RepoPath)
 	}
 }
 
 func TestRunInitLegacy_ReturnsAuth(t *testing.T) {
 	// runInitLegacy is auth-only: returns *Auth, does NOT save/extract/render
-	auth, err := runInitLegacy(context.Background(), &mockRepository{}, "sk-legacy-key", "opencode-go")
+	auth, err := runInitLegacy(context.Background(), &fileRepository{}, "sk-legacy-key", "opencode-go")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -632,13 +636,9 @@ func TestRunInitLegacy_ReturnsAuth(t *testing.T) {
 func TestRunInit_ContextCancelledMidFlow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	redirectConfigDir(t)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	// Override auth with one that respects cancelled context
 	ports.Auth = &mockAuthenticator{
@@ -670,13 +670,9 @@ func TestRunInit_ContextCancelledMidFlow(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_ForkAlreadyExists(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	// Override GitHub client to return fork-already-exists
 	ports.GitHub = &mockGitHubClient{
@@ -694,6 +690,7 @@ func TestRunInit_ForkAlreadyExists(t *testing.T) {
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -712,13 +709,9 @@ func TestRunInit_ForkAlreadyExists(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_ForkNon422Error(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	ports.GitHub = &mockGitHubClient{
 		getUserFunc: func(ctx context.Context, token string) (string, error) {
@@ -824,7 +817,7 @@ func TestParseSubmoduleURLs_EmptyInput(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInitSubmodule_SkipAll(t *testing.T) {
-	mc := &mockCloner{}
+	mc := &mockSubmoduleOps{}
 	err := runInitSubmodule(context.Background(), mc, t.TempDir(), nil, true, nil, false, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -841,7 +834,7 @@ func TestRunInitSubmodule_SkipAll(t *testing.T) {
 }
 
 func TestRunInitSubmodule_NoOverridesNoPrompt(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -866,7 +859,7 @@ func TestRunInitSubmodule_NoOverridesNoPrompt(t *testing.T) {
 }
 
 func TestRunInitSubmodule_WithPromptReturnsEmpty(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -891,7 +884,7 @@ func TestRunInitSubmodule_WithPromptReturnsEmpty(t *testing.T) {
 }
 
 func TestRunInitSubmodule_UrlOverridesOne(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -923,7 +916,7 @@ func TestRunInitSubmodule_UrlOverridesOne(t *testing.T) {
 }
 
 func TestRunInitSubmodule_UrlOverridesBoth(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -951,7 +944,7 @@ func TestRunInitSubmodule_UrlOverridesBoth(t *testing.T) {
 }
 
 func TestRunInitSubmodule_PromptReturnsOverride(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -979,7 +972,7 @@ func TestRunInitSubmodule_PromptReturnsOverride(t *testing.T) {
 }
 
 func TestRunInitSubmodule_OverridesPrecedePrompt(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -1008,7 +1001,7 @@ func TestRunInitSubmodule_OverridesPrecedePrompt(t *testing.T) {
 }
 
 func TestRunInitSubmodule_ListSubmodulesError(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return nil, fmt.Errorf("repo not found")
 		},
@@ -1024,7 +1017,7 @@ func TestRunInitSubmodule_ListSubmodulesError(t *testing.T) {
 }
 
 func TestRunInitSubmodule_SetSubmoduleURLError(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -1049,7 +1042,7 @@ func TestRunInitSubmodule_SetSubmoduleURLError(t *testing.T) {
 }
 
 func TestRunInitSubmodule_InitAndUpdateError(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -1070,7 +1063,7 @@ func TestRunInitSubmodule_InitAndUpdateError(t *testing.T) {
 }
 
 func TestRunInitSubmodule_PromptError(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -1095,7 +1088,7 @@ func TestRunInitSubmodule_ContextCancelled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return nil, ctx.Err()
 		},
@@ -1108,7 +1101,7 @@ func TestRunInitSubmodule_ContextCancelled(t *testing.T) {
 }
 
 func TestRunInitSubmodule_EmptySubmoduleList(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{}, nil
 		},
@@ -1127,7 +1120,7 @@ func TestRunInitSubmodule_EmptySubmoduleList(t *testing.T) {
 }
 
 func TestRunInitSubmodule_OverrideNonExistentSubmodule(t *testing.T) {
-	mc := &mockCloner{
+	mc := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{
 				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
@@ -1319,13 +1312,9 @@ func TestInit_SuccessMessage(t *testing.T) {
 		os.Stderr = oldStderr
 	}()
 
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	redirectConfigDir(t)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	err = runInit(context.Background(), InitDeps{
 		Ports:          ports,
@@ -1514,7 +1503,7 @@ func TestAuthPerProvider_SaveWritesJqParseableOutput(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{
 		APIKey:   "sk-jq-test",
 		Provider: "opencode-go",
@@ -1579,7 +1568,7 @@ func TestAuthPerProvider_RoundTripWithProvider(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{
 		APIKey:      "sk-abc",
 		Provider:    "opencode-go",
@@ -1647,7 +1636,7 @@ func TestConfigBackwardCompat_OldAuthLoads(t *testing.T) {
 	oldContent := `{"api_key": "sk-old-key"}`
 	os.WriteFile(oldPath, []byte(oldContent), 0600)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth, err := cfg.Load(context.Background())
 	if err != nil {
 		t.Fatalf("Load of old format failed: %v", err)
@@ -1664,7 +1653,7 @@ func TestConfigBackwardCompat_RoundTripPreservesNewFields(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
 
-	cfg := NewRepository()
+	cfg := &fileRepository{}
 	auth := &Auth{
 		APIKey:      "sk-abc",
 		GitHubToken: "gho_token",
@@ -1818,13 +1807,9 @@ func TestRunInitPromptSource_ForkURLMode(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_SkipFork(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
@@ -1840,27 +1825,17 @@ func TestRunInit_SkipFork(t *testing.T) {
 	if err != nil {
 		t.Fatalf("skip-fork flow failed: %v", err)
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called after skip-fork flow")
 	}
 }
 
 func TestRunInit_ForkURL(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
-	cloneCalled := false
 	submoduleInited := false
-	clone := &mockCloner{
-		cloneWorktreeFunc: func(ctx context.Context, token, repoURL, workdir string) error {
-			cloneCalled = true
-			if repoURL != "https://github.com/user/existing-fork.git" {
-				t.Errorf("expected clone URL 'https://github.com/user/existing-fork.git', got %q", repoURL)
-			}
-			return nil
-		},
+	ops := &mockSubmoduleOps{
 		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]Submodule, error) {
 			return []Submodule{{Name: "pi", URL: "https://github.com/SchneiderDaniel/pi.git"}}, nil
 		},
@@ -1870,14 +1845,27 @@ func TestRunInit_ForkURL(t *testing.T) {
 		},
 	}
 
+	// Capture the CloneWorktree seam args (git clone --bare <authURL> <dir>)
+	var cloneURL string
+	savedRun := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "clone" {
+			cloneURL = arg[2]
+			return &mockCmd{}
+		}
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("24.0.9"), nil }}
+		}
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = savedRun }()
+
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
-	ports.Cloner = clone
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   ops,
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -1889,22 +1877,23 @@ func TestRunInit_ForkURL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("fork-url flow failed: %v", err)
 	}
-	if !cloneCalled {
-		t.Error("Clone should be called with fork URL")
+	if cloneURL == "" {
+		t.Error("CloneWorktree should be called with fork URL")
+	}
+	if cloneURL != "https://oauth2:gho_test_token@github.com/user/existing-fork.git" {
+		t.Errorf("expected tokenized clone URL, got %q", cloneURL)
 	}
 	if !submoduleInited {
 		t.Error("Submodule init should be called with fork URL")
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called after fork-url flow")
 	}
 }
 
 func TestRunInit_ForkURLSkipsCreateFork(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
 	forkCalled := false
 	waitForkCalled := false
@@ -1922,26 +1911,15 @@ func TestRunInit_ForkURLSkipsCreateFork(t *testing.T) {
 		},
 	}
 
-	clone := &mockCloner{
-		cloneFunc: func(ctx context.Context, token, repoURL, destPath string) error {
-			return nil
-		},
-		setSubmoduleURLFunc: func(ctx context.Context, repoPath, name, newURL string) error {
-			return nil
-		},
-	}
-
 	mockAuth := &mockAuthenticator{}
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 	ports.Auth = mockAuth
 	ports.GitHub = mockGH
-	ports.Cloner = clone
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -1962,13 +1940,9 @@ func TestRunInit_ForkURLSkipsCreateFork(t *testing.T) {
 }
 
 func TestRunInit_ForkURLInvalid(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
@@ -1994,17 +1968,14 @@ func TestRunInit_ForkURLInvalid(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_PostCloneConfirm_Accepted(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        false,
@@ -2016,19 +1987,15 @@ func TestRunInit_PostCloneConfirm_Accepted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("post-clone confirm flow failed: %v", err)
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called when confirm is accepted")
 	}
 }
 
 func TestRunInit_PostCloneConfirm_Declined(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
@@ -2044,25 +2011,22 @@ func TestRunInit_PostCloneConfirm_Declined(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected nil error (clean exit) when confirm is declined: %v", err)
 	}
-	if mockCfg.saved {
+	if authJSONExists(t) {
 		t.Error("Save should NOT be called when confirm is declined")
 	}
 }
 
 func TestRunInit_PostCloneConfirm_NoInputSkipsPrompt(t *testing.T) {
 	// With noInput=true, the post-clone confirm should be skipped
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 
 	// If confirm were called with false, we'd error (but it won't be called)
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -2073,7 +2037,7 @@ func TestRunInit_PostCloneConfirm_NoInputSkipsPrompt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("post-clone confirm with noInput=true failed: %v", err)
 	}
-	if !mockCfg.saved {
+	if !authJSONExists(t) {
 		t.Error("Save should be called when noInput skips prompt")
 	}
 }
@@ -2279,46 +2243,42 @@ func TestSettingsScaffold_ContextCancelled(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestGitInitializer_Init(t *testing.T) {
-	gitInit := NewGitInitializer()
 	workdir := t.TempDir()
 
-	if err := gitInit.Init(context.Background(), workdir); err != nil {
-		t.Fatalf("Init failed: %v", err)
+	if err := gitInit(context.Background(), workdir); err != nil {
+		t.Fatalf("gitInit failed: %v", err)
 	}
 
 	// .git directory should exist
 	gitDir := filepath.Join(workdir, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
-		t.Error("expected .git directory to exist after Init")
+		t.Error("expected .git directory to exist after gitInit")
 	}
 }
 
 func TestGitInitializer_Idempotent(t *testing.T) {
-	gitInit := NewGitInitializer()
 	workdir := t.TempDir()
 
 	// First call: create .git
-	if err := gitInit.Init(context.Background(), workdir); err != nil {
-		t.Fatalf("first Init failed: %v", err)
+	if err := gitInit(context.Background(), workdir); err != nil {
+		t.Fatalf("first gitInit failed: %v", err)
 	}
 
 	// Second call: should no-op
-	if err := gitInit.Init(context.Background(), workdir); err != nil {
-		t.Fatalf("second Init should not error: %v", err)
+	if err := gitInit(context.Background(), workdir); err != nil {
+		t.Fatalf("second gitInit should not error: %v", err)
 	}
 
 	// .git still exists
 	gitDir := filepath.Join(workdir, ".git")
 	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
-		t.Error("expected .git directory to exist after idempotent Init")
+		t.Error("expected .git directory to exist after idempotent gitInit")
 	}
 }
 
 func TestGitInitializer_NonExistentWorkdir(t *testing.T) {
-	gitInit := NewGitInitializer()
-
 	// Use null byte in path — forces EINVAL from git init
-	err := gitInit.Init(context.Background(), "/nonexistent\x00path")
+	err := gitInit(context.Background(), "/nonexistent\x00path")
 	if err == nil {
 		t.Fatal("expected error for invalid path with null byte")
 	}
@@ -2328,13 +2288,20 @@ func TestGitInitializer_NonExistentWorkdir(t *testing.T) {
 }
 
 func TestGitInitializer_ContextCancelled(t *testing.T) {
-	gitInit := NewGitInitializer()
 	workdir := t.TempDir()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancelled
 
-	err := gitInit.Init(ctx, workdir)
+	// Seam must not be touched for a pre-cancelled ctx.
+	saved := runCommandContext
+	runCommandContext = func(ctx context.Context, name string, arg ...string) runner {
+		t.Errorf("runCommandContext should not be invoked with cancelled ctx")
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitInit(ctx, workdir)
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -2579,10 +2546,8 @@ func TestInitRemove_TrailingWhitespaceStripped(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_RemoverCalled(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
 	removerCalled := false
 	var calledWith string
@@ -2595,13 +2560,12 @@ func TestRunInit_RemoverCalled(t *testing.T) {
 	}
 
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 	ports.Remover = remover
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -2622,19 +2586,16 @@ func TestRunInit_RemoverCalled(t *testing.T) {
 }
 
 func TestRunInit_RemoverNil(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 	ports.Remover = nil // explicitly nil
 
 	workdir := t.TempDir()
 	err := runInit(context.Background(), InitDeps{
 		Ports:          ports,
+		SubmoduleOps:   &mockSubmoduleOps{},
 		NoDockerCheck:  false,
 		NoGitHub:       false,
 		NoInput:        true,
@@ -2649,10 +2610,8 @@ func TestRunInit_RemoverNil(t *testing.T) {
 }
 
 func TestRunInit_RemoverError(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
 	remover := &mockInitRemover{
 		removeFunc: func(workdir string) error {
@@ -2661,8 +2620,6 @@ func TestRunInit_RemoverError(t *testing.T) {
 	}
 
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 	ports.Remover = remover
 
 	workdir := t.TempDir()
@@ -2685,10 +2642,8 @@ func TestRunInit_RemoverError(t *testing.T) {
 }
 
 func TestRunInit_RemoverSkipFork(t *testing.T) {
-	mockDocker := &mockDockerChecker{
-		result: &CheckResult{Installed: true, Running: true, Version: "24.0.9"},
-	}
-	mockCfg := &mockRepository{}
+	redirectConfigDir(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
 
 	removerCalled := false
 	remover := &mockInitRemover{
@@ -2699,8 +2654,6 @@ func TestRunInit_RemoverSkipFork(t *testing.T) {
 	}
 
 	ports := defaultMocks()
-	ports.Docker = mockDocker
-	ports.Cfg = mockCfg
 	ports.Remover = remover
 
 	workdir := t.TempDir()
@@ -2744,4 +2697,46 @@ func captureStderr(t *testing.T, fn func()) string {
 	os.Stderr = orig
 	w.Close()
 	return <-out
+}
+// ──────────────────────────────────────────────
+// gitInit seam tests (runner-level)
+// ──────────────────────────────────────────────
+
+func TestGitInit_SeamArgsCaptured(t *testing.T) {
+	var captured []string
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+		captured = arg
+		return &mockCmd{}
+	}
+	defer func() { runCommandContext = saved }()
+
+	workdir := t.TempDir()
+	if err := gitInit(context.Background(), workdir); err != nil {
+		t.Fatalf("gitInit failed: %v", err)
+	}
+	if strings.Join(captured, " ") != "init "+workdir {
+		t.Errorf("expected (git, init, workdir), got %v", captured)
+	}
+}
+
+func TestGitInit_ErrorWrapsOutput(t *testing.T) {
+	saved := runCommandContext
+	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+		return &mockCmd{combinedFn: func() ([]byte, error) {
+			return []byte("fatal: Invalid path"), fmt.Errorf("exit status 128")
+		}}
+	}
+	defer func() { runCommandContext = saved }()
+
+	err := gitInit(context.Background(), t.TempDir())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "git init") {
+		t.Errorf("error should mention git init: %v", err)
+	}
+	if !strings.Contains(err.Error(), "Invalid path") {
+		t.Errorf("error should include command output: %v", err)
+	}
 }

--- a/cmd/cheasee-pi/runner.go
+++ b/cmd/cheasee-pi/runner.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os/exec"
+)
+
+// runner is the subset of *exec.Cmd used by the init CLI seams:
+// output capture plus Run and dir/env/stdout/stderr configuration.
+type runner interface {
+	Output() ([]byte, error)
+	CombinedOutput() ([]byte, error)
+	Run() error
+	SetDir(string)
+	SetEnv([]string)
+	SetStdout(io.Writer)
+	SetStderr(io.Writer)
+}
+
+// execRunner adapts *exec.Cmd to runner (its config surface is field-based,
+// not method-based).
+type execRunner struct{ *exec.Cmd }
+
+func (e execRunner) SetDir(d string)       { e.Cmd.Dir = d }
+func (e execRunner) SetEnv(env []string)   { e.Cmd.Env = env }
+func (e execRunner) SetStdout(w io.Writer) { e.Cmd.Stdout = w }
+func (e execRunner) SetStderr(w io.Writer) { e.Cmd.Stderr = w }
+
+// runCommand and runCommandContext are os/exec.Command wrappers, overridable
+// in tests. They mirror orphan.go's execCommand var but add context support
+// and the wider runner surface (Run/Dir/Env/Stdout/Stderr) needed by the
+// docker/git call sites.
+//
+// NOTE: the package has zero t.Parallel() tests; swapping these vars is
+// race-free only under that constraint. Do not add t.Parallel() without
+// switching to a per-test registry.
+var runCommand = func(name string, arg ...string) runner {
+	return execRunner{exec.Command(name, arg...)}
+}
+
+var runCommandContext = func(ctx context.Context, name string, arg ...string) runner {
+	return execRunner{exec.CommandContext(ctx, name, arg...)}
+}

--- a/cmd/cheasee-pi/uninstall.go
+++ b/cmd/cheasee-pi/uninstall.go
@@ -85,7 +85,7 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 	}
 
 	// Auth config
-	repo := NewRepository()
+	repo := &fileRepository{}
 	authPath, err := repo.Path()
 	if err == nil {
 		if _, err := os.Stat(authPath); err == nil {

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -52,9 +52,9 @@ func init() {
 	upCmd.Flags().BoolVar(&upDryRun, "dry-run", false, "Print env vars that would be passed, then exit")
 }
 
-// newRepository is the Repository constructor, overridable in tests.
-var newRepository = func() Repository {
-	return NewRepository()
+// newRepository is the auth config constructor, overridable in tests.
+var newRepository = func() *fileRepository {
+	return &fileRepository{}
 }
 
 // allKnownEnvVars is the complete set of pi provider env vars.
@@ -96,8 +96,7 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 
 	// Phase 1: Docker check
 	if !upNoDockerCheck {
-		checker := NewChecker(5 * time.Second)
-		if err := runInitDockerCheck(ctx, checker); err != nil {
+		if err := runInitDockerCheck(ctx); err != nil {
 			return err
 		}
 	}

--- a/cmd/cheasee-pi/up_test.go
+++ b/cmd/cheasee-pi/up_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 )
@@ -182,6 +183,12 @@ func TestOrphanScanBash_echoesKilledPIDs(t *testing.T) {
 type mockCmd struct {
 	outputFn   func() ([]byte, error)
 	combinedFn func() ([]byte, error)
+	runFn      func() error
+	// Captured Set* config, for callers that configure the command
+	dir    string
+	env    []string
+	stdout interface{ Write([]byte) (int, error) }
+	stderr interface{ Write([]byte) (int, error) }
 }
 
 func (m *mockCmd) Output() ([]byte, error) {
@@ -197,6 +204,18 @@ func (m *mockCmd) CombinedOutput() ([]byte, error) {
 	}
 	return nil, nil
 }
+
+func (m *mockCmd) Run() error {
+	if m.runFn != nil {
+		return m.runFn()
+	}
+	return nil
+}
+
+func (m *mockCmd) SetDir(d string)       { m.dir = d }
+func (m *mockCmd) SetEnv(e []string)     { m.env = e }
+func (m *mockCmd) SetStdout(w io.Writer) { m.stdout = w }
+func (m *mockCmd) SetStderr(w io.Writer) { m.stderr = w }
 
 func TestScanOrphans_containerNotRunning(t *testing.T) {
 	saved := execCommand
@@ -383,15 +402,11 @@ func indexOf(slice []string, val string) int {
 // ──────────────────────────────────────────────
 
 func TestBuildEnvFlags_resolvesClaudeAlias(t *testing.T) {
-	saved := newRepository
-	newRepository = func() Repository {
-		return &mockRepository{
-			providers: map[string]string{
-				"claude": "sk-ant-xxx",
-			},
-		}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg := &fileRepository{}
+	if err := cfg.AddProvider(context.Background(), "claude", "sk-ant-xxx"); err != nil {
+		t.Fatalf("seed auth.json: %v", err)
 	}
-	defer func() { newRepository = saved }()
 
 	flags, err := buildEnvFlags(context.Background())
 	if err != nil {
@@ -411,15 +426,11 @@ func TestBuildEnvFlags_resolvesClaudeAlias(t *testing.T) {
 }
 
 func TestBuildEnvFlags_resolvesGoogleAlias(t *testing.T) {
-	saved := newRepository
-	newRepository = func() Repository {
-		return &mockRepository{
-			providers: map[string]string{
-				"google": "xxx",
-			},
-		}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg := &fileRepository{}
+	if err := cfg.AddProvider(context.Background(), "google", "xxx"); err != nil {
+		t.Fatalf("seed auth.json: %v", err)
 	}
-	defer func() { newRepository = saved }()
 
 	flags, err := buildEnvFlags(context.Background())
 	if err != nil {
@@ -439,15 +450,11 @@ func TestBuildEnvFlags_resolvesGoogleAlias(t *testing.T) {
 }
 
 func TestBuildEnvFlags_resolvesOpenCodeAlias(t *testing.T) {
-	saved := newRepository
-	newRepository = func() Repository {
-		return &mockRepository{
-			providers: map[string]string{
-				"opencode": "xxx",
-			},
-		}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg := &fileRepository{}
+	if err := cfg.AddProvider(context.Background(), "opencode", "xxx"); err != nil {
+		t.Fatalf("seed auth.json: %v", err)
 	}
-	defer func() { newRepository = saved }()
 
 	flags, err := buildEnvFlags(context.Background())
 	if err != nil {
@@ -467,15 +474,11 @@ func TestBuildEnvFlags_resolvesOpenCodeAlias(t *testing.T) {
 }
 
 func TestBuildEnvFlags_resolvesXaiDriftVictim(t *testing.T) {
-	saved := newRepository
-	newRepository = func() Repository {
-		return &mockRepository{
-			providers: map[string]string{
-				"xai": "xxx",
-			},
-		}
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	cfg := &fileRepository{}
+	if err := cfg.AddProvider(context.Background(), "xai", "xxx"); err != nil {
+		t.Fatalf("seed auth.json: %v", err)
 	}
-	defer func() { newRepository = saved }()
 
 	flags, err := buildEnvFlags(context.Background())
 	if err != nil {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1389

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 2m 10s | 60.2K | 31 | minimax-m3 |
| test-designer | ✓ SUCCESS | 4m 10s | 87.5K | 25 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 16m 36s | 195.9K | 107 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 4m 2s | 108.0K | 77 | minimax-m3 |

**Total:** 4 agents · 26m 58s · 451.5K tokens · 240 tool calls · 10 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1389
Closes #1389