### PR TITLE
feat(#1403): Reinvention: session-logger — manual JSONL parsing reimplements pi.parseSessionEntries (+ misses legacy-session migration)

### DIFF
--- a/.pi/extensions/session-logger/renderer/parse.ts
+++ b/.pi/extensions/session-logger/renderer/parse.ts
@@ -4,6 +4,14 @@
  * Hides readFileSync + line format. Shared by the markdown renderer and the
  * stats walk. Must NOT swallow JSON.parse throws — the caller's try/catch
  * (report.ts) owns that error path.
+ *
+ * Reinvention decision (#1403): the manual trim().split("\n").filter().map()
+ * parse deliberately stays — do NOT swap it for the host package's
+ * parseSessionEntries/migrateSessionEntries. parseSessionEntries silently
+ * skips malformed lines (would break this module's fail-closed contract), and
+ * render-time migration would misrepresent on-disk format versions. Version
+ * migration belongs to the host SessionManager for active-session loads only;
+ * the read-only recovery path renders what is on disk (provenance).
  */
 
 import { readFileSync } from "node:fs";

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 3 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/assistant-before-user.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 3,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/compaction.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 3 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/consecutive-users.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 3,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-data.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-non-supervisor-no-data.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-failed.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-full.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-minimal.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/custom-supervisor-no-details.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.md
@@ -7,7 +7,7 @@
 | **Name** | `A\|B\`C` |
 | **Mode** | x\|y\`z |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 4 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/escaping-in-tables.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 4,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/file-access-dedup.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 7 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-cost-thresholds.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 7,
   "tokens": {
     "input": 6,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 6 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-duration-thresholds.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 6,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 5 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/fmt-token-thresholds.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 5,
   "tokens": {
     "input": 1001000,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 6 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/full-multi-turn.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 6,
   "tokens": {
     "input": 110,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 1 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/header-only.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 1,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 **Models:** anthropic/claude-sonnet-4  

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/model-change.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.md
@@ -7,7 +7,7 @@
 | **Name** | `My Session` |
 | **Mode** | full |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 4 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-both.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 4,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.md
@@ -6,7 +6,7 @@
 | **Start** | `2025-06-01T10:00:00Z` |
 | **Mode** | full |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 4 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-mode.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 4,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.md
@@ -6,7 +6,7 @@
 | **Start** | `2025-06-01T10:00:00Z` |
 | **Name** | `My Session` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 4 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/overrides-session-name.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 4,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 4 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/subagent-tool-complete.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 4,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 **Thinking:** high  

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-change.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 0,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 2 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/thinking-preview-long.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 2,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.md
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.md
@@ -5,7 +5,7 @@
 | **Session** | `test-session-001` |
 | **Start** | `2025-06-01T10:00:00Z` |
 | **CWD** | `/tmp/project` |
-| **Version** | 1.0 |
+| **Version** | 3 |
 | **Entries** | 4 |
 
 

--- a/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.stats.json
+++ b/.pi/extensions/session-logger/test/fixtures/session-logger-renderer-goldens/truncation-boundaries.stats.json
@@ -2,7 +2,7 @@
   "sessionId": "test-session-001",
   "timestamp": "2025-06-01T10:00:00Z",
   "cwd": "/tmp/project",
-  "version": "1.0",
+  "version": 3,
   "entryCount": 4,
   "tokens": {
     "input": 100,

--- a/.pi/extensions/session-logger/test/session-logger-renderer-golden.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-renderer-golden.test.mts
@@ -42,7 +42,10 @@ function sessionHeader(overrides: Record<string, unknown> = {}): Record<string, 
 		id: "test-session-001",
 		timestamp: "2025-06-01T10:00:00Z",
 		cwd: "/tmp/project",
-		version: "1.0",
+		// Numeric, matching CURRENT_SESSION_VERSION — ParsedSessionStats.version
+		// is declared `number` (session-stats.ts); string "1.0" was a latent
+		// type violation and a misfire trigger for version-gated logic.
+		version: 3,
 		...overrides,
 	};
 }
@@ -470,6 +473,58 @@ describe("session-logger renderer golden characterization (byte-for-byte)", () =
 	}
 });
 
+// ─── Version handling (fixture version is numeric) ─────────────────
+
+function writeJsonlTo(dir: string, entries: Record<string, unknown>[]): string {
+	const filepath = path.join(dir, "test-session.jsonl");
+	const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+	writeFileSync(filepath, lines, "utf-8");
+	return filepath;
+}
+
+describe("session-logger renderer version handling", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(path.join(os.tmpdir(), "session-logger-golden-ver-"));
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it("header-only fixture → stats.version is numeric 3", () => {
+		const filepath = writeJsonlTo(tmpDir, [sessionHeader()]);
+		const stats = parseSessionStats(filepath);
+		assert.ok(stats, "expected stats");
+		assert.equal(stats.version, 3);
+		assert.equal(typeof stats.version, "number");
+	});
+
+	it("header missing version → stats.version === 0", () => {
+		const filepath = writeJsonlTo(tmpDir, [
+			{ type: "session", id: "no-ver", timestamp: "2025-06-01T10:00:00Z", cwd: "/tmp" },
+		]);
+		const stats = parseSessionStats(filepath);
+		assert.ok(stats, "expected stats");
+		assert.equal(stats.version, 0);
+	});
+
+	it("no stale string-version fixtures remain in golden corpus", () => {
+		const files = readdirSync(GOLDEN_DIR).filter(
+			(f) => f.endsWith(".md") || f.endsWith(".stats.json"),
+		);
+		assert.ok(files.length > 0, "expected golden fixtures present");
+		for (const f of files) {
+			const content = readFileSync(join(GOLDEN_DIR, f), "utf8");
+			assert.ok(
+				!content.includes('"version": "1.0"') && !content.includes("| **Version** | 1.0 |"),
+				`stale string version in ${f}`,
+			);
+		}
+	});
+});
+
 // ─── Boundary error paths ──────────────────────────────────────────
 
 describe("session-logger renderer boundary error paths", () => {
@@ -571,5 +626,16 @@ describe("renderer/* import standalone (no ESM cycle)", () => {
 				`${f} must not import back from renderer.ts (ESM cycle risk)`,
 			);
 		}
+	});
+
+	it("parse.ts does not import host parseSessionEntries/migrateSessionEntries", () => {
+		// Reinvention #1403 settled: the fail-closed manual parse stays. Any
+		// import of the host package's parse/migrate helpers would violate the
+		// docstring contract in parse.ts.
+		const source = readFileSync(join(dir, "parse.ts"), "utf8");
+		assert.ok(
+			!source.includes('from "@earendil-works/pi-coding-agent"'),
+			"parse.ts must not import host parse/migrate helpers (reinvention #1403)",
+		);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1403

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 6m 14s | 71.1K | 43 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 3m 9s | 46.2K | 22 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 29s | 38.6K | 20 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 56s | 35.8K | 19 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 58s | 47.2K | 16 | minimax-m3 |

**Total:** 5 agents · 14m 47s · 238.9K tokens · 120 tool calls · 3 failed (3%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1403
Closes #1403