### PR TITLE
feat(#1409): CLEAN: Split 321-line renderSessionToMarkdown in renderer.ts

### DIFF
--- a/.pi/extensions/session-logger/renderer.ts
+++ b/.pi/extensions/session-logger/renderer.ts
@@ -3,366 +3,54 @@
  *
  * Reads any .pi/sessions/*.jsonl file and produces a human-readable .md report.
  * Pure function — no side effects, no extension dependencies.
+ *
+ * Public entry point. Orchestrates six section builders and re-exports the
+ * metadata-side stats API; internals live in renderer/{parse,format,details,
+ * session-stats}.ts (import graph acyclic — see golden test structural guard).
  */
 
-import { readFileSync } from "node:fs";
-import { createPerTurnState, flushTurn } from "./per-turn.ts";
-import type { PerTurnState } from "./per-turn.ts";
-import { handleModelChanges } from "./session-utils.ts";
+import { loadSessionEntries } from "./renderer/parse.ts";
+import { escMd, fmtCost, fmtTokens } from "./renderer/format.ts";
+import {
+	renderCompactionEntry,
+	renderCustomEntry,
+	renderMessageEntry,
+	renderModelChangeEntry,
+	renderThinkingChangeEntry,
+} from "./renderer/details.ts";
+import type { ConversationTurnState } from "./renderer/details.ts";
+import { parseSessionStats } from "./renderer/session-stats.ts";
+import type { ParsedSessionStats } from "./renderer/session-stats.ts";
 
-const TRUNCATE_RESULT_LINES = 8;
-const THINKING_PREVIEW_CHARS = 120;
-
-// ── Parsed session data (used by metadata + markdown) ──
-
-export interface ParsedSessionStats {
-	sessionId: string;
-	timestamp: string;
-	cwd: string;
-	version: number;
-	parentSession?: string;
-	entryCount: number;
-	tokens: {
-		input: number;
-		output: number;
-		cacheRead: number;
-		cacheWrite: number;
-		total: number;
-	};
-	cost: number;
-	modelChanges: Array<{ time: string; model: string }>;
-	thinkingChanges: Array<{ time: string; level: string }>;
-	compactions: number;
-	toolStats: Record<string, { calls: number; errors: number; totalDurationMs: number }>;
-	subagentToolStats?: Record<
-		string,
-		Record<string, { calls: number; errors: number; totalDurationMs: number }>
-	>;
-	fileModifications: Array<{ action: string; path: string; timestamp: string; size?: number }>;
-	perTurnTokens: Array<{
-		turnIndex: number;
-		tokens: number;
-		cost: number;
-		toolCount: number;
-		errorCount: number;
-	}>;
-}
-
-function fmtTokens(n: number): string {
-	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-	if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
-	return String(n);
-}
-
-function fmtCost(c: number | undefined | null): string {
-	if (c == null || c === 0) return "$0";
-	if (c < 0.001) return `$${c.toFixed(6)}`;
-	if (c < 1) return `$${c.toFixed(4)}`;
-	return `$${c.toFixed(2)}`;
-}
-
-function truncate(s: string, n: number): string {
-	if (s.length <= n) return s;
-	return s.slice(0, n) + `…(+${s.length - n} chars)`;
-}
-
-function resultPreview(text: string): string {
-	const lines = text.split("\n");
-	if (lines.length <= TRUNCATE_RESULT_LINES && text.length <= 500) return text;
-	return (
-		lines.slice(0, TRUNCATE_RESULT_LINES).join("\n") +
-		`\n…(+${lines.length - TRUNCATE_RESULT_LINES} more lines, ${text.length} total chars)`
-	);
-}
-
-function escMd(s: string): string {
-	return s.replace(/\|/g, "\\|").replace(/`/g, "\\`");
-}
-
-/** Format duration from milliseconds to human-readable string. */
-function fmtDuration(ms: number): string {
-	if (ms < 1000) return `${ms}ms`;
-	if (ms < 60000) return `${(ms / 1000).toFixed(0)}s`;
-	const min = Math.floor(ms / 60000);
-	const sec = Math.round((ms % 60000) / 1000);
-	return `${min}m ${sec}s`;
-}
-
-/**
- * Render sub-agent details from a supervisor custom message.
- *
- * Expects `details` shape:
- * {
- *   agentName?: string;
- *   statusLabel?: string;
- *   toolCount?: number;
- *   tokenCount?: number;
- *   durationMs?: number;
- *   thinkingOutput?: string;
- *   hasThinking?: boolean;
- *   textOutput?: string;
- *   rawOutput?: string;
- *   hasRawOutput?: boolean;
- *   auditScore?: number;
- * }
- *
- * All fields optional — degrades gracefully via `?.` optional chaining.
- */
-function renderSupervisorDetails(details: Record<string, unknown>): string[] {
-	const lines: string[] = [];
-
-	const agentName = details?.agentName ?? "unknown-agent";
-	const statusLabel = details?.statusLabel ?? "";
-	const toolCount = details?.toolCount;
-	const tokenCount = details?.tokenCount;
-	const durationMs = details?.durationMs;
-	const thinkingOutput = details?.thinkingOutput;
-	const hasThinking = details?.hasThinking;
-	const textOutput = details?.textOutput;
-	const rawOutput = details?.rawOutput;
-	const hasRawOutput = details?.hasRawOutput;
-	const auditScore = details?.auditScore;
-
-	// Agent header
-	const statusPart = statusLabel ? ` -- ${statusLabel}` : "";
-	lines.push(`### Agent: ${agentName}${statusPart}`);
-
-	// Stats line
-	const stats: string[] = [];
-	if (toolCount != null) stats.push(`${toolCount} tools`);
-	if (tokenCount != null) stats.push(`${fmtTokens(tokenCount as number)} tokens`);
-	if (durationMs != null) stats.push(fmtDuration(durationMs as number));
-	if (stats.length > 0) {
-		lines.push(``);
-		lines.push(stats.join(", "));
-	}
-
-	// Thinking blocks
-	if (
-		hasThinking &&
-		thinkingOutput &&
-		typeof thinkingOutput === "string" &&
-		thinkingOutput.trim()
-	) {
-		lines.push(``);
-		lines.push(`Thinking:`);
-		for (const para of thinkingOutput.split("\n")) {
-			lines.push(`  ${para}`);
-		}
-	}
-
-	// Tool calls and results (textOutput)
-	if (textOutput && typeof textOutput === "string" && textOutput.trim()) {
-		lines.push(``);
-		for (const line of textOutput.split("\n")) {
-			lines.push(`  ${line}`);
-		}
-	}
-
-	// Raw output — collapsed section
-	if (hasRawOutput && rawOutput && typeof rawOutput === "string" && rawOutput.trim()) {
-		lines.push(``);
-		lines.push(`<details>`);
-		lines.push(`<summary>Raw output (collapsed)</summary>`);
-		lines.push(``);
-		lines.push("```");
-		lines.push(rawOutput);
-		lines.push("```");
-		lines.push(`</details>`);
-	}
-
-	// Audit score
-	if (auditScore != null) {
-		lines.push(``);
-		lines.push(`Audit score: ${auditScore}`);
-	}
-
-	lines.push(``);
-	return lines;
-}
-
-/** Parse a .jsonl session file and extract statistics for metadata. */
-export function parseSessionStats(filepath: string): ParsedSessionStats | null {
-	const raw = readFileSync(filepath, "utf-8").trim();
-	if (!raw) return null;
-
-	const entries = raw
-		.split("\n")
-		.filter(Boolean)
-		.map((l) => JSON.parse(l));
-	if (entries.length === 0) return null;
-
-	const header = entries[0];
-
-	const modelChanges: Array<{ time: string; model: string }> = [];
-	const thinkingChanges: Array<{ time: string; level: string }> = [];
-	let inputTokens = 0;
-	let outputTokens = 0;
-	let cacheRead = 0;
-	let cacheWrite = 0;
-	let totalTokens = 0;
-	let totalCost = 0;
-	let compactions = 0;
-	const toolCounts: Record<string, { calls: number; errors: number; totalDurationMs: number }> = {};
-	const subagentToolStats: Record<
-		string,
-		Record<string, { calls: number; errors: number; totalDurationMs: number }>
-	> = {};
-	const fileMods: Array<{ action: string; path: string; timestamp: string; size?: number }> = [];
-
-	// Per-turn tracking — uses shared PerTurnState from per-turn.ts
-	const turnState: PerTurnState = createPerTurnState();
-
-	handleModelChanges(entries, modelChanges, thinkingChanges);
-
-	for (const entry of entries) {
-		if (entry.type === "compaction") {
-			compactions++;
-		} else if (entry.type === "message") {
-			const msg = entry.message ?? {};
-			const role = msg.role;
-
-			// Token tracking from assistant messages
-			if (role === "assistant") {
-				const usage = msg.usage;
-				if (usage) {
-					inputTokens += usage.input ?? 0;
-					outputTokens += usage.output ?? 0;
-					cacheRead += usage.cacheRead ?? 0;
-					cacheWrite += usage.cacheWrite ?? 0;
-					totalTokens += usage.totalTokens ?? 0;
-					const cost = usage.cost?.total ?? 0;
-					totalCost += cost;
-					turnState.currentTurnTokens += usage.totalTokens ?? 0;
-					turnState.currentTurnCost += cost;
-				}
-
-				// File modifications from tool calls
-				for (const c of msg.content ?? []) {
-					if (c.type === "toolCall") {
-						const action =
-							c.name === "read"
-								? "read"
-								: c.name === "write"
-									? "write"
-									: c.name === "edit"
-										? "edit"
-										: null;
-						if (action) {
-							fileMods.push({
-								action,
-								path: c.arguments?.path ?? "?",
-								timestamp: entry.timestamp ?? new Date().toISOString(),
-								size: action === "write" ? c.arguments?.content?.length : undefined,
-							});
-						}
-					}
-				}
-			}
-
-			// Tool result tracking
-			if (role === "toolResult") {
-				const tn = msg.toolName ?? "?";
-				if (!toolCounts[tn]) toolCounts[tn] = { calls: 0, errors: 0, totalDurationMs: 0 };
-				toolCounts[tn].calls++;
-				if (msg.isError) toolCounts[tn].errors++;
-				turnState.currentTurnToolCount++;
-				if (msg.isError) turnState.currentTurnErrorCount++;
-			}
-
-			// Turn boundaries
-			if (role === "user") {
-				flushTurn(turnState);
-				turnState.currentTurnIndex++;
-			} else if (role === "assistant" && turnState.currentTurnIndex < 0) {
-				turnState.currentTurnIndex = 0;
-			}
-		} else if (entry.type === "custom") {
-			// Extract subagent tool calls from supervisor custom messages
-			const details = entry.details as Record<string, unknown> | undefined;
-			if (
-				entry.customType === "supervisor" &&
-				details?.eventType === "tool-complete" &&
-				details?.toolName &&
-				typeof details.toolName === "string"
-			) {
-				const toolName = details.toolName;
-				const isError = !!details.isError;
-				const durationMs =
-					typeof details.toolDurationMs === "number" ? details.toolDurationMs : 0;
-				const agentName =
-					details?.agentName && typeof details.agentName === "string"
-						? details.agentName
-						: "?";
-
-				// Merge into flat toolStats
-				if (!toolCounts[toolName])
-					toolCounts[toolName] = { calls: 0, errors: 0, totalDurationMs: 0 };
-				toolCounts[toolName].calls++;
-				if (isError) toolCounts[toolName].errors++;
-				toolCounts[toolName].totalDurationMs += durationMs;
-
-				// Build per-agent breakdown
-				if (!subagentToolStats[agentName]) subagentToolStats[agentName] = {};
-				if (!subagentToolStats[agentName][toolName])
-					subagentToolStats[agentName][toolName] = {
-						calls: 0,
-						errors: 0,
-						totalDurationMs: 0,
-					};
-				subagentToolStats[agentName][toolName].calls++;
-				if (isError) subagentToolStats[agentName][toolName].errors++;
-				subagentToolStats[agentName][toolName].totalDurationMs += durationMs;
-			}
-		}
-	}
-	flushTurn(turnState);
-
-	const hasSubagentTools = Object.keys(subagentToolStats).length > 0;
-
-	return {
-		sessionId: header.id ?? "?",
-		timestamp: header.timestamp ?? "?",
-		cwd: header.cwd ?? "?",
-		version: header.version ?? 0,
-		parentSession: header.parentSession,
-		entryCount: entries.length,
-		tokens: {
-			input: inputTokens,
-			output: outputTokens,
-			cacheRead,
-			cacheWrite,
-			total: totalTokens,
-		},
-		cost: totalCost,
-		modelChanges,
-		thinkingChanges,
-		compactions,
-		toolStats: toolCounts,
-		subagentToolStats: hasSubagentTools ? subagentToolStats : undefined,
-		fileModifications: fileMods,
-		perTurnTokens: turnState.perTurnTokens,
-	};
-}
+export { parseSessionStats };
+export type { ParsedSessionStats };
 
 /** Render a .jsonl session file to Markdown. */
 export function renderSessionToMarkdown(
 	filepath: string,
 	overrides?: { sessionName?: string; mode?: string },
 ): string {
-	const raw = readFileSync(filepath, "utf-8").trim();
-	if (!raw) return "*Empty session*";
-
-	const lines = raw
-		.split("\n")
-		.filter(Boolean)
-		.map((l) => JSON.parse(l));
-	if (lines.length === 0) return "*Empty session*";
+	const loaded = loadSessionEntries(filepath);
+	if (!loaded) return "*Empty session*";
 
 	const sections: string[] = [];
+	sections.push(...renderHeader(loaded.entries[0], loaded.entries.length, overrides));
+	sections.push(...renderModelSummary(loaded.entries));
+	sections.push(...renderTokenTotals(loaded.entries));
+	sections.push(...renderToolUsage(loaded.entries));
+	sections.push(...renderFileAccess(loaded.entries));
+	sections.push(...renderConversation(loaded.entries));
+	return sections.join("\n");
+}
 
-	// ── Header ──
-	const header = lines[0];
+// ── Section builders ──
+
+function renderHeader(
+	header: any,
+	entryCount: number,
+	overrides?: { sessionName?: string; mode?: string },
+): string[] {
+	const sections: string[] = [];
 	const sid = header.id ?? "?";
 	const ts = header.timestamp ?? "?";
 	const cwd = header.cwd ?? "?";
@@ -379,11 +67,14 @@ export function renderSessionToMarkdown(
 	if (overrides?.mode !== undefined) sections.push(`| **Mode** | ${escMd(overrides.mode)} |`);
 	sections.push(`| **CWD** | \`${cwd}\` |`);
 	sections.push(`| **Version** | ${ver} |`);
-	sections.push(`| **Entries** | ${lines.length} |`);
+	sections.push(`| **Entries** | ${entryCount} |`);
 	if (parentSession) sections.push(`| **Parent** | \`${parentSession}\` |`);
 	sections.push(``);
+	return sections;
+}
 
-	// ── Model / thinking summary ──
+function renderModelSummary(lines: any[]): string[] {
+	const sections: string[] = [];
 	const models = new Set<string>();
 	const thinkLevels = new Set<string>();
 	for (const l of lines) {
@@ -393,8 +84,11 @@ export function renderSessionToMarkdown(
 	if (models.size) sections.push(`**Models:** ${[...models].join(", ")}  `);
 	if (thinkLevels.size) sections.push(`**Thinking:** ${[...thinkLevels].join(", ")}  `);
 	sections.push(``);
+	return sections;
+}
 
-	// ── Token / cost totals ──
+function renderTokenTotals(lines: any[]): string[] {
+	const sections: string[] = [];
 	let totalTokens = 0;
 	let totalCost = 0;
 	let inputTokens = 0;
@@ -424,8 +118,11 @@ export function renderSessionToMarkdown(
 	sections.push(`| **Total tokens** | ${fmtTokens(totalTokens)} |`);
 	sections.push(`| **Total cost** | ${fmtCost(totalCost)} |`);
 	sections.push(``);
+	return sections;
+}
 
-	// ── Tool usage ──
+function renderToolUsage(lines: any[]): string[] {
+	const sections: string[] = [];
 	const toolCounts: Record<string, { calls: number; errors: number }> = {};
 	for (const l of lines) {
 		if (l.type === "message" && l.message?.role === "toolResult") {
@@ -459,8 +156,11 @@ export function renderSessionToMarkdown(
 		}
 		sections.push(``);
 	}
+	return sections;
+}
 
-	// ── File modifications summary ──
+function renderFileAccess(lines: any[]): string[] {
+	const sections: string[] = [];
 	const fileActions: Array<{ action: string; path: string }> = [];
 	for (const l of lines) {
 		if (l.type === "message" && l.message?.role === "assistant") {
@@ -492,14 +192,16 @@ export function renderSessionToMarkdown(
 		}
 		sections.push(``);
 	}
+	return sections;
+}
 
-	// ── Conversation ──
-	sections.push(`## Conversation`);
-	sections.push(``);
+// ── Conversation ──
+
+function renderConversation(lines: any[]): string[] {
+	const sections: string[] = [`## Conversation`, ``];
 
 	// Build turns: walk entries, group into user → assistant exchanges
-	let turnIdx = 0;
-	let inTurn = false;
+	const turn: ConversationTurnState = { turnIdx: 0, inTurn: false };
 
 	for (let i = 0; i < lines.length; i++) {
 		const l = lines[i];
@@ -507,164 +209,22 @@ export function renderSessionToMarkdown(
 		// Skip header
 		if (i === 0 && l.type === "session") continue;
 
-		// Pass-through entries
+		let rendered: string[];
 		if (l.type === "model_change") {
-			sections.push(`> **Model:** \`${l.provider}/${l.modelId}\``);
-			sections.push(``);
+			rendered = renderModelChangeEntry(l);
+		} else if (l.type === "thinking_level_change") {
+			rendered = renderThinkingChangeEntry(l);
+		} else if (l.type === "custom") {
+			rendered = renderCustomEntry(l);
+		} else if (l.type === "compaction") {
+			rendered = renderCompactionEntry(l);
+		} else if (l.type === "message") {
+			rendered = renderMessageEntry(l, turn);
+		} else {
 			continue;
 		}
-		if (l.type === "thinking_level_change") {
-			sections.push(`> **Thinking:** \`${l.thinkingLevel}\``);
-			sections.push(``);
-			continue;
-		}
-		if (l.type === "custom") {
-			// Supervisor custom messages with details get expanded rendering
-			if (
-				l.customType === "supervisor" &&
-				l.details &&
-				typeof l.details === "object" &&
-				Object.keys(l.details as Record<string, unknown>).length > 0
-			) {
-				sections.push(...renderSupervisorDetails(l.details as Record<string, unknown>));
-			} else {
-				const data = JSON.stringify(l.data ?? {});
-				sections.push(`> *${l.customType}* ${data !== "{}" ? `— ${data}` : ""}`);
-				sections.push(``);
-			}
-			continue;
-		}
-		if (l.type === "compaction") {
-			sections.push(
-				`> **Context compacted** — ${fmtTokens(l.tokensBefore ?? 0)} tokens summarized`,
-			);
-			sections.push(``);
-			continue;
-		}
-
-		if (l.type !== "message") continue;
-
-		const msg = l.message ?? {};
-		const role = msg.role ?? "?";
-		const content = msg.content ?? [];
-
-		if (role === "user") {
-			// Close previous turn
-			if (inTurn) {
-				sections.push(`---`);
-				sections.push(``);
-			}
-			turnIdx++;
-			inTurn = true;
-
-			const texts = content
-				.filter((c: any) => c.type === "text")
-				.map((c: any) => c.text)
-				.join("\n");
-			sections.push(`### Turn ${turnIdx} — User`);
-			sections.push(``);
-			sections.push(`${texts}`);
-			sections.push(``);
-		} else if (role === "assistant") {
-			if (!inTurn) {
-				turnIdx++;
-				inTurn = true;
-				sections.push(`### Turn ${turnIdx} — Assistant`);
-				sections.push(``);
-			}
-
-			const usage = msg.usage ?? {};
-			const toks = usage.totalTokens ?? 0;
-			const cost = usage.cost?.total;
-			const stop = msg.stopReason ?? "";
-
-			// Metadata line
-			const metaParts: string[] = [];
-			if (toks) metaParts.push(`tokens=${fmtTokens(toks)}`);
-			if (cost) metaParts.push(`cost=${fmtCost(cost)}`);
-			if (stop) metaParts.push(`stop=\`${stop}\``);
-
-			// Extract parts
-			const thinkBlocks = content
-				.filter((c: any) => c.type === "thinking")
-				.map((c: any) => c.thinking);
-			const textBlocks = content.filter((c: any) => c.type === "text").map((c: any) => c.text);
-			const toolCalls = content.filter((c: any) => c.type === "toolCall");
-
-			const thinkTotal = thinkBlocks.reduce((s: number, t: string) => s + t.length, 0);
-
-			if (metaParts.length || thinkTotal) {
-				const line = metaParts.join(", ");
-				sections.push(`*${line}*`);
-				sections.push(``);
-			}
-
-			// Thinking — collapsed
-			if (thinkTotal > 0) {
-				const firstLine = thinkBlocks[0].split("\n")[0].slice(0, THINKING_PREVIEW_CHARS);
-				sections.push(`> 💭 ${firstLine}`);
-				if (thinkTotal > THINKING_PREVIEW_CHARS) {
-					sections.push(`> *(…${fmtTokens(thinkTotal)} chars thinking)*`);
-				}
-				sections.push(``);
-			}
-
-			// Text blocks
-			for (const txt of textBlocks) {
-				if (txt.trim()) {
-					sections.push(txt.trim());
-					sections.push(``);
-				}
-			}
-
-			// Tool calls — inline
-			for (const tc of toolCalls) {
-				const tName = tc.name ?? "?";
-				const args = tc.arguments ?? {};
-				let argStr = "";
-				if (typeof args === "object") {
-					const parts: string[] = [];
-					for (const [k, v] of Object.entries(args)) {
-						const vStr = typeof v === "string" ? truncate(v, 80) : JSON.stringify(v);
-						parts.push(`${k}=\`${escMd(vStr)}\``);
-					}
-					argStr = parts.join(", ");
-				} else {
-					argStr = truncate(String(args), 120);
-				}
-				sections.push(`- 🔧 \`${tName}(${argStr})\``);
-			}
-			if (toolCalls.length > 0) sections.push(``);
-		} else if (role === "toolResult") {
-			const tn = msg.toolName ?? "?";
-			const isErr = msg.isError ?? false;
-			const resultText = content
-				.filter((c: any) => c.type === "text")
-				.map((c: any) => c.text)
-				.join("\n");
-			const errMark = isErr ? " ⚠️" : "";
-			const sizeLabel = fmtTokens(resultText.length);
-
-			sections.push(`  📥 \`${tn}\`${errMark} — ${sizeLabel}`);
-			if (isErr) {
-				sections.push(`  \`\`\``);
-				sections.push(`  ${truncate(resultText, 300)}`);
-				sections.push(`  \`\`\``);
-			} else if (resultText.length > 0) {
-				const preview = resultPreview(resultText);
-				if (preview.includes("\n")) {
-					sections.push(`  \`\`\``);
-					for (const line of preview.split("\n")) {
-						sections.push(`  ${line}`);
-					}
-					sections.push(`  \`\`\``);
-				} else {
-					sections.push(`  \`${truncate(escMd(resultText), 200)}\``);
-				}
-			}
-			sections.push(``);
-		}
+		sections.push(...rendered);
 	}
 
-	return sections.join("\n");
+	return sections;
 }

--- a/.pi/extensions/session-logger/renderer/details.ts
+++ b/.pi/extensions/session-logger/renderer/details.ts
@@ -1,0 +1,291 @@
+/**
+ * renderer/details.ts — per-entry / per-role Markdown detail rendering.
+ *
+ * Extracted from the renderSessionToMarkdown conversation loop in
+ * renderer.ts. Each renderer returns the exact lines the original loop
+ * pushed, preserving byte-identical output (golden-characterized).
+ */
+
+import {
+	escMd,
+	fmtCost,
+	fmtDuration,
+	fmtTokens,
+	resultPreview,
+	THINKING_PREVIEW_CHARS,
+	truncate,
+} from "./format.ts";
+
+/**
+ * Render sub-agent details from a supervisor custom message.
+ *
+ * Expects `details` shape:
+ * {
+ *   agentName?: string;
+ *   statusLabel?: string;
+ *   toolCount?: number;
+ *   tokenCount?: number;
+ *   durationMs?: number;
+ *   thinkingOutput?: string;
+ *   hasThinking?: boolean;
+ *   textOutput?: string;
+ *   rawOutput?: string;
+ *   hasRawOutput?: boolean;
+ *   auditScore?: number;
+ * }
+ *
+ * All fields optional — degrades gracefully via `?.` optional chaining.
+ */
+export function renderSupervisorDetails(details: Record<string, unknown>): string[] {
+	const lines: string[] = [];
+
+	const agentName = details?.agentName ?? "unknown-agent";
+	const statusLabel = details?.statusLabel ?? "";
+	const toolCount = details?.toolCount;
+	const tokenCount = details?.tokenCount;
+	const durationMs = details?.durationMs;
+	const thinkingOutput = details?.thinkingOutput;
+	const hasThinking = details?.hasThinking;
+	const textOutput = details?.textOutput;
+	const rawOutput = details?.rawOutput;
+	const hasRawOutput = details?.hasRawOutput;
+	const auditScore = details?.auditScore;
+
+	// Agent header
+	const statusPart = statusLabel ? ` -- ${statusLabel}` : "";
+	lines.push(`### Agent: ${agentName}${statusPart}`);
+
+	// Stats line
+	const stats: string[] = [];
+	if (toolCount != null) stats.push(`${toolCount} tools`);
+	if (tokenCount != null) stats.push(`${fmtTokens(tokenCount as number)} tokens`);
+	if (durationMs != null) stats.push(fmtDuration(durationMs as number));
+	if (stats.length > 0) {
+		lines.push(``);
+		lines.push(stats.join(", "));
+	}
+
+	// Thinking blocks
+	if (
+		hasThinking &&
+		thinkingOutput &&
+		typeof thinkingOutput === "string" &&
+		thinkingOutput.trim()
+	) {
+		lines.push(``);
+		lines.push(`Thinking:`);
+		for (const para of thinkingOutput.split("\n")) {
+			lines.push(`  ${para}`);
+		}
+	}
+
+	// Tool calls and results (textOutput)
+	if (textOutput && typeof textOutput === "string" && textOutput.trim()) {
+		lines.push(``);
+		for (const line of textOutput.split("\n")) {
+			lines.push(`  ${line}`);
+		}
+	}
+
+	// Raw output — collapsed section
+	if (hasRawOutput && rawOutput && typeof rawOutput === "string" && rawOutput.trim()) {
+		lines.push(``);
+		lines.push(`<details>`);
+		lines.push(`<summary>Raw output (collapsed)</summary>`);
+		lines.push(``);
+		lines.push("```");
+		lines.push(rawOutput);
+		lines.push("```");
+		lines.push(`</details>`);
+	}
+
+	// Audit score
+	if (auditScore != null) {
+		lines.push(``);
+		lines.push(`Audit score: ${auditScore}`);
+	}
+
+	lines.push(``);
+	return lines;
+}
+
+/** Pass-through `model_change` entry line. */
+export function renderModelChangeEntry(entry: any): string[] {
+	return [`> **Model:** \`${entry.provider}/${entry.modelId}\``, ``];
+}
+
+/** Pass-through `thinking_level_change` entry line. */
+export function renderThinkingChangeEntry(entry: any): string[] {
+	return [`> **Thinking:** \`${entry.thinkingLevel}\``, ``];
+}
+
+/**
+ * `custom` entry — supervisor entries with non-empty details expand to
+ * renderSupervisorDetails; everything else falls through to a one-liner.
+ */
+export function renderCustomEntry(entry: any): string[] {
+	if (
+		entry.customType === "supervisor" &&
+		entry.details &&
+		typeof entry.details === "object" &&
+		Object.keys(entry.details as Record<string, unknown>).length > 0
+	) {
+		return renderSupervisorDetails(entry.details as Record<string, unknown>);
+	}
+	const data = JSON.stringify(entry.data ?? {});
+	return [`> *${entry.customType}* ${data !== "{}" ? `— ${data}` : ""}`, ``];
+}
+
+/** `compaction` entry line. */
+export function renderCompactionEntry(entry: any): string[] {
+	return [`> **Context compacted** — ${fmtTokens(entry.tokensBefore ?? 0)} tokens summarized`, ``];
+}
+
+/** Mutable turn bookkeeping shared by the conversation renderer and message renderers. */
+export interface ConversationTurnState {
+	turnIdx: number;
+	inTurn: boolean;
+}
+
+function renderUserMessage(msg: any, content: any[], turn: ConversationTurnState): string[] {
+	const sections: string[] = [];
+
+	// Close previous turn
+	if (turn.inTurn) {
+		sections.push(`---`);
+		sections.push(``);
+	}
+	turn.turnIdx++;
+	turn.inTurn = true;
+
+	const texts = content
+		.filter((c: any) => c.type === "text")
+		.map((c: any) => c.text)
+		.join("\n");
+	sections.push(`### Turn ${turn.turnIdx} — User`);
+	sections.push(``);
+	sections.push(`${texts}`);
+	sections.push(``);
+	return sections;
+}
+
+function renderAssistantMessage(msg: any, content: any[], turn: ConversationTurnState): string[] {
+	const sections: string[] = [];
+
+	if (!turn.inTurn) {
+		turn.turnIdx++;
+		turn.inTurn = true;
+		sections.push(`### Turn ${turn.turnIdx} — Assistant`);
+		sections.push(``);
+	}
+
+	const usage = msg.usage ?? {};
+	const toks = usage.totalTokens ?? 0;
+	const cost = usage.cost?.total;
+	const stop = msg.stopReason ?? "";
+
+	// Metadata line
+	const metaParts: string[] = [];
+	if (toks) metaParts.push(`tokens=${fmtTokens(toks)}`);
+	if (cost) metaParts.push(`cost=${fmtCost(cost)}`);
+	if (stop) metaParts.push(`stop=\`${stop}\``);
+
+	// Extract parts
+	const thinkBlocks = content.filter((c: any) => c.type === "thinking").map((c: any) => c.thinking);
+	const textBlocks = content.filter((c: any) => c.type === "text").map((c: any) => c.text);
+	const toolCalls = content.filter((c: any) => c.type === "toolCall");
+
+	const thinkTotal = thinkBlocks.reduce((s: number, t: string) => s + t.length, 0);
+
+	if (metaParts.length || thinkTotal) {
+		const line = metaParts.join(", ");
+		sections.push(`*${line}*`);
+		sections.push(``);
+	}
+
+	// Thinking — collapsed
+	if (thinkTotal > 0) {
+		const firstLine = thinkBlocks[0].split("\n")[0].slice(0, THINKING_PREVIEW_CHARS);
+		sections.push(`> 💭 ${firstLine}`);
+		if (thinkTotal > THINKING_PREVIEW_CHARS) {
+			sections.push(`> *(…${fmtTokens(thinkTotal)} chars thinking)*`);
+		}
+		sections.push(``);
+	}
+
+	// Text blocks
+	for (const txt of textBlocks) {
+		if (txt.trim()) {
+			sections.push(txt.trim());
+			sections.push(``);
+		}
+	}
+
+	// Tool calls — inline
+	for (const tc of toolCalls) {
+		const tName = tc.name ?? "?";
+		const args = tc.arguments ?? {};
+		let argStr = "";
+		if (typeof args === "object") {
+			const parts: string[] = [];
+			for (const [k, v] of Object.entries(args)) {
+				const vStr = typeof v === "string" ? truncate(v, 80) : JSON.stringify(v);
+				parts.push(`${k}=\`${escMd(vStr)}\``);
+			}
+			argStr = parts.join(", ");
+		} else {
+			argStr = truncate(String(args), 120);
+		}
+		sections.push(`- 🔧 \`${tName}(${argStr})\``);
+	}
+	if (toolCalls.length > 0) sections.push(``);
+	return sections;
+}
+
+function renderToolResultMessage(msg: any, content: any[]): string[] {
+	const sections: string[] = [];
+
+	const tn = msg.toolName ?? "?";
+	const isErr = msg.isError ?? false;
+	const resultText = content
+		.filter((c: any) => c.type === "text")
+		.map((c: any) => c.text)
+		.join("\n");
+	const errMark = isErr ? " ⚠️" : "";
+	const sizeLabel = fmtTokens(resultText.length);
+
+	sections.push(`  📥 \`${tn}\`${errMark} — ${sizeLabel}`);
+	if (isErr) {
+		sections.push(`  \`\`\``);
+		sections.push(`  ${truncate(resultText, 300)}`);
+		sections.push(`  \`\`\``);
+	} else if (resultText.length > 0) {
+		const preview = resultPreview(resultText);
+		if (preview.includes("\n")) {
+			sections.push(`  \`\`\``);
+			for (const line of preview.split("\n")) {
+				sections.push(`  ${line}`);
+			}
+			sections.push(`  \`\`\``);
+		} else {
+			sections.push(`  \`${truncate(escMd(resultText), 200)}\``);
+		}
+	}
+	sections.push(``);
+	return sections;
+}
+
+/**
+ * `message` entry dispatcher — user / assistant / toolResult roles.
+ * Unknown roles render nothing (no crash).
+ */
+export function renderMessageEntry(entry: any, turn: ConversationTurnState): string[] {
+	const msg = entry.message ?? {};
+	const role = msg.role ?? "?";
+	const content = msg.content ?? [];
+
+	if (role === "user") return renderUserMessage(msg, content, turn);
+	if (role === "assistant") return renderAssistantMessage(msg, content, turn);
+	if (role === "toolResult") return renderToolResultMessage(msg, content);
+	return [];
+}

--- a/.pi/extensions/session-logger/renderer/format.ts
+++ b/.pi/extensions/session-logger/renderer/format.ts
@@ -1,0 +1,50 @@
+/**
+ * renderer/format.ts — Markdown formatting primitives for session reports.
+ *
+ * Pure functions, no I/O. Moved verbatim from renderer.ts — the escaping
+ * rules (escMd pipes/backticks) are GFM-table-critical, so any change here
+ * alters rendered output (golden-characterized).
+ */
+
+export const TRUNCATE_RESULT_LINES = 8;
+export const THINKING_PREVIEW_CHARS = 120;
+
+export function fmtTokens(n: number): string {
+	if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+	if (n >= 1_000) return `${(n / 1_000).toFixed(0)}K`;
+	return String(n);
+}
+
+export function fmtCost(c: number | undefined | null): string {
+	if (c == null || c === 0) return "$0";
+	if (c < 0.001) return `$${c.toFixed(6)}`;
+	if (c < 1) return `$${c.toFixed(4)}`;
+	return `$${c.toFixed(2)}`;
+}
+
+export function truncate(s: string, n: number): string {
+	if (s.length <= n) return s;
+	return s.slice(0, n) + `…(+${s.length - n} chars)`;
+}
+
+export function resultPreview(text: string): string {
+	const lines = text.split("\n");
+	if (lines.length <= TRUNCATE_RESULT_LINES && text.length <= 500) return text;
+	return (
+		lines.slice(0, TRUNCATE_RESULT_LINES).join("\n") +
+		`\n…(+${lines.length - TRUNCATE_RESULT_LINES} more lines, ${text.length} total chars)`
+	);
+}
+
+export function escMd(s: string): string {
+	return s.replace(/\|/g, "\\|").replace(/`/g, "\\`");
+}
+
+/** Format duration from milliseconds to human-readable string. */
+export function fmtDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	if (ms < 60000) return `${(ms / 1000).toFixed(0)}s`;
+	const min = Math.floor(ms / 60000);
+	const sec = Math.round((ms % 60000) / 1000);
+	return `${min}m ${sec}s`;
+}

--- a/.pi/extensions/session-logger/renderer/parse.ts
+++ b/.pi/extensions/session-logger/renderer/parse.ts
@@ -1,0 +1,29 @@
+/**
+ * renderer/parse.ts — JSONL session file loading (data-source adapter).
+ *
+ * Hides readFileSync + line format. Shared by the markdown renderer and the
+ * stats walk. Must NOT swallow JSON.parse throws — the caller's try/catch
+ * (report.ts) owns that error path.
+ */
+
+import { readFileSync } from "node:fs";
+
+/**
+ * Read and parse a .jsonl session file.
+ *
+ * @returns `{ entries }` for a non-empty file, or `null` for empty /
+ * whitespace-only content. A missing file propagates ENOENT; a malformed
+ * line propagates the JSON.parse SyntaxError.
+ */
+export function loadSessionEntries(filepath: string): { entries: any[] } | null {
+	const raw = readFileSync(filepath, "utf-8").trim();
+	if (!raw) return null;
+
+	const entries = raw
+		.split("\n")
+		.filter(Boolean)
+		.map((l) => JSON.parse(l));
+	if (entries.length === 0) return null;
+
+	return { entries };
+}

--- a/.pi/extensions/session-logger/renderer/session-stats.ts
+++ b/.pi/extensions/session-logger/renderer/session-stats.ts
@@ -1,0 +1,236 @@
+/**
+ * renderer/session-stats.ts — metadata-side session stats accumulation.
+ *
+ * parseSessionStats feeds both the .md renderer's sibling walk (via
+ * report.ts → buildMetadata → metadata.json) and downstream metadata. The
+ * single-pass accumulation is split into per-entry accumulators (Clean Code
+ * ch. 3 — small functions), reproducing the original byte-identical results
+ * (golden-characterized).
+ *
+ * Named session-stats.ts (not stats.ts) to avoid collision with the sibling
+ * session-logger/stats.ts module.
+ */
+
+import { createPerTurnState, flushTurn } from "../per-turn.ts";
+import type { PerTurnState } from "../per-turn.ts";
+import { handleModelChanges } from "../session-utils.ts";
+import { loadSessionEntries } from "./parse.ts";
+
+// ── Parsed session data (used by metadata + markdown) ──
+
+export interface ParsedSessionStats {
+	sessionId: string;
+	timestamp: string;
+	cwd: string;
+	version: number;
+	parentSession?: string;
+	entryCount: number;
+	tokens: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		total: number;
+	};
+	cost: number;
+	modelChanges: Array<{ time: string; model: string }>;
+	thinkingChanges: Array<{ time: string; level: string }>;
+	compactions: number;
+	toolStats: Record<string, { calls: number; errors: number; totalDurationMs: number }>;
+	subagentToolStats?: Record<
+		string,
+		Record<string, { calls: number; errors: number; totalDurationMs: number }>
+	>;
+	fileModifications: Array<{ action: string; path: string; timestamp: string; size?: number }>;
+	perTurnTokens: Array<{
+		turnIndex: number;
+		tokens: number;
+		cost: number;
+		toolCount: number;
+		errorCount: number;
+	}>;
+}
+
+type ToolStat = { calls: number; errors: number; totalDurationMs: number };
+
+/** Mutable state threaded through the per-entry accumulators. */
+interface StatsAccumulator {
+	modelChanges: Array<{ time: string; model: string }>;
+	thinkingChanges: Array<{ time: string; level: string }>;
+	inputTokens: number;
+	outputTokens: number;
+	cacheRead: number;
+	cacheWrite: number;
+	totalTokens: number;
+	totalCost: number;
+	compactions: number;
+	toolCounts: Record<string, ToolStat>;
+	subagentToolStats: Record<string, Record<string, ToolStat>>;
+	fileMods: Array<{ action: string; path: string; timestamp: string; size?: number }>;
+	turnState: PerTurnState;
+}
+
+function createStatsAccumulator(): StatsAccumulator {
+	return {
+		modelChanges: [],
+		thinkingChanges: [],
+		inputTokens: 0,
+		outputTokens: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		totalCost: 0,
+		compactions: 0,
+		toolCounts: {},
+		subagentToolStats: {},
+		fileMods: [],
+		turnState: createPerTurnState(),
+	};
+}
+
+/** Accumulate a `message` entry: assistant token/file tracking, toolResult counts, turn boundaries. */
+function accumulateMessageStats(acc: StatsAccumulator, entry: any): void {
+	const msg = entry.message ?? {};
+	const role = msg.role;
+
+	// Token tracking from assistant messages
+	if (role === "assistant") {
+		const usage = msg.usage;
+		if (usage) {
+			acc.inputTokens += usage.input ?? 0;
+			acc.outputTokens += usage.output ?? 0;
+			acc.cacheRead += usage.cacheRead ?? 0;
+			acc.cacheWrite += usage.cacheWrite ?? 0;
+			acc.totalTokens += usage.totalTokens ?? 0;
+			const cost = usage.cost?.total ?? 0;
+			acc.totalCost += cost;
+			acc.turnState.currentTurnTokens += usage.totalTokens ?? 0;
+			acc.turnState.currentTurnCost += cost;
+		}
+
+		// File modifications from tool calls
+		for (const c of msg.content ?? []) {
+			if (c.type === "toolCall") {
+				const action =
+					c.name === "read"
+						? "read"
+						: c.name === "write"
+							? "write"
+							: c.name === "edit"
+								? "edit"
+								: null;
+				if (action) {
+					acc.fileMods.push({
+						action,
+						path: c.arguments?.path ?? "?",
+						timestamp: entry.timestamp ?? new Date().toISOString(),
+						size: action === "write" ? c.arguments?.content?.length : undefined,
+					});
+				}
+			}
+		}
+	}
+
+	// Tool result tracking
+	if (role === "toolResult") {
+		const tn = msg.toolName ?? "?";
+		if (!acc.toolCounts[tn]) acc.toolCounts[tn] = { calls: 0, errors: 0, totalDurationMs: 0 };
+		acc.toolCounts[tn].calls++;
+		if (msg.isError) acc.toolCounts[tn].errors++;
+		acc.turnState.currentTurnToolCount++;
+		if (msg.isError) acc.turnState.currentTurnErrorCount++;
+	}
+
+	// Turn boundaries
+	if (role === "user") {
+		flushTurn(acc.turnState);
+		acc.turnState.currentTurnIndex++;
+	} else if (role === "assistant" && acc.turnState.currentTurnIndex < 0) {
+		acc.turnState.currentTurnIndex = 0;
+	}
+}
+
+/** Accumulate a `custom` entry: subagent tool-complete merges into flat + per-agent stats. */
+function accumulateCustomStats(acc: StatsAccumulator, entry: any): void {
+	const details = entry.details as Record<string, unknown> | undefined;
+	if (
+		entry.customType === "supervisor" &&
+		details?.eventType === "tool-complete" &&
+		details?.toolName &&
+		typeof details.toolName === "string"
+	) {
+		const toolName = details.toolName;
+		const isError = !!details.isError;
+		const durationMs = typeof details.toolDurationMs === "number" ? details.toolDurationMs : 0;
+		const agentName =
+			details?.agentName && typeof details.agentName === "string" ? details.agentName : "?";
+
+		// Merge into flat toolStats
+		if (!acc.toolCounts[toolName])
+			acc.toolCounts[toolName] = { calls: 0, errors: 0, totalDurationMs: 0 };
+		acc.toolCounts[toolName].calls++;
+		if (isError) acc.toolCounts[toolName].errors++;
+		acc.toolCounts[toolName].totalDurationMs += durationMs;
+
+		// Build per-agent breakdown
+		if (!acc.subagentToolStats[agentName]) acc.subagentToolStats[agentName] = {};
+		if (!acc.subagentToolStats[agentName][toolName])
+			acc.subagentToolStats[agentName][toolName] = { calls: 0, errors: 0, totalDurationMs: 0 };
+		acc.subagentToolStats[agentName][toolName].calls++;
+		if (isError) acc.subagentToolStats[agentName][toolName].errors++;
+		acc.subagentToolStats[agentName][toolName].totalDurationMs += durationMs;
+	}
+}
+
+/** Dispatch one JSONL entry to the matching accumulator; unknown types skipped. */
+function accumulateParsedEntry(acc: StatsAccumulator, entry: any): void {
+	if (entry.type === "compaction") {
+		acc.compactions++;
+	} else if (entry.type === "message") {
+		accumulateMessageStats(acc, entry);
+	} else if (entry.type === "custom") {
+		accumulateCustomStats(acc, entry);
+	}
+}
+
+/** Parse a .jsonl session file and extract statistics for metadata. */
+export function parseSessionStats(filepath: string): ParsedSessionStats | null {
+	const loaded = loadSessionEntries(filepath);
+	if (!loaded) return null;
+
+	const acc = createStatsAccumulator();
+
+	handleModelChanges(loaded.entries, acc.modelChanges, acc.thinkingChanges);
+
+	for (const entry of loaded.entries) {
+		accumulateParsedEntry(acc, entry);
+	}
+	flushTurn(acc.turnState);
+
+	const header = loaded.entries[0];
+	const hasSubagentTools = Object.keys(acc.subagentToolStats).length > 0;
+
+	return {
+		sessionId: header.id ?? "?",
+		timestamp: header.timestamp ?? "?",
+		cwd: header.cwd ?? "?",
+		version: header.version ?? 0,
+		parentSession: header.parentSession,
+		entryCount: loaded.entries.length,
+		tokens: {
+			input: acc.inputTokens,
+			output: acc.outputTokens,
+			cacheRead: acc.cacheRead,
+			cacheWrite: acc.cacheWrite,
+			total: acc.totalTokens,
+		},
+		cost: acc.totalCost,
+		modelChanges: acc.modelChanges,
+		thinkingChanges: acc.thinkingChanges,
+		compactions: acc.compactions,
+		toolStats: acc.toolCounts,
+		subagentToolStats: hasSubagentTools ? acc.subagentToolStats : undefined,
+		fileModifications: acc.fileMods,
+		perTurnTokens: acc.turnState.perTurnTokens,
+	};
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.md
@@ -1,0 +1,34 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 3 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+Preemptive note
+
+---
+
+### Turn 2 — User
+
+Hello
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.stats.json
@@ -1,0 +1,36 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 3,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 0,
+      "errorCount": 0
+    },
+    {
+      "turnIndex": 1,
+      "tokens": 0,
+      "cost": 0,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.md
@@ -1,0 +1,24 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+> **Context compacted** — 75K tokens summarized
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 1,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.md
@@ -1,0 +1,32 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 3 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+### Turn 1 — User
+
+First
+
+---
+
+### Turn 2 — User
+
+Second
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.stats.json
@@ -1,0 +1,36 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 3,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 0,
+      "cost": 0,
+      "toolCount": 0,
+      "errorCount": 0
+    },
+    {
+      "turnIndex": 1,
+      "tokens": 0,
+      "cost": 0,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.md
@@ -1,0 +1,24 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+> *other* — {"foo":"bar"}
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.md
@@ -1,0 +1,24 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+> *other* 
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.md
@@ -1,0 +1,30 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+### Agent: dev-agent -- FAILED
+
+1 tools, 300 tokens, 60s
+
+  edit failed
+
+Audit score: 1
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.md
@@ -1,0 +1,44 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+### Agent: dev-agent -- SUCCESS
+
+3 tools, 12K tokens, 1m 24s
+
+Thinking:
+  First thinking line
+  Second thinking line
+
+  read(path=src/main.py)
+  src/main.py -- 2KB
+
+<details>
+<summary>Raw output (collapsed)</summary>
+
+```
+raw dump
+line 2
+```
+</details>
+
+Audit score: 4
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.md
@@ -1,0 +1,24 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+### Agent: dev-agent
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.md
@@ -1,0 +1,24 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+> *supervisor* 
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.md
@@ -1,0 +1,51 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **Name** | `A\|B\`C` |
+| **Mode** | x\|y\`z |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 4 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `bash\|pipe` | 1 | — |
+| `edit` | 1 | — |
+
+## File Access
+
+| Action | File |
+|--------|------|
+| 📖 read | `src/weird\|file\`x.ts` |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+Escaping check
+
+- 🔧 `read(path=`src/weird\|file\`x.ts`)`
+
+  📥 `bash|pipe` — 2
+  `ok`
+
+  📥 `edit` — 14
+  `single line ok`
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.stats.json
@@ -1,0 +1,46 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 4,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "bash|pipe": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    },
+    "edit": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    }
+  },
+  "fileModifications": [
+    {
+      "action": "read",
+      "path": "src/weird|file`x.ts",
+      "timestamp": "2025-06-01T10:02:00Z"
+    }
+  ],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 2,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.md
@@ -1,0 +1,41 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## File Access
+
+| Action | File |
+|--------|------|
+| 📖 read | `a.ts` |
+| ✏️ write | `b.ts` |
+| 📖 read | `a.ts` |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+Multiple edits
+
+- 🔧 `read(path=`a.ts`)`
+- 🔧 `read(path=`a.ts`)`
+- 🔧 `write(path=`b.ts`, content=`x`)`
+- 🔧 `read(path=`a.ts`)`
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.stats.json
@@ -1,0 +1,51 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [
+    {
+      "action": "read",
+      "path": "a.ts",
+      "timestamp": "2025-06-01T10:02:00Z"
+    },
+    {
+      "action": "read",
+      "path": "a.ts",
+      "timestamp": "2025-06-01T10:02:00Z"
+    },
+    {
+      "action": "write",
+      "path": "b.ts",
+      "timestamp": "2025-06-01T10:02:00Z",
+      "size": 1
+    },
+    {
+      "action": "read",
+      "path": "a.ts",
+      "timestamp": "2025-06-01T10:02:00Z"
+    }
+  ],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.md
@@ -1,0 +1,48 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 7 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 6 |
+| **Output tokens** | 6 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 12 |
+| **Total cost** | $125.46 |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=2, stop=`end_turn`*
+
+a
+
+*tokens=2, cost=$0.000900, stop=`end_turn`*
+
+b
+
+*tokens=2, cost=$0.0010, stop=`end_turn`*
+
+c
+
+*tokens=2, cost=$0.9999, stop=`end_turn`*
+
+d
+
+*tokens=2, cost=$1.00, stop=`end_turn`*
+
+e
+
+*tokens=2, cost=$123.46, stop=`end_turn`*
+
+f
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.stats.json
@@ -1,0 +1,29 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 7,
+  "tokens": {
+    "input": 6,
+    "output": 6,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 12
+  },
+  "cost": 125.4578,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 12,
+      "cost": 125.4578,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.md
@@ -1,0 +1,42 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 6 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+### Agent: d1
+
+999ms
+
+### Agent: d2
+
+1s
+
+### Agent: d3
+
+60s
+
+### Agent: d4
+
+1m 0s
+
+### Agent: d5
+
+1m 30s
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 6,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.md
@@ -1,0 +1,40 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 5 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 1.0M |
+| **Output tokens** | 1.0M |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 2.0M |
+| **Total cost** | $0 |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=999, stop=`end_turn`*
+
+a
+
+*tokens=1K, stop=`end_turn`*
+
+b
+
+*tokens=1000K, stop=`end_turn`*
+
+c
+
+*tokens=1.0M, stop=`end_turn`*
+
+d
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.stats.json
@@ -1,0 +1,29 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 5,
+  "tokens": {
+    "input": 1001000,
+    "output": 1000998,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 2001998
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 2001998,
+      "cost": 0,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.md
@@ -1,0 +1,62 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 6 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 110 |
+| **Output tokens** | 55 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 180 |
+| **Total cost** | $0.0010 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `read` | 1 | — |
+
+## File Access
+
+| Action | File |
+|--------|------|
+| 📖 read | `src/main.py` |
+
+## Conversation
+
+### Turn 1 — User
+
+First user question
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+> 💭 Let me think about this.
+
+I'll check the file.
+
+- 🔧 `read(path=`src/main.py`)`
+
+  📥 `read` — 20
+  ```
+  def main():
+      pass
+  ```
+
+---
+
+### Turn 2 — User
+
+Follow up question
+
+*tokens=15, stop=`end_turn`*
+
+Done.
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.stats.json
@@ -1,0 +1,48 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 6,
+  "tokens": {
+    "input": 110,
+    "output": 55,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 180
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "read": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    }
+  },
+  "fileModifications": [
+    {
+      "action": "read",
+      "path": "src/main.py",
+      "timestamp": "2025-06-01T10:02:00Z"
+    }
+  ],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 1,
+      "errorCount": 0
+    },
+    {
+      "turnIndex": 1,
+      "tokens": 15,
+      "cost": 0,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.md
@@ -1,0 +1,22 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 1 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.stats.json
@@ -1,0 +1,21 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 1,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.md
@@ -1,0 +1,25 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+**Models:** anthropic/claude-sonnet-4  
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+> **Model:** `anthropic/claude-sonnet-4`
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.stats.json
@@ -1,0 +1,26 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [
+    {
+      "time": "2025-06-01T10:05:00Z",
+      "model": "anthropic/claude-sonnet-4"
+    }
+  ],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.md
@@ -1,0 +1,54 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **Name** | `My Session` |
+| **Mode** | full |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 4 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `read` | 1 | — |
+
+## File Access
+
+| Action | File |
+|--------|------|
+| 📖 read | `src/main.py` |
+
+## Conversation
+
+### Turn 1 — User
+
+First user question
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+> 💭 Let me think about this.
+
+I'll check the file.
+
+- 🔧 `read(path=`src/main.py`)`
+
+  📥 `read` — 20
+  ```
+  def main():
+      pass
+  ```
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.stats.json
@@ -1,0 +1,41 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 4,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "read": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    }
+  },
+  "fileModifications": [
+    {
+      "action": "read",
+      "path": "src/main.py",
+      "timestamp": "2025-06-01T10:02:00Z"
+    }
+  ],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 1,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.md
@@ -1,0 +1,53 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **Mode** | full |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 4 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `read` | 1 | — |
+
+## File Access
+
+| Action | File |
+|--------|------|
+| 📖 read | `src/main.py` |
+
+## Conversation
+
+### Turn 1 — User
+
+First user question
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+> 💭 Let me think about this.
+
+I'll check the file.
+
+- 🔧 `read(path=`src/main.py`)`
+
+  📥 `read` — 20
+  ```
+  def main():
+      pass
+  ```
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.stats.json
@@ -1,0 +1,41 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 4,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "read": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    }
+  },
+  "fileModifications": [
+    {
+      "action": "read",
+      "path": "src/main.py",
+      "timestamp": "2025-06-01T10:02:00Z"
+    }
+  ],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 1,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.md
@@ -1,0 +1,53 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **Name** | `My Session` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 4 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `read` | 1 | — |
+
+## File Access
+
+| Action | File |
+|--------|------|
+| 📖 read | `src/main.py` |
+
+## Conversation
+
+### Turn 1 — User
+
+First user question
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+> 💭 Let me think about this.
+
+I'll check the file.
+
+- 🔧 `read(path=`src/main.py`)`
+
+  📥 `read` — 20
+  ```
+  def main():
+      pass
+  ```
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.stats.json
@@ -1,0 +1,41 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 4,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "read": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    }
+  },
+  "fileModifications": [
+    {
+      "action": "read",
+      "path": "src/main.py",
+      "timestamp": "2025-06-01T10:02:00Z"
+    }
+  ],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 1,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.md
@@ -1,0 +1,35 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 4 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `bash` | 2 | 1 |
+| `read` | 1 | — |
+
+## Conversation
+
+### Agent: agent-a
+
+### Agent: agent-a
+
+### Agent: agent-b
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.stats.json
@@ -1,0 +1,48 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 4,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "bash": {
+      "calls": 2,
+      "errors": 1,
+      "totalDurationMs": 2000
+    },
+    "read": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 200
+    }
+  },
+  "subagentToolStats": {
+    "agent-a": {
+      "bash": {
+        "calls": 2,
+        "errors": 1,
+        "totalDurationMs": 2000
+      }
+    },
+    "agent-b": {
+      "read": {
+        "calls": 1,
+        "errors": 0,
+        "totalDurationMs": 200
+      }
+    }
+  },
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.md
@@ -1,0 +1,25 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+**Thinking:** high  
+
+| | |
+|---|---|
+| **Input tokens** | 0 |
+| **Output tokens** | 0 |
+| **Cache read** | 0 |
+| **Cache write** | 0 |
+| **Total tokens** | 0 |
+| **Total cost** | $0 |
+
+## Conversation
+
+> **Thinking:** `high`
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.stats.json
@@ -1,0 +1,26 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 0,
+    "output": 0,
+    "cacheRead": 0,
+    "cacheWrite": 0,
+    "total": 0
+  },
+  "cost": 0,
+  "modelChanges": [],
+  "thinkingChanges": [
+    {
+      "time": "2025-06-01T10:05:00Z",
+      "level": "high"
+    }
+  ],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": []
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.md
@@ -1,0 +1,31 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 2 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+> 💭 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+> *(…150 chars thinking)*
+
+Long thought
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.stats.json
@@ -1,0 +1,29 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 2,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {},
+  "fileModifications": [],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 0,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.md
@@ -1,0 +1,53 @@
+# Session Report
+
+| Field | Value |
+|-------|-------|
+| **Session** | `test-session-001` |
+| **Start** | `2025-06-01T10:00:00Z` |
+| **CWD** | `/tmp/project` |
+| **Version** | 1.0 |
+| **Entries** | 4 |
+
+
+| | |
+|---|---|
+| **Input tokens** | 100 |
+| **Output tokens** | 50 |
+| **Cache read** | 10 |
+| **Cache write** | 5 |
+| **Total tokens** | 165 |
+| **Total cost** | $0.0010 |
+
+## Tool Usage
+
+| Tool | Calls | Errors |
+|------|-------|--------|
+| `bash` | 1 | — |
+| `read` | 1 | — |
+
+## Conversation
+
+### Turn 1 — Assistant
+
+*tokens=165, cost=$0.0010, stop=`end_turn`*
+
+Big outputs
+
+- 🔧 `bash(command=`run-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa…(+24 chars)`)`
+
+  📥 `bash` — 69
+  ```
+  line 0
+  line 1
+  line 2
+  line 3
+  line 4
+  line 5
+  line 6
+  line 7
+  …(+2 more lines, 69 total chars)
+  ```
+
+  📥 `read` — 250
+  `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…(+50 chars)`
+

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.stats.json
@@ -1,0 +1,40 @@
+{
+  "sessionId": "test-session-001",
+  "timestamp": "2025-06-01T10:00:00Z",
+  "cwd": "/tmp/project",
+  "version": "1.0",
+  "entryCount": 4,
+  "tokens": {
+    "input": 100,
+    "output": 50,
+    "cacheRead": 10,
+    "cacheWrite": 5,
+    "total": 165
+  },
+  "cost": 0.001,
+  "modelChanges": [],
+  "thinkingChanges": [],
+  "compactions": 0,
+  "toolStats": {
+    "bash": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    },
+    "read": {
+      "calls": 1,
+      "errors": 0,
+      "totalDurationMs": 0
+    }
+  },
+  "fileModifications": [],
+  "perTurnTokens": [
+    {
+      "turnIndex": 0,
+      "tokens": 165,
+      "cost": 0.001,
+      "toolCount": 2,
+      "errorCount": 0
+    }
+  ]
+}

