### PR TITLE
feat(#1421): [Bug] resolveSkillPaths ignores settings.json skill roots — subagent dies on private-pi skill in worktree

### DIFF
--- a/.pi/extensions/supervisor/config/config.ts
+++ b/.pi/extensions/supervisor/config/config.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { readFileSync, existsSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 
 // ─── Constants ──────────────────────────────────────────────────────
 
@@ -104,6 +105,50 @@ export function loadConfig(): SupervisorConfig {
 		submodules,
 		agentTimeoutsMin,
 	};
+}
+
+// ─── Skill roots ──────────────────────────────────────────────────────
+
+/**
+ * Read the `skills` array from `.pi/settings.json` and return absolute
+ * skill-root paths in declared order.
+ *
+ * - Pattern-prefixed entries (`!foo`, `+foo`, `-foo`) are SDK override
+ *   patterns over auto-discovered skills, not roots — filtered out.
+ * - Non-string / empty entries are ignored.
+ * - Base dir rule: `../`-prefixed entries resolve against the settings dir
+ *   (`<cwd>/.pi`), everything else against `cwd`. This makes both
+ *   `.pi/skills` and `../private-pi/skills` land where the CLI loads them
+ *   (`<repo>/.pi/skills` and `<repo>/private-pi/skills`).
+ * - Fail-open: missing/unreadable settings or missing `skills` key → `[]`
+ *   (worktrees stripped of submodule roots by init.go are the expected
+ *   state, not an anomaly).
+ */
+export function loadSkillsRoots(cwd: string): string[] {
+	const settingsPath = resolvePath(cwd, ".pi/settings.json");
+	let settings: Record<string, unknown> | null;
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(settingsPath, "utf-8"));
+		settings = (typeof parsed === "object" && parsed !== null ? parsed : null) as Record<
+			string,
+			unknown
+		> | null;
+	} catch {
+		return [];
+	}
+	const entries = settings?.skills;
+	if (!Array.isArray(entries)) return [];
+
+	const settingsDir = resolvePath(cwd, ".pi");
+	const roots: string[] = [];
+	for (const entry of entries) {
+		if (typeof entry !== "string") continue;
+		const trimmed = entry.trim();
+		if (!trimmed || /^[!+-]/.test(trimmed)) continue;
+		const base = trimmed.startsWith("..") ? settingsDir : cwd;
+		roots.push(resolvePath(base, trimmed));
+	}
+	return roots;
 }
 
 // ─── Timeout validation ──────────────────────────────────────────────

--- a/.pi/extensions/supervisor/lib/extensions.ts
+++ b/.pi/extensions/supervisor/lib/extensions.ts
@@ -4,6 +4,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
+import { loadSkillsRoots } from "../config/config.ts";
 
 // ─── Extension path resolution ──────────────────────────────────────
 
