### PR TITLE
feat(#1399): Duplicate Code: lsp-auditor — formatPlainText reimplements formatDiagnostics from formatting.ts

### DIFF
--- a/.pi/extensions/lsp-auditor/formatting.ts
+++ b/.pi/extensions/lsp-auditor/formatting.ts
@@ -44,6 +44,34 @@ export function thresholdValue(threshold: string): number {
 // ─── Formatting ──────────────────────────────────────────────────────
 
 /**
+ * Truncate a diagnostic message to at most `max` characters (default 500),
+ * appending "..." when truncated. Uses UTF-16 slice semantics — kept as-is;
+ * centralizing here means any future fix propagates to all formatters.
+ */
+export function truncateMessage(msg: string, max = 500): string {
+	if (msg.length > max) return msg.slice(0, max - 3) + "...";
+	return msg;
+}
+
+/**
+ * Build a block of formatted diagnostic lines and append it to `blocks`,
+ * separating consecutive blocks with exactly one blank line.
+ * Shared by all text formatters so the join/blank-line logic stays in one place.
+ */
+export function pushLineBlock(
+	blocks: string[],
+	diags: LspDiagnostic[],
+	formatLine: (d: LspDiagnostic) => string,
+): void {
+	const lines: string[] = [];
+	for (const d of diags) {
+		lines.push(formatLine(d));
+	}
+	if (blocks.length > 0) blocks.push("");
+	blocks.push(lines.join("\n"));
+}
+
+/**
  * Format diagnostics into a compact, human-readable message.
  * Grouped by file, sorted by line.
  */
@@ -62,15 +90,9 @@ export function formatDiagnostics(diagnostics: LspDiagnostic[]): string {
 	for (const file of files) {
 		const diags = byFile.get(file)!;
 		diags.sort((a, b) => (a.line !== b.line ? a.line - b.line : a.column - b.column));
-
-		const lines: string[] = [];
-		for (const d of diags) {
-			let msg = d.message;
-			if (msg.length > 500) msg = msg.slice(0, 497) + "...";
-			lines.push(`${file}, Line ${d.line}: [${d.severity}] ${msg}`);
-		}
-		if (blocks.length > 0) blocks.push("");
-		blocks.push(lines.join("\n"));
+		pushLineBlock(blocks, diags, (d) =>
+			`${file}, Line ${d.line}: [${d.severity}] ${truncateMessage(d.message)}`,
+		);
 	}
 
 	return blocks.join("\n");

--- a/.pi/extensions/lsp-auditor/output-adapter.ts
+++ b/.pi/extensions/lsp-auditor/output-adapter.ts
@@ -11,6 +11,7 @@
  *   - "print" / others       → plain text string
  */
 
+import { formatDiagnostics, pushLineBlock, truncateMessage } from "./formatting.ts";
 import type { LspDiagnostic, StructuredDiagnostics } from "./types.ts";
 
 // ─── Public API ──────────────────────────────────────────────────────
@@ -69,14 +70,9 @@ function formatTuiWithUris(diagnostics: LspDiagnostic[], worktreePath: string): 
 	const blocks: string[] = [];
 	for (const [filePath, diags] of byFile) {
 		const uri = pathToFileUri(filePath);
-		const lines: string[] = [];
-		for (const d of diags) {
-			let msg = d.message;
-			if (msg.length > 500) msg = msg.slice(0, 497) + "...";
-			lines.push(`${uri}:${d.line}:${d.column} — [${d.severity}] ${msg}`);
-		}
-		if (blocks.length > 0) blocks.push("");
-		blocks.push(lines.join("\n"));
+		pushLineBlock(blocks, diags, (d) =>
+			`${uri}:${d.line}:${d.column} — [${d.severity}] ${truncateMessage(d.message)}`,
+		);
 	}
 
 	return blocks.join("\n");
@@ -84,27 +80,10 @@ function formatTuiWithUris(diagnostics: LspDiagnostic[], worktreePath: string): 
 
 /**
  * Format diagnostics as plain text (no URI links).
- * Matches formatDiagnostics() style from formatting.ts.
+ * Delegates to formatDiagnostics() — single canonical plain-text renderer.
  */
 function formatPlainText(diagnostics: LspDiagnostic[]): string {
-	if (diagnostics.length === 0) return "";
-
-	const byFile = groupByFile(diagnostics);
-
-	const blocks: string[] = [];
-	for (const [filePath, diags] of byFile) {
-		diags.sort((a, b) => (a.line !== b.line ? a.line - b.line : a.column - b.column));
-		const lines: string[] = [];
-		for (const d of diags) {
-			let msg = d.message;
-			if (msg.length > 500) msg = msg.slice(0, 497) + "...";
-			lines.push(`${filePath}, Line ${d.line}: [${d.severity}] ${msg}`);
-		}
-		if (blocks.length > 0) blocks.push("");
-		blocks.push(lines.join("\n"));
-	}
-
-	return blocks.join("\n");
+	return formatDiagnostics(diagnostics);
 }
 
 /**

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor-output.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor-output.test.mts
@@ -12,6 +12,7 @@ import assert from "node:assert";
 import { describe, it } from "node:test";
 import type { LspDiagnostic, StructuredDiagnostics } from "../types.ts";
 import { formatForMode } from "../output-adapter.ts";
+import { formatDiagnostics } from "../formatting.ts";
 
 // ─── Shared fixture — 3 diagnostics across 2 files ───────────────────
 
@@ -40,6 +41,16 @@ const SAMPLE_DIAGS: LspDiagnostic[] = [
 ];
 
 const WORKTREE_PATH = "/workspace";
+
+// Non-alphabetical fixture — locks the accepted ordering delta (blocks become alphabetical)
+const NON_ALPHA_DIAGS: LspDiagnostic[] = [
+	{ file: "/workspace/z.ts", line: 1, column: 1, severity: "Error", message: "zzz" },
+	{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: "aaa" },
+];
+
+// Boundary fixtures for truncation tests
+const EXACT_500_MSG = "x".repeat(500);
+const LONG_MSG_501 = "x".repeat(501);
 
 // =========================================================================
 // Tests
@@ -233,5 +244,108 @@ describe("formatForMode — edge cases", () => {
 	it("unknown mode → defaults to print mode (plain text)", () => {
 		const result = formatForMode(SAMPLE_DIAGS, "unknown-mode", WORKTREE_PATH, false);
 		assert.strictEqual(typeof result, "string");
+	});
+});
+
+describe("formatForMode — delegation to formatDiagnostics", () => {
+	it("print route ≡ formatDiagnostics (exact equality)", () => {
+		const result = formatForMode(SAMPLE_DIAGS, "print", WORKTREE_PATH, false) as string;
+		assert.strictEqual(result, formatDiagnostics(SAMPLE_DIAGS));
+	});
+
+	it("tui + hasUI=false route ≡ formatDiagnostics (exact equality)", () => {
+		const result = formatForMode(SAMPLE_DIAGS, "tui", WORKTREE_PATH, false) as string;
+		assert.strictEqual(result, formatDiagnostics(SAMPLE_DIAGS));
+	});
+
+	it("unknown mode route ≡ formatDiagnostics (exact equality)", () => {
+		const result = formatForMode(SAMPLE_DIAGS, "unknown-mode", WORKTREE_PATH, false) as string;
+		assert.strictEqual(result, formatDiagnostics(SAMPLE_DIAGS));
+	});
+
+	it("single diagnostic → exact plain-text line", () => {
+		const single = [
+			{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: "msg" },
+		] as LspDiagnostic[];
+		const result = formatForMode(single, "print", WORKTREE_PATH, false) as string;
+		assert.strictEqual(result, "/workspace/a.ts, Line 1: [Error] msg");
+	});
+
+	it("same-file diagnostics sorted by line asc then column asc", () => {
+		const unsorted = [
+			{ file: "/workspace/a.ts", line: 5, column: 9, severity: "Warning", message: "w" },
+			{ file: "/workspace/a.ts", line: 2, column: 7, severity: "Error", message: "e" },
+			{ file: "/workspace/a.ts", line: 2, column: 3, severity: "Hint", message: "h" },
+		] as LspDiagnostic[];
+		const result = formatForMode(unsorted, "print", WORKTREE_PATH, false) as string;
+		assert.strictEqual(
+			result,
+			[
+				"/workspace/a.ts, Line 2: [Hint] h",
+				"/workspace/a.ts, Line 2: [Error] e",
+				"/workspace/a.ts, Line 5: [Warning] w",
+			].join("\n"),
+		);
+	});
+
+	it("two files → blocks separated by exactly one blank line", () => {
+		const result = formatForMode(SAMPLE_DIAGS, "print", WORKTREE_PATH, false) as string;
+		const appBlock = [
+			"/workspace/src/app.ts, Line 10: [Error] Type 'string' is not assignable to type 'number'",
+			"/workspace/src/app.ts, Line 25: [Warning] Variable 'x' is declared but never used",
+		].join("\n");
+		const libBlock = "/workspace/src/lib.ts, Line 3: [Error] Cannot find name 'foo'";
+		assert.strictEqual(result, `${appBlock}\n\n${libBlock}`);
+	});
+
+	it("message exactly 500 chars → untruncated, no ... suffix", () => {
+		const result = formatForMode(
+			[{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: EXACT_500_MSG }],
+			"print",
+			WORKTREE_PATH,
+			false,
+		) as string;
+		assert.strictEqual(result, `/workspace/a.ts, Line 1: [Error] ${EXACT_500_MSG}`);
+	});
+
+	it("message 501 chars → exactly 497 chars + ...", () => {
+		const result = formatForMode(
+			[{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: LONG_MSG_501 }],
+			"print",
+			WORKTREE_PATH,
+			false,
+		) as string;
+		assert.strictEqual(
+			result,
+			`/workspace/a.ts, Line 1: [Error] ${LONG_MSG_501.slice(0, 497)}...`,
+		);
+	});
+
+	it("empty message → rendered, no truncation", () => {
+		const result = formatForMode(
+			[{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: "" }],
+			"print",
+			WORKTREE_PATH,
+			false,
+		) as string;
+		assert.strictEqual(result, "/workspace/a.ts, Line 1: [Error] ");
+	});
+
+	it("same line+column pair keeps input order (stable sort)", () => {
+		const samePos = [
+			{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: "first" },
+			{ file: "/workspace/a.ts", line: 1, column: 1, severity: "Error", message: "second" },
+		] as LspDiagnostic[];
+		const result = formatForMode(samePos, "print", WORKTREE_PATH, false) as string;
+		assert.strictEqual(
+			result,
+			"/workspace/a.ts, Line 1: [Error] first\n/workspace/a.ts, Line 1: [Error] second",
+		);
+	});
+
+	it("non-alphabetical input [z.ts, a.ts] → first block is a.ts (alphabetical delta)", () => {
+		const result = formatForMode(NON_ALPHA_DIAGS, "print", WORKTREE_PATH, false) as string;
+		assert.ok(result.startsWith("/workspace/a.ts"));
+		assert.strictEqual(result, formatDiagnostics(NON_ALPHA_DIAGS));
 	});
 });

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
@@ -15,6 +15,7 @@ import {
 	severityValue,
 	thresholdValue,
 	formatDiagnostics,
+	truncateMessage,
 	filterBySeverity,
 } from "../formatting.ts";
 import { buildServerMappings } from "../server-mappings.ts";
@@ -159,6 +160,29 @@ describe("formatDiagnostics", () => {
 			{ file: "a.ts", line: 1, column: 1, severity: "Error", message: "🚀 unicode test 世界" },
 		]);
 		assert.ok(result.includes("🚀 unicode test 世界"));
+	});
+});
+
+describe("truncateMessage", () => {
+	it("empty message → empty string", () => {
+		assert.strictEqual(truncateMessage(""), "");
+	});
+
+	it("message ≤ 500 chars → unchanged, no ... suffix", () => {
+		const msg = "x".repeat(500);
+		assert.strictEqual(truncateMessage(msg), msg);
+	});
+
+	it("message 501 chars → exactly 497 chars + ...", () => {
+		const msg = "x".repeat(501);
+		assert.strictEqual(truncateMessage(msg), "x".repeat(497) + "...");
+	});
+
+	it("message 1000 chars → ends with ... (UTF-16 slice semantics)", () => {
+		const msg = "x".repeat(1000);
+		const result = truncateMessage(msg);
+		assert.strictEqual(result.length, 500);
+		assert.ok(result.endsWith("..."));
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1399

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 6m 1s | 54.5K | 29 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 16s | 31.3K | 15 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 9s | 40.6K | 10 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 3m 5s | 36.0K | 24 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 18s | 56.1K | 24 | minimax-m3 |

**Total:** 5 agents · 13m 49s · 218.6K tokens · 102 tool calls · 8 failed (8%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1399
Closes #1399