--- a/.pi/extensions/session-logger/test/session-logger-renderer-golden.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-renderer-golden.test.mts
@@ -1,0 +1,575 @@
+/**
+ * Golden characterization tests for session-logger/renderer.ts.
+ *
+ * Captures byte-for-byte .md render output AND parseSessionStats JSON
+ * snapshots (the metadata.json consumer) for representative session
+ * fixtures, so the 321-line renderSessionToMarkdown split can be proven
+ * output-equivalent (Feathers characterization-test pattern).
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/session-logger/test/session-logger-renderer-golden.test.mts
+ * Regenerate goldens (only when the renderer intentionally changes):
+ *   GOLDEN_UPDATE=1 node --experimental-strip-types --test .pi/extensions/session-logger/test/session-logger-renderer-golden.test.mts
+ */
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	readdirSync,
+	writeFileSync,
+	rmSync,
+} from "node:fs";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderSessionToMarkdown, parseSessionStats } from "../renderer.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const GOLDEN_DIR = join(__dirname, "fixtures", "session-logger-renderer-goldens");
+const UPDATE = process.env.GOLDEN_UPDATE === "1";
+
+// ─── Fixture builders ─────────────────────────────────────────────
+
+function sessionHeader(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		type: "session",
+		id: "test-session-001",
+		timestamp: "2025-06-01T10:00:00Z",
+		cwd: "/tmp/project",
+		version: "1.0",
+		...overrides,
+	};
+}
+
+function userMsg(text: string, timestamp = "2025-06-01T10:01:00Z"): Record<string, unknown> {
+	return {
+		type: "message",
+		timestamp,
+		message: { role: "user", content: [{ type: "text", text }] },
+	};
+}
+
+function assistantMsg(opts: {
+	thinking?: string;
+	text?: string;
+	toolCalls?: Array<{ name: string; args: Record<string, unknown> }>;
+	usage?: Record<string, unknown>;
+	stopReason?: string;
+	timestamp?: string;
+}): Record<string, unknown> {
+	const content: Array<Record<string, unknown>> = [];
+	if (opts.thinking) content.push({ type: "thinking", thinking: opts.thinking });
+	if (opts.text) content.push({ type: "text", text: opts.text });
+	for (const tc of opts.toolCalls ?? []) {
+		content.push({ type: "toolCall", name: tc.name, arguments: tc.args });
+	}
+	return {
+		type: "message",
+		timestamp: opts.timestamp ?? "2025-06-01T10:02:00Z",
+		message: {
+			role: "assistant",
+			content,
+			usage: opts.usage ?? {
+				input: 100,
+				output: 50,
+				cacheRead: 10,
+				cacheWrite: 5,
+				totalTokens: 165,
+				cost: { total: 0.001 },
+			},
+			stopReason: opts.stopReason ?? "end_turn",
+		},
+	};
+}
+
+function toolResultMsg(
+	toolName: string,
+	text: string,
+	opts: { isError?: boolean; timestamp?: string } = {},
+): Record<string, unknown> {
+	return {
+		type: "message",
+		timestamp: opts.timestamp ?? "2025-06-01T10:03:00Z",
+		message: {
+			role: "toolResult",
+			toolName,
+			isError: opts.isError ?? false,
+			content: [{ type: "text", text }],
+		},
+	};
+}
+
+function customSupervisor(
+	details: Record<string, unknown>,
+	opts: { data?: Record<string, unknown>; timestamp?: string } = {},
+): Record<string, unknown> {
+	return {
+		type: "custom",
+		customType: "supervisor",
+		timestamp: opts.timestamp ?? "2025-06-01T10:04:00Z",
+		data: opts.data ?? {},
+		details,
+	};
+}
+
+function toolComplete(
+	toolName: string,
+	agentName: string,
+	opts: { isError?: boolean; toolDurationMs?: number } = {},
+): Record<string, unknown> {
+	return customSupervisor({
+		eventType: "tool-complete",
+		toolName,
+		agentName,
+		isError: opts.isError ?? false,
+		toolDurationMs: opts.toolDurationMs ?? 1234,
+	});
+}
+
+const FULL_TURN = [
+	userMsg("First user question"),
+	assistantMsg({
+		thinking: "Let me think about this.",
+		text: "I'll check the file.",
+		toolCalls: [{ name: "read", args: { path: "src/main.py" } }],
+	}),
+	toolResultMsg("read", "def main():\n    pass"),
+];
+
+// ─── Corpus ────────────────────────────────────────────────────────
+
+interface GoldenCase {
+	name: string;
+	entries: Record<string, unknown>[];
+	overrides?: { sessionName?: string; mode?: string };
+}
+
+const CASES: GoldenCase[] = [
+	// header-only
+	{ name: "header-only", entries: [sessionHeader()] },
+
+	// full multi-turn: user→assistant(thinking+text+toolCall)→toolResult, then a second exchange
+	{
+		name: "full-multi-turn",
+		entries: [
+			sessionHeader(),
+			...FULL_TURN,
+			userMsg("Follow up question"),
+			assistantMsg({
+				text: "Done.",
+				usage: { input: 10, output: 5, totalTokens: 15, cost: { total: 0 } },
+			}),
+		],
+	},
+
+	// assistant-before-user
+	{
+		name: "assistant-before-user",
+		entries: [sessionHeader(), assistantMsg({ text: "Preemptive note" }), userMsg("Hello")],
+	},
+
+	// consecutive user turns (--- separator)
+	{
+		name: "consecutive-users",
+		entries: [sessionHeader(), userMsg("First"), userMsg("Second")],
+	},
+
+	// model_change + thinking_level_change + compaction pass-through entries
+	{
+		name: "model-change",
+		entries: [
+			sessionHeader(),
+			{
+				type: "model_change",
+				timestamp: "2025-06-01T10:05:00Z",
+				provider: "anthropic",
+				modelId: "claude-sonnet-4",
+			},
+		],
+	},
+	{
+		name: "thinking-change",
+		entries: [
+			sessionHeader(),
+			{ type: "thinking_level_change", timestamp: "2025-06-01T10:05:00Z", thinkingLevel: "high" },
+		],
+	},
+	{
+		name: "compaction",
+		entries: [
+			sessionHeader(),
+			{ type: "compaction", timestamp: "2025-06-01T10:05:00Z", tokensBefore: 75000 },
+		],
+	},
+
+	// supervisor custom details variants
+	{
+		name: "custom-supervisor-full",
+		entries: [
+			sessionHeader(),
+			customSupervisor({
+				agentName: "dev-agent",
+				statusLabel: "SUCCESS",
+				toolCount: 3,
+				tokenCount: 12000,
+				durationMs: 84000,
+				thinkingOutput: "First thinking line\nSecond thinking line",
+				hasThinking: true,
+				textOutput: "read(path=src/main.py)\nsrc/main.py -- 2KB",
+				rawOutput: "raw dump\nline 2",
+				hasRawOutput: true,
+				auditScore: 4,
+			}),
+		],
+	},
+	{
+		name: "custom-supervisor-failed",
+		entries: [
+			sessionHeader(),
+			customSupervisor({
+				agentName: "dev-agent",
+				statusLabel: "FAILED",
+				toolCount: 1,
+				tokenCount: 300,
+				durationMs: 59999,
+				textOutput: "edit failed",
+				auditScore: 1,
+			}),
+		],
+	},
+	{
+		name: "custom-supervisor-minimal",
+		entries: [sessionHeader(), customSupervisor({ agentName: "dev-agent" })],
+	},
+	{
+		name: "custom-supervisor-no-details",
+		entries: [sessionHeader(), customSupervisor({})],
+	},
+
+	// non-supervisor custom fallthrough — with and without data
+	{
+		name: "custom-non-supervisor-data",
+		entries: [
+			sessionHeader(),
+			{
+				type: "custom",
+				customType: "other",
+				timestamp: "2025-06-01T10:04:00Z",
+				data: { foo: "bar" },
+			},
+		],
+	},
+	{
+		name: "custom-non-supervisor-no-data",
+		entries: [
+			sessionHeader(),
+			{ type: "custom", customType: "other", timestamp: "2025-06-01T10:04:00Z", data: {} },
+		],
+	},
+
+	// subagent tool-complete: merged flat toolStats + per-agent breakdown, isError, multiple agents
+	{
+		name: "subagent-tool-complete",
+		entries: [
+			sessionHeader(),
+			toolComplete("bash", "agent-a", { toolDurationMs: 500 }),
+			toolComplete("bash", "agent-a", { isError: true, toolDurationMs: 1500 }),
+			toolComplete("read", "agent-b", { toolDurationMs: 200 }),
+		],
+	},
+
+	// overrides — sessionName / mode / both
+	{
+		name: "overrides-session-name",
+		entries: [sessionHeader(), ...FULL_TURN],
+		overrides: { sessionName: "My Session" },
+	},
+	{
+		name: "overrides-mode",
+		entries: [sessionHeader(), ...FULL_TURN],
+		overrides: { mode: "full" },
+	},
+	{
+		name: "overrides-both",
+		entries: [sessionHeader(), ...FULL_TURN],
+		overrides: { sessionName: "My Session", mode: "full" },
+	},
+
+	// escMd in tables: pipes + backticks in overrides, tool paths, tool names
+	{
+		name: "escaping-in-tables",
+		entries: [
+			sessionHeader(),
+			assistantMsg({
+				text: "Escaping check",
+				toolCalls: [{ name: "read", args: { path: "src/weird|file`x.ts" } }],
+			}),
+			toolResultMsg("bash|pipe", "ok"),
+			toolResultMsg("edit", "single line ok"),
+		],
+		overrides: { sessionName: "A|B`C", mode: "x|y`z" },
+	},
+
+	// file-access: consecutive same-action dedup + interleaved non-dedup
+	{
+		name: "file-access-dedup",
+		entries: [
+			sessionHeader(),
+			assistantMsg({
+				text: "Multiple edits",
+				toolCalls: [
+					{ name: "read", args: { path: "a.ts" } },
+					{ name: "read", args: { path: "a.ts" } },
+					{ name: "write", args: { path: "b.ts", content: "x" } },
+					{ name: "read", args: { path: "a.ts" } },
+				],
+			}),
+		],
+	},
+
+	// truncation boundaries: multi-line result >8 lines, single-line >200 chars, args >80 chars
+	{
+		name: "truncation-boundaries",
+		entries: [
+			sessionHeader(),
+			assistantMsg({
+				text: "Big outputs",
+				toolCalls: [{ name: "bash", args: { command: "run-" + "a".repeat(100) } }],
+			}),
+			toolResultMsg("bash", Array.from({ length: 10 }, (_v, i) => `line ${i}`).join("\n")),
+			toolResultMsg("read", "x".repeat(250)),
+		],
+	},
+
+	// fmtTokens thresholds: 999 / 1000 / 999999 / 1000000
+	{
+		name: "fmt-token-thresholds",
+		entries: [
+			sessionHeader(),
+			assistantMsg({
+				text: "a",
+				usage: { input: 500, output: 499, totalTokens: 999, cost: { total: 0 } },
+			}),
+			assistantMsg({
+				text: "b",
+				usage: { input: 500, output: 500, totalTokens: 1000, cost: { total: 0 } },
+			}),
+			assistantMsg({
+				text: "c",
+				usage: { input: 500000, output: 499999, totalTokens: 999999, cost: { total: 0 } },
+			}),
+			assistantMsg({
+				text: "d",
+				usage: { input: 500000, output: 500000, totalTokens: 1000000, cost: { total: 0 } },
+			}),
+		],
+	},
+
+	// fmtCost thresholds: 0 / 0.0009 / 0.001 / 0.9999 / 1 / 123.456
+	{
+		name: "fmt-cost-thresholds",
+		entries: [
+			sessionHeader(),
+			assistantMsg({
+				text: "a",
+				usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 0 } },
+			}),
+			assistantMsg({
+				text: "b",
+				usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 0.0009 } },
+			}),
+			assistantMsg({
+				text: "c",
+				usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 0.001 } },
+			}),
+			assistantMsg({
+				text: "d",
+				usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 0.9999 } },
+			}),
+			assistantMsg({
+				text: "e",
+				usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 1 } },
+			}),
+			assistantMsg({
+				text: "f",
+				usage: { input: 1, output: 1, totalTokens: 2, cost: { total: 123.456 } },
+			}),
+		],
+	},
+
+	// fmtDuration thresholds via supervisor details: 999 / 1000 / 59999 / 60000 / 90000
+	{
+		name: "fmt-duration-thresholds",
+		entries: [
+			sessionHeader(),
+			customSupervisor({ agentName: "d1", durationMs: 999 }),
+			customSupervisor({ agentName: "d2", durationMs: 1000 }),
+			customSupervisor({ agentName: "d3", durationMs: 59999 }),
+			customSupervisor({ agentName: "d4", durationMs: 60000 }),
+			customSupervisor({ agentName: "d5", durationMs: 90000 }),
+		],
+	},
+
+	// thinking preview > 120 chars → collapsed with char count
+	{
+		name: "thinking-preview-long",
+		entries: [sessionHeader(), assistantMsg({ thinking: "x".repeat(150), text: "Long thought" })],
+	},
+];
+
+// ─── Golden helpers ────────────────────────────────────────────────
+
+function goldenPath(name: string, ext: string): string {
+	return join(GOLDEN_DIR, `${name}.${ext}`);
+}
+
+describe("session-logger renderer golden characterization (byte-for-byte)", () => {
+	for (const c of CASES) {
+		it(`renders ${c.name} (md + stats)`, () => {
+			const tmpDir = mkdtempSync(path.join(os.tmpdir(), "session-logger-golden-"));
+			try {
+				const filepath = path.join(tmpDir, "test-session.jsonl");
+				const lines = c.entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+				writeFileSync(filepath, lines, "utf-8");
+
+				const md = renderSessionToMarkdown(filepath, c.overrides);
+				const stats = parseSessionStats(filepath);
+
+				const mdFile = goldenPath(c.name, "md");
+				const statsFile = goldenPath(c.name, "stats.json");
+				if (UPDATE) {
+					mkdirSync(GOLDEN_DIR, { recursive: true });
+					writeFileSync(mdFile, md + "\n", "utf8");
+					writeFileSync(statsFile, JSON.stringify(stats, null, 2) + "\n", "utf8");
+					return;
+				}
+				assert.ok(
+					existsSync(mdFile),
+					`missing golden ${mdFile} — run with GOLDEN_UPDATE=1 to create`,
+				);
+				assert.equal(md + "\n", readFileSync(mdFile, "utf8"), `md golden mismatch for ${c.name}`);
+				assert.ok(
+					existsSync(statsFile),
+					`missing golden ${statsFile} — run with GOLDEN_UPDATE=1 to create`,
+				);
+				assert.equal(
+					JSON.stringify(stats, null, 2) + "\n",
+					readFileSync(statsFile, "utf8"),
+					`stats golden mismatch for ${c.name}`,
+				);
+			} finally {
+				rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+	}
+});
+
+// ─── Boundary error paths ──────────────────────────────────────────
+
+describe("session-logger renderer boundary error paths", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(path.join(os.tmpdir(), "session-logger-golden-edge-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeJsonl(entries: Record<string, unknown>[]): string {
+		const filepath = path.join(tmpDir, "test-session.jsonl");
+		const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+		writeFileSync(filepath, lines, "utf-8");
+		return filepath;
+	}
+
+	it("missing file → ENOENT propagates from renderSessionToMarkdown", () => {
+		assert.throws(() => renderSessionToMarkdown(path.join(tmpDir, "missing.jsonl")), {
+			code: "ENOENT",
+		});
+	});
+
+	it("missing file → ENOENT propagates from parseSessionStats", () => {
+		assert.throws(() => parseSessionStats(path.join(tmpDir, "missing.jsonl")), {
+			code: "ENOENT",
+		});
+	});
+
+	it("malformed JSON line → SyntaxError propagates from renderSessionToMarkdown", () => {
+		const filepath = path.join(tmpDir, "bad.jsonl");
+		fs.writeFileSync(filepath, '{"type":"session"}\n{not json\n', "utf-8");
+		assert.throws(() => renderSessionToMarkdown(filepath), SyntaxError);
+	});
+
+	it("malformed JSON line → SyntaxError propagates from parseSessionStats", () => {
+		const filepath = path.join(tmpDir, "bad.jsonl");
+		fs.writeFileSync(filepath, '{"type":"session"}\n{not json\n', "utf-8");
+		assert.throws(() => parseSessionStats(filepath), SyntaxError);
+	});
+
+	it("empty file → renderSessionToMarkdown returns '*Empty session*'", () => {
+		const filepath = path.join(tmpDir, "empty.jsonl");
+		fs.writeFileSync(filepath, "", "utf-8");
+		assert.equal(renderSessionToMarkdown(filepath), "*Empty session*");
+	});
+
+	it("whitespace-only file → renderSessionToMarkdown returns '*Empty session*'", () => {
+		const filepath = path.join(tmpDir, "blank.jsonl");
+		fs.writeFileSync(filepath, "  \n\n  ", "utf-8");
+		assert.equal(renderSessionToMarkdown(filepath), "*Empty session*");
+	});
+
+	it("empty file → parseSessionStats returns null", () => {
+		const filepath = path.join(tmpDir, "empty.jsonl");
+		fs.writeFileSync(filepath, "", "utf-8");
+		assert.equal(parseSessionStats(filepath), null);
+	});
+
+	it("unknown entry type is skipped silently", () => {
+		const filepath = writeJsonl([sessionHeader(), { type: "mystery-entry", data: { x: 1 } }]);
+		const out = renderSessionToMarkdown(filepath);
+		assert.ok(!out.includes("mystery-entry"));
+	});
+
+	it("message with unknown role renders nothing, no crash", () => {
+		const filepath = writeJsonl([
+			sessionHeader(),
+			{ type: "message", message: { role: "weird", content: [{ type: "text", text: "x" }] } },
+		]);
+		const out = renderSessionToMarkdown(filepath);
+		assert.ok(!out.includes("weird"));
+	});
+});
+
+// ─── Structural guard (split integrity) ────────────────────────────
+// Precedent: supervisor/test/message-renderers.test.mts — every renderer/*
+// module imports standalone (no TDZ/cycle) and nothing imports back into
+// the public renderer.ts entry.
+
+describe("renderer/* import standalone (no ESM cycle)", () => {
+	const dir = join(__dirname, "..", "renderer");
+	const files = readdirSync(dir).filter((f) => f.endsWith(".ts"));
+
+	for (const f of files) {
+		it(`${f} dynamically imports without TDZ errors`, async () => {
+			await import(`../renderer/${f}`);
+		});
+	}
+
+	it("no renderer/* imports back from renderer.ts", () => {
+		for (const f of files) {
+			const source = readFileSync(join(dir, f), "utf8");
+			assert.ok(
+				!source.includes('from "../renderer.ts"'),
+				`${f} must not import back from renderer.ts (ESM cycle risk)`,
+			);
+		}
+	});
+});


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1409

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 4m 43s | 51.4K | 31 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 3m 28s | 51.3K | 27 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 22s | 33.9K | 21 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 21s | 72.7K | 37 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 43s | 67.5K | 52 | minimax-m3 |

**Total:** 5 agents · 18m 36s · 276.8K tokens · 168 tool calls · 11 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1409
Closes #1409