@@ -60,24 +61,22 @@ export function resolveExtensionPaths(extensionsRaw: string | undefined, cwd?: s
 // ─── Skill path resolution ───────────────────────────────────────────
 
 /**
- * Resolve comma-separated skill names from agent frontmatter to absolute
- * file paths suitable for --skill CLI flags.
- *
- * Resolution order:
- * 1. Try `.pi/skills/<name>.md` first
- * 2. Fall back to `.pi/skills/<name>/SKILL.md`
- * 3. If neither exists, throw an error with skill name and both paths
- *
- * Empty/undefined input returns empty array (noop).
- */
-/**
  * Internal version of resolveSkillPaths that accepts a custom existsSync
  * function for testing. Public API wraps this with real existsSync.
+ *
+ * Resolution per skill name, per root, in declared order:
+ * 1. `<root>/<name>.md`
+ * 2. `<root>/<name>/SKILL.md`
+ * first hit wins; later roots act as fallbacks.
+ *
+ * A skill missing from all roots warns (with name + tried paths) and is
+ * skipped — never throws (fail-open, matches SDK loadSkills semantics).
  */
 export function resolveSkillPathsWithFs(
 	skillsRaw: string | undefined,
 	cwd: string,
 	existsSyncFn: (path: string) => boolean,
+	roots?: string[],
 ): string[] {
 	if (!skillsRaw || !skillsRaw.trim()) {
 		return [];
@@ -92,17 +91,34 @@ export function resolveSkillPathsWithFs(
 		return [];
 	}
 
+	// Pattern-prefixed entries are SDK override patterns, never literal roots.
+	const skillRoots = (roots ?? [resolvePath(cwd, ".pi/skills")]).filter(
+		(r) => !/^[!+-]/.test(r),
+	);
+
 	const result: string[] = [];
 	for (const name of skills) {
-		const mdPath = resolvePath(cwd, `.pi/skills/${name}.md`);
-		const skillDirPath = resolvePath(cwd, `.pi/skills/${name}/SKILL.md`);
-
-		if (existsSyncFn(mdPath)) {
-			result.push(mdPath);
-		} else if (existsSyncFn(skillDirPath)) {
-			result.push(skillDirPath);
+		const tried: string[] = [];
+		let found: string | undefined;
+		for (const root of skillRoots) {
+			const mdPath = resolvePath(root, `${name}.md`);
+			const skillDirPath = resolvePath(root, `${name}/SKILL.md`);
+			tried.push(mdPath, skillDirPath);
+			if (existsSyncFn(mdPath)) {
+				found = mdPath;
+				break;
+			}
+			if (existsSyncFn(skillDirPath)) {
+				found = skillDirPath;
+				break;
+			}
+		}
+		if (found) {
+			result.push(found);
 		} else {
-			throw new Error(`Skill "${name}" not found: tried "${mdPath}" and "${skillDirPath}"`);
+			console.warn(
+				`Skill "${name}" not found: tried ${tried.map((p) => `"${p}"`).join(", ")} — skipping`,
+			);
 		}
 	}
 
@@ -113,15 +129,14 @@ export function resolveSkillPathsWithFs(
  * Resolve comma-separated skill names from agent frontmatter to absolute
  * file paths suitable for --skill CLI flags.
  *
- * Resolution order:
- * 1. Try `.pi/skills/<name>.md` first
- * 2. Fall back to `.pi/skills/<name>/SKILL.md`
- * 3. If neither exists, throw an error with skill name and both paths
+ * Skill roots come from the `skills` array in `.pi/settings.json`
+ * (see loadSkillsRoots) — missing skills warn and are skipped, never throw.
  *
  * Empty/undefined input returns empty array (noop).
  */
 export function resolveSkillPaths(skillsRaw: string | undefined, cwd?: string): string[] {
-	return resolveSkillPathsWithFs(skillsRaw, cwd || process.cwd(), existsSync);
+	const baseCwd = cwd || process.cwd();
+	return resolveSkillPathsWithFs(skillsRaw, baseCwd, existsSync, loadSkillsRoots(baseCwd));
 }
 
 // ─── Tool discovery ────────────────────────────────────────────────

--- a/.pi/extensions/supervisor/test/agent-runner-subprocess.test.mts
+++ b/.pi/extensions/supervisor/test/agent-runner-subprocess.test.mts
@@ -12,6 +12,8 @@
 import { describe, it, mock, before } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 
 // ─── Import real child_process to preserve non-mocked exports ─────
 // We need the real spawnSync for pi-coding-agent dependency.
@@ -1157,11 +1159,75 @@ if (hasMockModule) {
 			const result = buildSubprocessArgs(noModelAgent as any, "test task", "/tmp");
 			assert.ok(!result.args.includes("--model"), "should not have --model when empty");
 		});
+
+		it("missing skill with cwd lacking settings → no throw, skillPaths [], no --skill flag", async () => {
+			const { buildSubprocessArgs } = await import("../agent/runner.ts");
+			const badSkillAgent = {
+				config: {
+					name: "bad-skill-agent",
+					tools: "read",
+					model: "",
+					extensions: "",
+					skills: "definitely-missing-skill-xyz",
+					thinking: "",
+				},
+				systemPrompt: "You are a test agent.",
+			};
+			const result = buildSubprocessArgs(badSkillAgent as any, "test task", "/tmp");
+			assert.deepEqual(result.skillPaths, []);
+			assert.ok(!result.args.includes("--skill"), "no --skill flag for missing skill");
+			assert.ok(result.args.includes("--no-skills"), "--no-skills still present");
+		});
+
+		it("mixed resolvable + missing skill → only resolvable --skill emitted", async () => {
+			const { buildSubprocessArgs } = await import("../agent/runner.ts");
+			const mixedAgent = {
+				config: {
+					name: "mixed-agent",
+					tools: "read",
+					model: "",
+					extensions: "",
+					skills: "extension-spec, definitely-missing-skill-xyz",
+					thinking: "",
+				},
+				systemPrompt: "You are a test agent.",
+			};
+			const result = buildSubprocessArgs(mixedAgent as any, "test task", process.cwd());
+			const skillFlags = result.args.filter((a) => a === "--skill");
+			const hasPrivatePi = existsSync(
+				join(process.cwd(), "private-pi", "skills", "extension-spec", "SKILL.md"),
+			);
+			if (hasPrivatePi) {
+				assert.equal(result.skillPaths.length, 1);
+				assert.ok(
+					result.skillPaths[0]!.endsWith("extension-spec/SKILL.md"),
+					`got ${result.skillPaths[0]}`,
+				);
+				assert.equal(skillFlags.length, 1, "exactly one --skill flag");
+				assert.ok(result.args.includes("--no-skills"), "--no-skills still present");
+			} else {
+				// Submodule absent → both skills fail open
+				assert.deepEqual(result.skillPaths, []);
+				assert.equal(skillFlags.length, 0);
+			}
+		});
 	});
 
 	describe("runAgentSubprocess — safe fallback (guarded pre-Promise block)", () => {
-		it("sync throw from resolveSkillPaths (missing skill) returns {success: false}", async () => {
+		it("missing skill does not throw — subprocess runs with skill skipped (fail-open)", async () => {
 			resetMock();
+			currentMockOpts = {
+				stdoutLines: [
+					JSON.stringify({
+						type: "message_update",
+						delta: { type: "text_delta", text_delta: "Completed." },
+					}),
+					JSON.stringify({ type: "message_update", delta: { type: "text_end" } }),
+					JSON.stringify({ type: "message_end", message: { role: "assistant" } }),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
 			const badSkillAgent = {
 				config: {
 					name: "bad-skill-agent",
@@ -1175,22 +1241,12 @@ if (hasMockModule) {
 			};
 
 			const { runAgentSubprocess } = await import("../agent/runner.ts");
-			const result = await runAgentSubprocess(
-				badSkillAgent as any,
-				"test task",
-				mockCtx,
-				5000,
-			);
+			const resultPromise = runAgentSubprocess(badSkillAgent as any, "test task", mockCtx, 5000);
+			emitMockEvents();
+			const result = await resultPromise;
 
-			assert.equal(result.success, false);
-			assert.ok(
-				result.summaryLine.includes("Subprocess setup failed") ||
-					result.summaryLine.includes("not found"),
-				`summaryLine should indicate failure: ${result.summaryLine}`,
-			);
+			assert.equal(result.success, true);
 			assert.equal(result.agentName, "bad-skill-agent");
-			assert.equal(result.toolCount, 0);
-			assert.equal(result.tokenCount, 0);
 		});
 
 		it("existsSync(effectiveCwd) guard still returns {success: false} (regression)", async () => {
@@ -1213,10 +1269,32 @@ if (hasMockModule) {
 		});
 
 		it("runAgentSubprocess never rejects for any input (bad skill, bad cwd)", async () => {
-			resetMock();
 			const { runAgentSubprocess } = await import("../agent/runner.ts");
 
-			// Bad skill
+			// Bad cwd — guarded before spawn, resolves without rejection
+			const badCwdResult = await runAgentSubprocess(
+				mockAgent as any,
+				"test task",
+				mockCtx,
+				5000,
+				"/nonexistent-path-12345",
+			);
+			assert.equal(badCwdResult.success, false);
+			assert.equal(badCwdResult.agentName, "test-agent");
+
+			// Bad skill — fail-open: agent runs without the missing skill
+			resetMock();
+			currentMockOpts = {
+				stdoutLines: [
+					JSON.stringify({
+						type: "message_update",
+						delta: { type: "text_delta", text_delta: "Done." },
+					}),
+					JSON.stringify({ type: "message_end", message: { role: "assistant" } }),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
 			const badSkillAgent = {
 				config: {
 					name: "bad-skill-agent",
@@ -1229,13 +1307,10 @@ if (hasMockModule) {
 				systemPrompt: "You are a test agent.",
 			};
 
-			const result = await runAgentSubprocess(
-				badSkillAgent as any,
-				"test task",
-				mockCtx,
-				5000,
-			);
-			assert.equal(result.success, false);
+			const resultPromise = runAgentSubprocess(badSkillAgent as any, "test task", mockCtx, 5000);
+			emitMockEvents();
+			const result = await resultPromise;
+			assert.equal(result.success, true);
 			assert.equal(result.agentName, "bad-skill-agent");
 		});
 
@@ -1266,8 +1341,19 @@ if (hasMockModule) {
 			assert.equal(result.success, true);
 		});
 
-		it("sync throw produces AgentRunResult with all expected fields", async () => {
+		it("fail-open missing skill still produces AgentRunResult with all expected fields", async () => {
 			resetMock();
+			currentMockOpts = {
+				stdoutLines: [
+					JSON.stringify({
+						type: "message_update",
+						delta: { type: "text_delta", text_delta: "Finished." },
+					}),
+					JSON.stringify({ type: "message_end", message: { role: "assistant" } }),
+				],
+				exitCode: 0,
+				exitSignal: null,
+			};
 			const badSkillAgent = {
 				config: {
 					name: "bad-skill-agent",
@@ -1281,12 +1367,9 @@ if (hasMockModule) {
 			};
 
 			const { runAgentSubprocess } = await import("../agent/runner.ts");
-			const result = await runAgentSubprocess(
-				badSkillAgent as any,
-				"test task",
-				mockCtx,
-				5000,
-			);
+			const resultPromise = runAgentSubprocess(badSkillAgent as any, "test task", mockCtx, 5000);
+			emitMockEvents();
+			const result = await resultPromise;
 
 			// Verify all AgentRunResult fields are present
 			assert.equal(typeof result.success, "boolean");

--- a/.pi/extensions/supervisor/test/auditor-extension-dead-code-hunter.test.mts
+++ b/.pi/extensions/supervisor/test/auditor-extension-dead-code-hunter.test.mts
@@ -9,7 +9,7 @@
  */
 
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -103,8 +103,18 @@ describe("resolveSkillPaths regression (Phase 2)", () => {
 		assert.deepEqual(resolveSkillPaths("   "), []);
 	});
 
-	it("resolveSkillPaths('nonexistent-skill-xyz') throws (regression)", () => {
-		assert.throws(() => resolveSkillPaths("nonexistent-skill-xyz"), /nonexistent-skill-xyz/);
+	it("resolveSkillPaths('nonexistent-skill-xyz') does not throw — warns and skips (regression)", () => {
+		const warnSpy = mock.method(console, "warn");
+		try {
+			const result = resolveSkillPaths("nonexistent-skill-xyz");
+			assert.deepEqual(result, []);
+		} finally {
+			warnSpy.mock.restore();
+		}
+		assert.ok(warnSpy.mock.calls.length >= 1, "should warn for missing skill");
+		assert.ok(
+			String(warnSpy.mock.calls[0]?.arguments[0] ?? "").includes("nonexistent-skill-xyz"),
+		);
 	});
 });
 

--- a/.pi/extensions/supervisor/test/auditor-extension-duplicate-code-hunter.test.mts
+++ b/.pi/extensions/supervisor/test/auditor-extension-duplicate-code-hunter.test.mts
@@ -10,7 +10,7 @@
  */
 
 import assert from "node:assert";
-import { describe, it } from "node:test";
+import { describe, it, mock } from "node:test";
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -136,7 +136,17 @@ describe("resolveSkillPaths regression (Phase 3)", () => {
 		assert.deepEqual(resolveSkillPaths("   "), []);
 	});
 
-	it("resolveSkillPaths('nonexistent-skill-xyz') throws (regression)", () => {
-		assert.throws(() => resolveSkillPaths("nonexistent-skill-xyz"), /nonexistent-skill-xyz/);
+	it("resolveSkillPaths('nonexistent-skill-xyz') does not throw — warns and skips (regression)", () => {
+		const warnSpy = mock.method(console, "warn");
+		try {
+			const result = resolveSkillPaths("nonexistent-skill-xyz");
+			assert.deepEqual(result, []);
+		} finally {
+			warnSpy.mock.restore();
+		}
+		assert.ok(warnSpy.mock.calls.length >= 1, "should warn for missing skill");
+		assert.ok(
+			String(warnSpy.mock.calls[0]?.arguments[0] ?? "").includes("nonexistent-skill-xyz"),
+		);
 	});
 });

--- a/.pi/extensions/supervisor/test/config.test.mts
+++ b/.pi/extensions/supervisor/test/config.test.mts
@@ -1,9 +1,12 @@
 // ─── Tests: config.ts — Phase 1 config validation ──────────────────
 // Pure function tests — no infra needed.
 
-import { describe, it } from "node:test";
+import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { validateAgentTimeouts } from "../config/config.ts";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, isAbsolute } from "node:path";
+import { validateAgentTimeouts, loadSkillsRoots } from "../config/config.ts";
 
 // ─── validateAgentTimeouts ────────────────────────────────────────
 
@@ -181,5 +184,76 @@ describe("loadConfig — config shape", () => {
 			typeof 1.0 === "number" && !isNaN(1.0) && 1.0 >= 0 && 1.0 <= 1,
 			"1.0 should be valid",
 		);
+	});
+});
+
+// ─── loadSkillsRoots — settings-driven skill roots ────────────────
+
+describe("loadSkillsRoots", () => {
+	let tmp: string;
+
+	afterEach(() => {
+		if (tmp) rmSync(tmp, { recursive: true, force: true });
+		tmp = "";
+	});
+
+	/** Write `.pi/settings.json` in a fresh temp dir; settingsJson null → no file. */
+	function makeFixture(settingsJson: string | null): string {
+		tmp = mkdtempSync(join(tmpdir(), "pi-skills-"));
+		if (settingsJson !== null) {
+			mkdirSync(join(tmp, ".pi"), { recursive: true });
+			writeFileSync(join(tmp, ".pi", "settings.json"), settingsJson);
+		}
+		return tmp;
+	}
+
+	it("adapter: plain entries resolve against cwd, ../ entries against settings dir", () => {
+		const dir = makeFixture(JSON.stringify({ skills: [".pi/skills", "../private-pi/skills"] }));
+		assert.deepEqual(loadSkillsRoots(dir), [
+			join(dir, ".pi", "skills"),
+			join(dir, "private-pi", "skills"),
+		]);
+	});
+
+	it("adapter: missing settings.json → [] (fail-open, no throw)", () => {
+		const dir = makeFixture(null);
+		assert.deepEqual(loadSkillsRoots(dir), []);
+	});
+
+	it("adapter: invalid JSON → [] (fail-open, no throw)", () => {
+		const dir = makeFixture("{ not json");
+		assert.deepEqual(loadSkillsRoots(dir), []);
+	});
+
+	it("entity: missing skills key or empty array → []", () => {
+		assert.deepEqual(loadSkillsRoots(makeFixture(JSON.stringify({ prompts: [] }))), []);
+		assert.deepEqual(loadSkillsRoots(makeFixture(JSON.stringify({ skills: [] }))), []);
+	});
+
+	it("entity: pattern-prefixed entries (!/+/−) filtered out, plain kept", () => {
+		const dir = makeFixture(
+			JSON.stringify({ skills: ["!foo", "+bar", "-baz", ".pi/skills"] }),
+		);
+		assert.deepEqual(loadSkillsRoots(dir), [join(dir, ".pi", "skills")]);
+	});
+
+	it("entity: non-string entries filtered out", () => {
+		const dir = makeFixture(
+			JSON.stringify({ skills: [".pi/skills", 42, null, true, "../private-pi/skills"] }),
+		);
+		assert.deepEqual(loadSkillsRoots(dir), [
+			join(dir, ".pi", "skills"),
+			join(dir, "private-pi", "skills"),
+		]);
+	});
+
+	it("entity: every root is absolute; order matches declared order", () => {
+		const dir = makeFixture(JSON.stringify({ skills: ["../a", ".pi/skills", "../b"] }));
+		const roots = loadSkillsRoots(dir);
+		assert.equal(roots.length, 3);
+		for (const r of roots) assert.ok(isAbsolute(r), `${r} should be absolute`);
+		assert.equal(roots[0], join(dir, "a"));
+		assert.equal(roots[1], join(dir, ".pi", "skills"));
+		assert.equal(roots[2], join(dir, "b"));
 	});
 });

--- a/.pi/extensions/supervisor/test/extensions.test.mts
+++ b/.pi/extensions/supervisor/test/extensions.test.mts
@@ -4,9 +4,13 @@
 import { describe, it, afterEach, mock } from "node:test";
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve as resolvePath } from "node:path";
 import { resolveSkillPaths, resolveSkillPathsWithFs } from "../lib/extensions.ts";
 
 // ─── resolveSkillPaths (uses real fs) ────────────────────────────
+
+afterEach(() => mock.restoreAll());
 
 describe("resolveSkillPaths", () => {
 	it("returns empty array for undefined", () => {
@@ -21,31 +25,59 @@ describe("resolveSkillPaths", () => {
 		assert.deepEqual(resolveSkillPaths("   "), []);
 	});
 
-	it("resolves extension-spec (real SKILL.md exists)", () => {
+	it("resolves extension-spec (real SKILL.md exists in a configured root)", () => {
 		const result = resolveSkillPaths("extension-spec");
-		assert.equal(result.length, 1);
-		assert.ok(result[0]!.endsWith(".pi/skills/extension-spec/SKILL.md"));
+		if (fs.existsSync(resolvePath(process.cwd(), "private-pi/skills/extension-spec/SKILL.md"))) {
+			assert.equal(result.length, 1);
+			assert.ok(
+				result[0]!.endsWith("extension-spec/SKILL.md"),
+				`got ${result[0]}`,
+			);
+		} else {
+			// Submodule absent (e.g. uninitialized worktree) → fail-open
+			assert.deepEqual(result, []);
+		}
 	});
 
-	it("throws for nonexistent skill", () => {
-		assert.throws(() => resolveSkillPaths("nonexistent-skill-xyz"), /nonexistent-skill-xyz/);
+	it("warns and skips for nonexistent skill (fail-open, no throw)", () => {
+		const warnSpy = mock.method(console, "warn");
+		const result = resolveSkillPaths("nonexistent-skill-xyz");
+		warnSpy.mock.restore();
+		assert.deepEqual(result, []);
+		assert.ok(warnSpy.mock.calls.length >= 1, "should warn for missing skill");
+		assert.ok(
+			String(warnSpy.mock.calls[0]?.arguments[0] ?? "").includes("nonexistent-skill-xyz"),
+		);
 	});
 
-	it("throw message includes both attempted paths", () => {
+	it("warning message includes skill name and all tried paths", () => {
+		const warnSpy = mock.method(console, "warn");
+		const result = resolveSkillPaths("nosuchskill");
+		warnSpy.mock.restore();
+		assert.deepEqual(result, []);
+		const msg = String(warnSpy.mock.calls[0]?.arguments[0] ?? "");
+		assert.ok(msg.includes("nosuchskill"), `Message should include skill name: ${msg}`);
+		assert.ok(
+			msg.includes("nosuchskill.md") && msg.includes("SKILL.md"),
+			`Message should include tried paths: ${msg}`,
+		);
+	});
+
+	it("adapter: settings-driven roots resolve temp-dir skill (real fs)", () => {
+		const tmp = fs.mkdtempSync(join(tmpdir(), "pi-skills-"));
 		try {
-			resolveSkillPaths("nosuchskill");
-			assert.fail("Expected error");
-		} catch (e: unknown) {
-			const msg = e instanceof Error ? e.message : String(e);
-			assert.ok(msg.includes("nosuchskill"), `Message should include skill name: ${msg}`);
-			assert.ok(
-				msg.includes("nosuchskill.md") || msg.includes("nosuchskill.md"),
-				`Message should include .md path: ${msg}`,
+			fs.mkdirSync(join(tmp, ".pi"), { recursive: true });
+			fs.writeFileSync(
+				join(tmp, ".pi", "settings.json"),
+				JSON.stringify({ skills: [".pi/skills", "../private-pi/skills"] }),
 			);
-			assert.ok(
-				msg.includes("SKILL.md") || msg.includes("nosuchskill/SKILL.md"),
-				`Message should include SKILL.md path: ${msg}`,
-			);
+			fs.mkdirSync(join(tmp, "private-pi", "skills", "x"), { recursive: true });
+			fs.writeFileSync(join(tmp, "private-pi", "skills", "x", "SKILL.md"), "---\n");
+
+			const result = resolveSkillPaths("x", tmp);
+			assert.deepEqual(result, [join(tmp, "private-pi", "skills", "x", "SKILL.md")]);
+		} finally {
+			fs.rmSync(tmp, { recursive: true, force: true });
 		}
 	});
 });
@@ -80,22 +112,23 @@ describe("resolveSkillPathsWithFs", () => {
 		assert.ok(result[0]!.endsWith(".pi/skills/my-skill.md"));
 	});
 
-	it("throws when neither path exists", () => {
-		const mockExists = (): boolean => false;
-		assert.throws(() => resolveSkillPathsWithFs("bad-skill", "/root", mockExists), /bad-skill/);
+	it("warns and skips when no root has the skill (no throw)", () => {
+		const warnSpy = mock.method(console, "warn");
+		const result = resolveSkillPathsWithFs("bad-skill", "/root", () => false);
+		warnSpy.mock.restore();
+		assert.deepEqual(result, []);
+		assert.ok(warnSpy.mock.calls.length >= 1, "should warn for missing skill");
 	});
 
-	it("throw message includes both paths", () => {
-		const mockExists = (): boolean => false;
-		try {
-			resolveSkillPathsWithFs("bad-skill", "/root", mockExists);
-			assert.fail("Expected error");
-		} catch (e: unknown) {
-			const msg = e instanceof Error ? e.message : String(e);
-			assert.ok(msg.includes("bad-skill"));
-			assert.ok(msg.includes("bad-skill.md"));
-			assert.ok(msg.includes("SKILL.md"));
-		}
+	it("warning message includes name and both tried paths", () => {
+		const warnSpy = mock.method(console, "warn");
+		const result = resolveSkillPathsWithFs("bad-skill", "/root", () => false);
+		warnSpy.mock.restore();
+		assert.deepEqual(result, []);
+		const msg = String(warnSpy.mock.calls[0]?.arguments[0] ?? "");
+		assert.ok(msg.includes("bad-skill"));
+		assert.ok(msg.includes("bad-skill.md"));
+		assert.ok(msg.includes("SKILL.md"));
 	});
 
 	it("resolves multiple skills", () => {
@@ -112,14 +145,72 @@ describe("resolveSkillPathsWithFs", () => {
 		assert.ok(result[1]!.endsWith("skill-b.md"));
 	});
 
-	it("throws on missing skill in multiple (fail-fast)", () => {
+	it("returns present skills and skips missing one (partial results, single warning)", () => {
+		const warnSpy = mock.method(console, "warn");
 		const mockExists = (p: string): boolean => {
 			return p.includes(".pi/skills/skill-a.md");
 		};
-		assert.throws(
-			() => resolveSkillPathsWithFs("skill-a, missing-skill", "/root", mockExists),
-			/missing-skill/,
-		);
+		const result = resolveSkillPathsWithFs("skill-a, missing-skill", "/root", mockExists);
+		warnSpy.mock.restore();
+		assert.equal(result.length, 1);
+		assert.ok(result[0]!.endsWith("skill-a.md"));
+		assert.equal(warnSpy.mock.calls.length, 1, "warning emitted only for the missing skill");
+		assert.ok(String(warnSpy.mock.calls[0]?.arguments[0] ?? "").includes("missing-skill"));
+	});
+
+	it("injected roots: resolves via later root when earlier roots miss (the bug fix)", () => {
+		const roots = ["/root/.pi/skills", "/root/private-pi/skills"];
+		const mockExists = (p: string): boolean => {
+			return p === "/root/private-pi/skills/extension-spec/SKILL.md";
+		};
+		const result = resolveSkillPathsWithFs("extension-spec", "/root", mockExists, roots);
+		assert.deepEqual(result, ["/root/private-pi/skills/extension-spec/SKILL.md"]);
+	});
+
+	it("injected roots: first hit wins when name exists in multiple roots", () => {
+		const roots = ["/root/.pi/skills", "/root/private-pi/skills"];
+		const mockExists = (p: string): boolean => {
+			return (
+				p === "/root/.pi/skills/dup.md" || p === "/root/private-pi/skills/dup.md"
+			);
+		};
+		const result = resolveSkillPathsWithFs("dup", "/root", mockExists, roots);
+		assert.deepEqual(result, ["/root/.pi/skills/dup.md"]);
+	});
+
+	it("per-root probe order: root-1 SKILL.md beats root-2 .md", () => {
+		const roots = ["/root/.pi/skills", "/root/private-pi/skills"];
+		const mockExists = (p: string): boolean => {
+			return (
+				p === "/root/.pi/skills/x/SKILL.md" || p === "/root/private-pi/skills/x.md"
+			);
+		};
+		const result = resolveSkillPathsWithFs("x", "/root", mockExists, roots);
+		assert.deepEqual(result, ["/root/.pi/skills/x/SKILL.md"]);
+	});
+
+	it("missing across all injected roots → warn containing name and all tried root paths", () => {
+		const roots = ["/root/.pi/skills", "/root/private-pi/skills"];
+		const warnSpy = mock.method(console, "warn");
+		const result = resolveSkillPathsWithFs("ghost", "/root", () => false, roots);
+		warnSpy.mock.restore();
+		assert.deepEqual(result, []);
+		const msg = String(warnSpy.mock.calls[0]?.arguments[0] ?? "");
+		assert.ok(msg.includes("ghost"), `should include skill name: ${msg}`);
+		assert.ok(msg.includes("/root/.pi/skills"), `should include root-1 paths: ${msg}`);
+		assert.ok(msg.includes("/root/private-pi/skills"), `should include root-2 paths: ${msg}`);
+	});
+
+	it("pattern-prefixed entries in roots list are never probed as literal dirs", () => {
+		const roots = ["!foo", "/root/.pi/skills"];
+		const warnSpy = mock.method(console, "warn");
+		const mockExists = (p: string): boolean => {
+			return p.includes(".pi/skills/ok.md");
+		};
+		const result = resolveSkillPathsWithFs("ok", "/root", mockExists, roots);
+		warnSpy.mock.restore();
+		assert.deepEqual(result, [resolvePath("/root/.pi/skills", "ok.md")]);
+		assert.equal(warnSpy.mock.calls.length, 0, "no warning for resolvable skill");
 	});
 
 	it("respects custom cwd parameter", () => {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1421

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 7m 52s | 74.7K | 70 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 39s | 26.9K | 13 | minimax-m3 |
| test-designer | ✓ SUCCESS | 2m 12s | 40.8K | 19 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 6m 55s | 86.4K | 50 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 52s | 43.4K | 47 | minimax-m3 |

**Total:** 5 agents · 20m 28s · 272.2K tokens · 199 tool calls · 12 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1421
Closes #1421