### PR TITLE
feat(#1454): Remove 2 unused functions (getCommandName, stripThinkingPrefix) — dead code in piignore + supervisor extensions

### DIFF
--- a/.github/workflows/cli-install-smoke.yml
+++ b/.github/workflows/cli-install-smoke.yml
@@ -55,6 +55,14 @@ jobs:
           DOCKER_TLS_CERTDIR: ""
         ports:
           - 2375:2375
+        # Share the runner's /tmp with the DinD daemon so bind mounts in the
+        # generated docker-compose.yml (e.g. ./codeflow/config.json under the
+        # test's temp workdir) resolve to real files. Without this, the daemon
+        # sees a missing source path and creates a DIRECTORY instead, and
+        # file-onto-file bind mounts fail with "not a directory" (e.g. codeflow
+        # config.json bind mount added on main in "codeflow added" fa42875).
+        volumes:
+          - /tmp:/tmp
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/cli-install-smoke.yml
+++ b/.github/workflows/cli-install-smoke.yml
@@ -55,14 +55,6 @@ jobs:
           DOCKER_TLS_CERTDIR: ""
         ports:
           - 2375:2375
-        # Share the runner's /tmp with the DinD daemon so bind mounts in the
-        # generated docker-compose.yml (e.g. ./codeflow/config.json under the
-        # test's temp workdir) resolve to real files. Without this, the daemon
-        # sees a missing source path and creates a DIRECTORY instead, and
-        # file-onto-file bind mounts fail with "not a directory" (e.g. codeflow
-        # config.json bind mount added on main in "codeflow added" fa42875).
-        volumes:
-          - /tmp:/tmp
 
     steps:
       - uses: actions/checkout@v5

--- a/.pi/extensions/agent-harness/README.md
+++ b/.pi/extensions/agent-harness/README.md
@@ -89,9 +89,9 @@ flowchart TD
 | Pattern | Detected By | Redirect To |
 |---------|-------------|-------------|
 | `bash | grep` | `getBashSubKey()` token analysis | `ripgrep_search` |
-| `bash cat` | `getCommandName()` | `read` |
-| `bash rg` | `getCommandName()` | `ripgrep_search` |
-| `bash find . -name` | `getCommandName()` | `ripgrep_search` / `bash ls` |
+| `bash cat` | `getBashSubKey()` | `read` |
+| `bash rg` | `getBashSubKey()` | `ripgrep_search` |
+| `bash find . -name` | `getBashSubKey()` | `ripgrep_search` / `bash ls` |
 
 ### Key Design Decisions
 

--- a/.pi/extensions/piignore/index.ts
+++ b/.pi/extensions/piignore/index.ts
@@ -324,14 +324,6 @@ function segmentTokens(tokens: BashToken[]): BashToken[][] {
 }
 
 /**
- * Extract the command name from a bash command (first non-option token).
- */
-function getCommandName(command: string): string {
-	const tokens = tokenizeBashCommand(command);
-	return getCommandNameFromTokens(tokens);
-}
-
-/**
  * Extract the command name from a list of tokens (first non-option, non-operator token).
  */
 function getCommandNameFromTokens(tokens: BashToken[]): string {

--- a/.pi/extensions/piignore/test/dead-code-getCommandName-removal.test.mts
+++ b/.pi/extensions/piignore/test/dead-code-getCommandName-removal.test.mts
@@ -48,27 +48,31 @@ describe("piignore/index.ts — dead getCommandName removed", () => {
 describe("knip.ignoreIssues — criterion 3 suppression config", () => {
 	const packageJson = readSource("../../../package.json");
 
-	it('knip.ignoreIssues contains ".pi/git/**" (vendored code suppression)', () => {
+	// knip 6.x schema requires array values (zod: z.record(z.string(),
+	// z.array(issueTypeSchema))); "*" is rejected with "expected: array" and
+	// the pre-existing "default" type is likewise invalid — both make knip
+	// exit 2 with no stdout (dead-code gate status "error").
+	it('knip.ignoreIssues contains ".pi/git/**" (vendored code suppression, explicit /** glob)', () => {
 		assert.match(
 			packageJson,
 			/".pi\/git\/\*\*"\s*:\s*\[/,
-			'knip.ignoreIssues must suppress .pi/git/** findings (explicit /** glob)',
+			'knip.ignoreIssues must suppress .pi/git/** findings (explicit /** glob, array of valid issue types)',
 		);
 	});
 
-	it('knip.ignoreIssues contains "**/test/fixtures/**" (fixture suppression)', () => {
+	it('knip.ignoreIssues contains "**/test/fixtures/**" (fixture suppression, explicit /** glob)', () => {
 		assert.match(
 			packageJson,
 			/"\*\*\/test\/fixtures\/\*\*"\s*:\s*\[/,
-			'knip.ignoreIssues must suppress fixture findings (explicit /** glob)',
+			'knip.ignoreIssues must suppress fixture findings (explicit /** glob, array of valid issue types)',
 		);
 	});
 
-	it('knip.ignoreIssues entries use valid knip 6.x issue types (no stale invalid "default")', () => {
+	it('knip.ignoreIssues uses only valid knip 6 issue types (no "*", no stale "default")', () => {
 		assert.equal(
-			packageJson.includes("\"default\""),
+			packageJson.includes('"default"'),
 			false,
-			'"default" is not a valid knip 6.x issue type and breaks knip entirely — stale entry must stay removed',
+			'"default" is not a valid knip 6.x issue type and makes knip exit 2 with no stdout — it must be migrated to a valid type',
 		);
 	});
 });

--- a/.pi/extensions/piignore/test/dead-code-getCommandName-removal.test.mts
+++ b/.pi/extensions/piignore/test/dead-code-getCommandName-removal.test.mts
@@ -1,0 +1,74 @@
+/**
+ * Tests: Removal of dead function `getCommandName` from piignore/index.ts
+ *
+ * Dead-code analysis flagged `getCommandName` (index.ts) as unused —
+ * `checkBashCommand` calls `getCommandNameFromTokens` directly, and the
+ * test file ships its own local copy.
+ *
+ * Verifies:
+ *   - `getCommandName` is no longer defined in index.ts
+ *   - `getCommandNameFromTokens` still exists (live callee, do not delete)
+ *   - knip.ignoreIssues suppresses vendored `.pi/git/**` and fixture noise
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/piignore/test/dead-code-getCommandName-removal.test.mts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function readSource(relativePath: string): string {
+	const path = resolve(dirname(fileURLToPath(import.meta.url)), "..", relativePath);
+	return readFileSync(path, "utf8");
+}
+
+describe("piignore/index.ts — dead getCommandName removed", () => {
+	const source = readSource("index.ts");
+
+	it("getCommandName is no longer defined in index.ts", () => {
+		assert.equal(
+			source.includes("function getCommandName("),
+			false,
+			"getCommandName must be deleted from index.ts",
+		);
+	});
+
+	it("getCommandNameFromTokens still exists (live callee, do not delete)", () => {
+		assert.equal(
+			source.includes("function getCommandNameFromTokens("),
+			true,
+			"getCommandNameFromTokens must be kept — it is called by checkBashCommand",
+		);
+	});
+});
+
+describe("knip.ignoreIssues — criterion 3 suppression config", () => {
+	const packageJson = readSource("../../../package.json");
+
+	it('knip.ignoreIssues contains ".pi/git/**" (vendored code suppression)', () => {
+		assert.match(
+			packageJson,
+			/".pi\/git\/\*\*"\s*:\s*\[/,
+			'knip.ignoreIssues must suppress .pi/git/** findings (explicit /** glob)',
+		);
+	});
+
+	it('knip.ignoreIssues contains "**/test/fixtures/**" (fixture suppression)', () => {
+		assert.match(
+			packageJson,
+			/"\*\*\/test\/fixtures\/\*\*"\s*:\s*\[/,
+			'knip.ignoreIssues must suppress fixture findings (explicit /** glob)',
+		);
+	});
+
+	it('knip.ignoreIssues entries use valid knip 6.x issue types (no stale invalid "default")', () => {
+		assert.equal(
+			packageJson.includes("\"default\""),
+			false,
+			'"default" is not a valid knip 6.x issue type and breaks knip entirely — stale entry must stay removed',
+		);
+	});
+});

--- a/.pi/extensions/supervisor/agent/output.ts
+++ b/.pi/extensions/supervisor/agent/output.ts
@@ -30,10 +30,6 @@ export function stripAnsi(text: string): string {
  */
 const THINKING_PREFIX_RE = /^💭\s*/gm;
 
-function stripThinkingPrefix(text: string): string {
-	return text.replace(THINKING_PREFIX_RE, "");
-}
-
 const VALID_SEVERITIES = new Set<FindingSeverity>(["critical", "warning", "suggestion"]);
 
 // ─── Smart Quote Detection ──────────────────────────────────────

--- a/.pi/extensions/supervisor/test/agent-output.test.mts
+++ b/.pi/extensions/supervisor/test/agent-output.test.mts
@@ -893,8 +893,8 @@ describe("extractLastJson — string-boundary-aware brace matching", () => {
 // ─── Tests: thinking-prefix stripping — JSON in thinking blocks ────
 // When agents use thinking:high, JSON output may be emitted inside
 // thinking blocks. Event handlers push thinking lines to fullLog with
-// "💭 " prefix per line. stripThinkingPrefix removes these prefixes
-// so parseAgentOutput can still extract valid JSON.
+// "💭 " prefix per line. extractLastJson strips these prefixes via
+// THINKING_PREFIX_RE so parseAgentOutput can still extract valid JSON.
 
 describe("parseAgentOutput — JSON in thinking blocks (💭 prefix)", () => {
 	it("extracts JSON from thinking-prefixed lines (thinking:high scenario)", () => {

--- a/.pi/extensions/supervisor/test/dead-code-stripThinkingPrefix-removal.test.mts
+++ b/.pi/extensions/supervisor/test/dead-code-stripThinkingPrefix-removal.test.mts
@@ -1,0 +1,55 @@
+/**
+ * Tests: Removal of dead function `stripThinkingPrefix` from agent/output.ts
+ *
+ * Dead-code analysis flagged `stripThinkingPrefix` as unused — zero call
+ * sites. The underlying `THINKING_PREFIX_RE` const is LIVE (used inside
+ * `extractLastJson`) and must NOT be deleted.
+ *
+ * Verifies:
+ *   - `stripThinkingPrefix` is no longer defined in output.ts
+ *   - `THINKING_PREFIX_RE` still exists and is still referenced inside
+ *     `extractLastJson`
+ *
+ * Run with:
+ *   node --experimental-strip-types --test .pi/extensions/supervisor/test/dead-code-stripThinkingPrefix-removal.test.mts
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function readSource(relativePath: string): string {
+	const path = resolve(dirname(fileURLToPath(import.meta.url)), "..", relativePath);
+	return readFileSync(path, "utf8");
+}
+
+describe("agent/output.ts — dead stripThinkingPrefix removed", () => {
+	const source = readSource("agent/output.ts");
+
+	it("stripThinkingPrefix is no longer defined in output.ts", () => {
+		assert.equal(
+			source.includes("function stripThinkingPrefix("),
+			false,
+			"stripThinkingPrefix must be deleted from output.ts",
+		);
+	});
+
+	it("THINKING_PREFIX_RE still exists (live const, do not delete)", () => {
+		assert.equal(
+			source.includes("const THINKING_PREFIX_RE = /^💭\\s*/gm;"),
+			true,
+			"THINKING_PREFIX_RE must be kept — it is used by extractLastJson",
+		);
+	});
+
+	it("THINKING_PREFIX_RE is still referenced inside extractLastJson", () => {
+		const extractSection = source.slice(source.indexOf("function extractLastJson"));
+		assert.match(
+			extractSection,
+			/raw\.replace\(THINKING_PREFIX_RE, ""\)/,
+			"extractLastJson must keep its THINKING_PREFIX_RE strip (live call site)",
+		);
+	});
+});

--- a/docs/extensions/agent-harness.md
+++ b/docs/extensions/agent-harness.md
@@ -65,9 +65,9 @@ The `bash-query.ts` module classifies bash commands via pure functions:
 | Pattern | Detected By | Redirect To |
 |---------|-------------|-------------|
 | `bash | grep` | `getBashSubKey()` token analysis | `ripgrep_search` |
-| `bash cat` | `getCommandName()` | `read` |
-| `bash rg` | `getCommandName()` | `ripgrep_search` |
-| `bash find . -name` | `getCommandName()` | `ripgrep_search` or `bash ls` |
+| `bash cat` | `getBashSubKey()` | `read` |
+| `bash rg` | `getBashSubKey()` | `ripgrep_search` |
+| `bash find . -name` | `getBashSubKey()` | `ripgrep_search` or `bash ls` |
 
 ### Key Design Decisions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "main",
-	"version": "0.33",
+	"version": "0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "main",
-			"version": "0.33",
+			"version": "0.4",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23,9 +23,7 @@
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
-				"@types/js-yaml": "^4.0.9",
 				"@types/node": "^25.9.1",
-				"@types/shell-quote": "^1.7.5",
 				"eslint": "^10.5.0",
 				"js-yaml": "^5.2.2",
 				"prettier": "^3.8.3",
@@ -2359,11 +2357,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/js-yaml": {
-			"version": "4.0.9",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
 			"dev": true,
@@ -2378,11 +2371,6 @@
 		},
 		"node_modules/@types/retry": {
 			"version": "0.12.0",
-			"license": "MIT"
-		},
-		"node_modules/@types/shell-quote": {
-			"version": "1.7.5",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,44 @@
 			".pi/extensions/*/index.ts"
 		],
 		"ignoreIssues": {
+				".pi/git/**": [
+				"files",
+				"dependencies",
+				"devDependencies",
+				"optionalPeerDependencies",
+				"unlisted",
+				"binaries",
+				"unresolved",
+				"exports",
+				"types",
+				"nsExports",
+				"nsTypes",
+				"duplicates",
+				"enumMembers",
+				"namespaceMembers",
+				"catalog",
+				"catalogReferences",
+				"cycles"
+			],
+			"**/test/fixtures/**": [
+				"files",
+				"dependencies",
+				"devDependencies",
+				"optionalPeerDependencies",
+				"unlisted",
+				"binaries",
+				"unresolved",
+				"exports",
+				"types",
+				"nsExports",
+				"nsTypes",
+				"duplicates",
+				"enumMembers",
+				"namespaceMembers",
+				"catalog",
+				"catalogReferences",
+				"cycles"
+			],
 			".pi/extensions/supervisor/index.ts": [
 				"exports"
 			],
@@ -61,16 +99,15 @@
 				"exports",
 				"types"
 			],
-			".pi/extensions/format-on-save/index.ts": [
-				"default"
-			],
 			".pi/extensions/lsp-auditor/lsp-client.ts": [
 				"exports"
 			]
 		},
 		"ignoreDependencies": [
 			"boxen",
-			"prettier"
+			"prettier",
+			"@types/js-yaml",
+			"@types/shell-quote"
 		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
-		"@types/js-yaml": "^4.0.9",
 		"@types/node": "^25.9.1",
-		"@types/shell-quote": "^1.7.5",
 		"eslint": "^10.5.0",
 		"js-yaml": "^5.2.2",
 		"prettier": "^3.8.3",
@@ -50,7 +48,7 @@
 			".pi/extensions/*/index.ts"
 		],
 		"ignoreIssues": {
-				".pi/git/**": [
+			".pi/git/**": [
 				"files",
 				"dependencies",
 				"devDependencies",
@@ -99,15 +97,16 @@
 				"exports",
 				"types"
 			],
+			".pi/extensions/format-on-save/index.ts": [
+				"exports"
+			],
 			".pi/extensions/lsp-auditor/lsp-client.ts": [
 				"exports"
 			]
 		},
 		"ignoreDependencies": [
 			"boxen",
-			"prettier",
-			"@types/js-yaml",
-			"@types/shell-quote"
+			"prettier"
 		]
 	}
 }


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1454

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 4m 1s | 42.6K | 30 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 11m 13s | 83.7K | 69 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 56s | 63.4K | 44 | minimax-m3 |
| developer | ✓ SUCCESS | 8m 11s | 64.9K | 60 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 9m 38s | 61.2K | 58 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 59s | 73.4K | 58 | minimax-m3 |

**Total:** 6 agents · 40m 58s · 389.2K tokens · 319 tool calls · 19 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1454
Closes #1454

**Gate failures:**
- CI Gate gate failed on run 1 — developer restarted
- Dead Code Gate gate failed on run 4 — developer restarted