### PR TITLE
feat(#1455): Deduplicate copy-pasted test scaffolding in cmd/cheasee-pi

### DIFF
--- a/cmd/cheasee-pi/auth_envvars_test.go
+++ b/cmd/cheasee-pi/auth_envvars_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
 // linePattern matches "provider=ENV_VAR" lines
@@ -30,12 +32,7 @@ func runAuthEnvvars(t *testing.T, extraArgs ...string) string {
 		}
 	}
 
-	format := "shell"
-	for i, a := range extraArgs {
-		if a == "--format" && i+1 < len(extraArgs) {
-			format = extraArgs[i+1]
-		}
-	}
+	format := authEnvvarsFormatFromArgs(extraArgs...)
 
 	authEnvvarsFormat = format
 	var stdout bytes.Buffer
@@ -51,27 +48,29 @@ func runAuthEnvvars(t *testing.T, extraArgs ...string) string {
 // runAuthEnvvarsErr returns the error from runAuthEnvvarsE, for negative tests.
 func runAuthEnvvarsErr(t *testing.T, extraArgs ...string) error {
 	t.Helper()
-	format := "shell"
-	for i, a := range extraArgs {
-		if a == "--format" && i+1 < len(extraArgs) {
-			format = extraArgs[i+1]
-		}
-	}
+	format := authEnvvarsFormatFromArgs(extraArgs...)
 
 	authEnvvarsFormat = format
 	cmd := &cobra.Command{}
 	return runAuthEnvvarsE(cmd, nil)
 }
 
+// authEnvvarsFormatFromArgs extracts the --format value (default "shell").
+func authEnvvarsFormatFromArgs(extraArgs ...string) string {
+	format := "shell"
+	for i, a := range extraArgs {
+		if a == "--format" && i+1 < len(extraArgs) {
+			format = extraArgs[i+1]
+		}
+	}
+	return format
+}
+
 // runAuthEnvvarsCobra runs through cobra for tests that need full command parsing.
 func runAuthEnvvarsCobra(t *testing.T, extraArgs ...string) string {
 	t.Helper()
-	var stdout, stderr bytes.Buffer
-	rootCmd.SetOut(&stdout)
-	rootCmd.SetErr(&stderr)
-	rootCmd.SetArgs(append([]string{"auth", "envvars"}, extraArgs...))
-	rootCmd.ExecuteC() //nolint:errcheck
-	return stdout.String()
+	out, _ := testutil.RunCobra(t, rootCmd, append([]string{"auth", "envvars"}, extraArgs...)...)
+	return out
 }
 
 // ──────────────────────────────────────────────

--- a/cmd/cheasee-pi/config_test.go
+++ b/cmd/cheasee-pi/config_test.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
 func TestConfigSave_Load(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{APIKey: FakeAPIKey}
@@ -31,8 +32,7 @@ func TestConfigSave_Load(t *testing.T) {
 }
 
 func TestConfigSave_CreatesDirectory(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	dir := testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{APIKey: FakeAPIKey}
@@ -53,8 +53,7 @@ func TestConfigSave_CreatesDirectory(t *testing.T) {
 }
 
 func TestConfigSave_ValidJSON(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{APIKey: FakeAPIKey}
@@ -83,8 +82,7 @@ func TestConfigSave_ValidJSON(t *testing.T) {
 }
 
 func TestConfigSave_AtomicWrite(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{APIKey: FakeAPIKey}
@@ -105,8 +103,7 @@ func TestConfigSave_AtomicWrite(t *testing.T) {
 }
 
 func TestConfigLoad_FileNotExists(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	loaded, err := cfg.Load(context.Background())
@@ -122,8 +119,7 @@ func TestConfigLoad_FileNotExists(t *testing.T) {
 }
 
 func TestConfigLoad_InvalidJSON(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	dir := testutil.RedirectConfigHome(t)
 
 	// Create auth.json with invalid JSON
 	path := filepath.Join(dir, "cheasee-pi", "auth.json")
@@ -138,8 +134,7 @@ func TestConfigLoad_InvalidJSON(t *testing.T) {
 }
 
 func TestConfigLoad_PathIsDirectory(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	dir := testutil.RedirectConfigHome(t)
 
 	// Create auth.json as a directory
 	path := filepath.Join(dir, "cheasee-pi", "auth.json")
@@ -153,8 +148,7 @@ func TestConfigLoad_PathIsDirectory(t *testing.T) {
 }
 
 func TestConfigPath(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	dir := testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	path, err := cfg.Path()
@@ -169,8 +163,7 @@ func TestConfigPath(t *testing.T) {
 }
 
 func TestConfigSave_EmptyAPIKey(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{APIKey: ""}
@@ -188,8 +181,7 @@ func TestConfigSave_EmptyAPIKey(t *testing.T) {
 }
 
 func TestConfigSave_SpecialChars(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	specialKey := `key-"quoted"-with\backslash and ünicode`
 	cfg := &fileRepository{}

--- a/cmd/cheasee-pi/docker_check_test.go
+++ b/cmd/cheasee-pi/docker_check_test.go
@@ -108,9 +108,7 @@ func TestDockerVersionParsing(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestDockerCheck_NotInstalled(t *testing.T) {
-	saved := lookPath
-	lookPath = func(_ string) (string, error) { return "", fmt.Errorf("executable not found in $PATH") }
-	defer func() { lookPath = saved }()
+	stubLookPath(t, func(_ string) (string, error) { return "", fmt.Errorf("executable not found in $PATH") })
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -128,12 +126,7 @@ func TestDockerCheck_NotInstalled(t *testing.T) {
 }
 
 func TestDockerCheck_DaemonNotRunning(t *testing.T) {
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
-		return &mockCmd{runFn: func() error { return fmt.Errorf("Cannot connect to the Docker daemon") }}
-	}
-	defer func() { runCommandContext = saved }()
+	stubDockerCheck(t, fmt.Errorf("Cannot connect to the Docker daemon"), "", nil)
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -151,15 +144,7 @@ func TestDockerCheck_DaemonNotRunning(t *testing.T) {
 }
 
 func TestDockerCheck_VersionOutputError(t *testing.T) {
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
-		if len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) { return nil, fmt.Errorf("connection refused") }}
-		}
-		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	stubDockerCheck(t, nil, "", fmt.Errorf("connection refused"))
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -171,15 +156,7 @@ func TestDockerCheck_VersionOutputError(t *testing.T) {
 }
 
 func TestDockerCheck_EmptyVersion(t *testing.T) {
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
-		if len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("  \n"), nil }}
-		}
-		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	stubDockerCheck(t, nil, "  \n", nil)
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -194,15 +171,7 @@ func TestDockerCheck_EmptyVersion(t *testing.T) {
 }
 
 func TestDockerCheck_TooOld(t *testing.T) {
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
-		if len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("23.0.0"), nil }}
-		}
-		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	stubDockerCheck(t, nil, "23.0.0", nil)
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -214,15 +183,7 @@ func TestDockerCheck_TooOld(t *testing.T) {
 }
 
 func TestDockerCheck_InvalidVersion(t *testing.T) {
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
-		if len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("not-a-version"), nil }}
-		}
-		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	stubDockerCheck(t, nil, "not-a-version", nil)
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -234,15 +195,7 @@ func TestDockerCheck_InvalidVersion(t *testing.T) {
 }
 
 func TestDockerCheck_Healthy(t *testing.T) {
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
-		if len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("25.0.0-rc1"), nil }}
-		}
-		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	stubDockerCheck(t, nil, "25.0.0-rc1", nil)
 
 	res, err := dockerCheck(context.Background(), dockerCheckTimeout)
 	if err != nil {
@@ -260,18 +213,16 @@ func TestDockerCheck_Healthy(t *testing.T) {
 }
 
 func TestDockerCheck_ArgsCaptured(t *testing.T) {
-	stubDockerLookPath(t)
+	stubLookPath(t, func(_ string) (string, error) { return "/usr/bin/docker", nil })
 	var infoArgs, versionArgs []string
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
 		if len(arg) > 0 && arg[0] == "info" {
 			infoArgs = arg
 			return &mockCmd{}
 		}
 		versionArgs = arg
 		return &mockCmd{outputFn: func() ([]byte, error) { return []byte("24.0.9"), nil }}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	if _, err := dockerCheck(context.Background(), dockerCheckTimeout); err != nil {
 		t.Fatalf("dockerCheck returned error: %v", err)

--- a/cmd/cheasee-pi/github_test.go
+++ b/cmd/cheasee-pi/github_test.go
@@ -243,13 +243,11 @@ func TestRedactToken_EmptyTokenNoOp(t *testing.T) {
 }
 
 func TestGitCloneWorktree_InvalidURL(t *testing.T) {
-	saved := runCommandContext
 	called := false
-	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, _ ...string) runner {
 		called = true
 		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitCloneWorktree(context.Background(), FakeGitHubToken, "not-a-url", t.TempDir())
 	if err == nil {
@@ -265,8 +263,7 @@ func TestGitCloneWorktree_InvalidURL(t *testing.T) {
 
 func TestGitCloneWorktree_HappyPath(t *testing.T) {
 	var calls [][]string
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
 		calls = append(calls, arg)
 		if arg[0] == "clone" {
 			return &mockCmd{}
@@ -275,8 +272,7 @@ func TestGitCloneWorktree_HappyPath(t *testing.T) {
 			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("refs/remotes/origin/master"), nil }}
 		}
 		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	workdir := filepath.Join(t.TempDir(), "repo")
 	err := gitCloneWorktree(context.Background(), FakeGitHubToken, "https://github.com/owner/repo.git", workdir)
@@ -309,8 +305,7 @@ func TestGitCloneWorktree_HappyPath(t *testing.T) {
 
 func TestGitCloneWorktree_DefaultBranchFallback(t *testing.T) {
 	var worktreeArgs []string
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
 		if len(arg) > 2 && arg[2] == "symbolic-ref" {
 			return &mockCmd{outputFn: func() ([]byte, error) { return nil, fmt.Errorf("HEAD not found") }}
 		}
@@ -319,8 +314,7 @@ func TestGitCloneWorktree_DefaultBranchFallback(t *testing.T) {
 		}
 		worktreeArgs = arg
 		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitCloneWorktree(context.Background(), FakeGitHubToken, "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo"))
 	if err != nil {
@@ -335,11 +329,9 @@ func TestGitCloneWorktree_BareCloneError(t *testing.T) {
 	const token = FakeGitHubToken
 	// Output echoes the token as git would when echoing the URL.
 	output := []byte("fatal: unable to access 'https://oauth2:" + token + "@github.com/owner/repo.git/': Could not resolve host")
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, _ ...string) runner {
 		return &mockCmd{combinedFn: func() ([]byte, error) { return output, fmt.Errorf("exit status 128") }}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitCloneWorktree(context.Background(), token, "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo"))
 	if err == nil {
@@ -354,9 +346,8 @@ func TestGitCloneWorktree_BareCloneError(t *testing.T) {
 }
 
 func TestGitCloneWorktree_WorktreeAddError(t *testing.T) {
-	saved := runCommandContext
 	step := 0
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
 		step++
 		if step == 1 { // bare clone
 			return &mockCmd{}
@@ -365,8 +356,7 @@ func TestGitCloneWorktree_WorktreeAddError(t *testing.T) {
 			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("refs/remotes/origin/main"), nil }}
 		}
 		return &mockCmd{combinedFn: func() ([]byte, error) { return []byte("fatal: worktree error"), fmt.Errorf("exit status 128") }}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitCloneWorktree(context.Background(), FakeGitHubToken, "https://github.com/owner/repo.git", filepath.Join(t.TempDir(), "repo"))
 	if err == nil {
@@ -380,13 +370,11 @@ func TestGitCloneWorktree_WorktreeAddError(t *testing.T) {
 func TestGitAddSubmodule_CapturesArgsAndDir(t *testing.T) {
 	var capturedArgs []string
 	var captured *mockCmd
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
 		capturedArgs = arg
 		captured = &mockCmd{}
 		return captured
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	repoPath := t.TempDir()
 	if err := gitAddSubmodule(context.Background(), repoPath, "flask_blogs", "https://github.com/user/flask_blogs"); err != nil {
@@ -402,13 +390,11 @@ func TestGitAddSubmodule_CapturesArgsAndDir(t *testing.T) {
 }
 
 func TestGitAddSubmodule_ErrorWrapsOutput(t *testing.T) {
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, _ ...string) runner {
 		return &mockCmd{combinedFn: func() ([]byte, error) {
 			return []byte("fatal: path 'x' is already tracked"), fmt.Errorf("exit status 128")
 		}}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitAddSubmodule(context.Background(), t.TempDir(), "x", "https://github.com/a/b.git")
 	if err == nil {

--- a/cmd/cheasee-pi/helpers_test.go
+++ b/cmd/cheasee-pi/helpers_test.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
+	"testing"
 
 	"github.com/cli/oauth/api"
 	"github.com/cli/oauth/device"
@@ -163,3 +168,245 @@ var (
 	_ GitHubClient  = (*mockGitHubClient)(nil)
 	_ submoduleOps  = (*mockSubmoduleOps)(nil)
 )
+
+// ──────────────────────────────────────────────
+// Mock: cmdIface
+// ──────────────────────────────────────────────
+
+type mockCmd struct {
+	outputFn   func() ([]byte, error)
+	combinedFn func() ([]byte, error)
+	runFn      func() error
+	// Captured Set* config, for callers that configure the command
+	dir    string
+	env    []string
+	stdout interface{ Write([]byte) (int, error) }
+	stderr interface{ Write([]byte) (int, error) }
+}
+
+func (m *mockCmd) Output() ([]byte, error) {
+	if m.outputFn != nil {
+		return m.outputFn()
+	}
+	return nil, nil
+}
+
+func (m *mockCmd) CombinedOutput() ([]byte, error) {
+	if m.combinedFn != nil {
+		return m.combinedFn()
+	}
+	return nil, nil
+}
+
+func (m *mockCmd) Run() error {
+	if m.runFn != nil {
+		return m.runFn()
+	}
+	return nil
+}
+
+func (m *mockCmd) SetDir(d string)       { m.dir = d }
+func (m *mockCmd) SetEnv(e []string)     { m.env = e }
+func (m *mockCmd) SetStdout(w io.Writer) { m.stdout = w }
+func (m *mockCmd) SetStderr(w io.Writer) { m.stderr = w }
+
+// ──────────────────────────────────────────────
+// Seam stubs (docker/git CLI tests)
+// ──────────────────────────────────────────────
+
+// stubRunCommandContext replaces the runCommandContext seam for the duration
+// of the test. Serialized (no t.Parallel) — package-var swap is race-free
+// only under serial execution.
+func stubRunCommandContext(t *testing.T, fn func(context.Context, string, ...string) runner) {
+	t.Helper()
+	saved := runCommandContext
+	runCommandContext = fn
+	t.Cleanup(func() { runCommandContext = saved })
+}
+
+// stubExecCommand replaces the execCommand seam for the duration of the test.
+func stubExecCommand(t *testing.T, fn func(string, ...string) cmdIface) {
+	t.Helper()
+	saved := execCommand
+	execCommand = fn
+	t.Cleanup(func() { execCommand = saved })
+}
+
+// stubLookPath replaces the lookPath seam for the duration of the test.
+func stubLookPath(t *testing.T, fn func(string) (string, error)) {
+	t.Helper()
+	saved := lookPath
+	lookPath = fn
+	t.Cleanup(func() { lookPath = saved })
+}
+
+// stubDockerCheck stubs the docker seams. daemonErr, when non-nil, makes
+// `docker info` fail; version is the docker version output (versionErr wins
+// over version when set).
+func stubDockerCheck(t *testing.T, daemonErr error, version string, versionErr error) {
+	t.Helper()
+	stubLookPath(t, func(_ string) (string, error) { return "/usr/bin/docker", nil })
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
+		if len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) {
+				if versionErr != nil {
+					return nil, versionErr
+				}
+				return []byte(version), nil
+			}}
+		}
+		return &mockCmd{runFn: func() error { return daemonErr }}
+	})
+}
+
+// ──────────────────────────────────────────────
+// Renderer + scaffold helpers (package-main value types)
+// ──────────────────────────────────────────────
+
+// testGitIdentityConfig is the hermetic git identity used by init tests.
+const testGitIdentityConfig = "[user]\n\tname = Test User\n\temail = test@example.com\n"
+
+// ScaffoldSettings renders the embedded settings template into a fresh
+// workdir and returns the workdir.
+func ScaffoldSettings(t *testing.T, vals TemplateSettingsValues) string {
+	t.Helper()
+	workdir := t.TempDir()
+	if err := NewSettingsScaffold().Scaffold(context.Background(), workdir, vals); err != nil {
+		t.Fatalf("Scaffold failed: %v", err)
+	}
+	return workdir
+}
+
+// RenderEnv renders docker/.env from vals and returns the file content.
+func RenderEnv(t *testing.T, vals EnvValues) string {
+	t.Helper()
+	dest := filepath.Join(t.TempDir(), "docker", ".env")
+	if err := NewEnvRenderer().Render(context.Background(), dest, vals); err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	return string(data)
+}
+
+// ──────────────────────────────────────────────
+// Auth/config seeding + package-var mutation
+// ──────────────────────────────────────────────
+
+// defaultMocks returns a set of working mock implementations for the genuine
+// seam ports (network/external-service boundaries). In-process adapters
+// (probe, extract, env, scaffold, remover, uid, git identity) are real.
+func defaultMocks() InitPorts {
+	return InitPorts{
+		Auth: &mockAuthenticator{},
+		GitHub: &mockGitHubClient{
+			getUserFunc: func(ctx context.Context, token string) (string, error) {
+				return "testuser", nil
+			},
+			createForkFunc: func(ctx context.Context, token, sourceOwner, sourceRepo string) (string, error) {
+				return "testuser/cheasee-pi", nil
+			},
+			waitForkFunc: func(ctx context.Context, token, owner, repo string) error {
+				return nil
+			},
+		},
+	}
+}
+
+// seedAuth writes auth.json providers into the current config home. Call
+// testutil.RedirectConfigHome or pinPassthroughEnv first.
+func seedAuth(t *testing.T, providers map[string]string) {
+	t.Helper()
+	cfg := &fileRepository{}
+	for name, key := range providers {
+		if err := cfg.AddProvider(context.Background(), name, key); err != nil {
+			t.Fatalf("seed auth.json: %v", err)
+		}
+	}
+}
+
+// withInitProvider sets the package-level init provider for the test duration.
+func withInitProvider(t *testing.T, name string) {
+	t.Helper()
+	saved := initProvider
+	initProvider = name
+	t.Cleanup(func() { initProvider = saved })
+}
+
+// withAuthListWorkdir sets the package-level auth list workdir for the test duration.
+func withAuthListWorkdir(t *testing.T, workdir string) {
+	t.Helper()
+	saved := authListWorkdir
+	authListWorkdir = workdir
+	t.Cleanup(func() { authListWorkdir = saved })
+}
+
+// pinPassthroughEnv makes buildEnvFlags hermetic: fresh XDG_CONFIG_HOME,
+// every passthrough env name cleared, and PATH pointing at a failing gh
+// binary so GH_TOKEN extraction can't leak the host's real token into the map.
+func pinPassthroughEnv(t *testing.T) string {
+	t.Helper()
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	for _, name := range AllEnvVarNames() {
+		t.Setenv(name, "")
+	}
+	bin := t.TempDir()
+	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", bin)
+	return xdg
+}
+
+// submoduleFixture returns a mockSubmoduleOps whose ListSubmodules returns the
+// standard flask_blogs/private-pi fixture — or only flask_blogs when single is
+// true. Set additional mock funcs on the returned mock as needed.
+func submoduleFixture(single bool) *mockSubmoduleOps {
+	subs := []config.Submodule{
+		{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
+		{Name: "private-pi", Path: "private-pi", URL: "https://github.com/SchneiderDaniel/private-pi.git"},
+	}
+	if single {
+		subs = subs[:1]
+	}
+	return &mockSubmoduleOps{
+		listSubmodulesFunc: func(context.Context, string) ([]config.Submodule, error) {
+			return subs, nil
+		},
+	}
+}
+
+// marshalAuth JSON-marshals auth, failing the test on error.
+func marshalAuth(t *testing.T, auth *Auth) []byte {
+	t.Helper()
+	data, err := json.Marshal(auth)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	return data
+}
+
+// initDeps builds a runInit dependency set with the common test defaults:
+// mocked ports, docker check enabled, GitHub flow enabled, no input, prompt
+// fork, fresh workdir, confirming+empty-input fns. Override any field via
+// opts, e.g. initDeps(t, func(d *InitDeps) { d.NoGitHub = true }).
+func initDeps(t *testing.T, opts ...func(*InitDeps)) InitDeps {
+	t.Helper()
+	deps := InitDeps{
+		Ports:         defaultMocks(),
+		NoDockerCheck: false,
+		NoGitHub:      false,
+		NoInput:       true,
+		SourceFork:    SourceForkInput{Mode: ModePromptFork},
+		Workdir:       t.TempDir(),
+		ConfirmFn:     mockConfirmFn(true, nil),
+		InputFn:       mockInputFn("", nil),
+	}
+	for _, opt := range opts {
+		opt(&deps)
+	}
+	return deps
+}

--- a/cmd/cheasee-pi/init_test.go
+++ b/cmd/cheasee-pi/init_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,99 +13,9 @@ import (
 	"github.com/cli/oauth/api"
 	"github.com/cli/oauth/device"
 	"github.com/go-git/go-git/v5/config"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
-
-// defaultMocks returns a set of working mock implementations for the genuine
-// seam ports (network/external-service boundaries). In-process adapters
-// (probe, extract, env, scaffold, remover, uid, git identity) are real.
-func defaultMocks() InitPorts {
-	return InitPorts{
-		Auth: &mockAuthenticator{},
-		GitHub: &mockGitHubClient{
-			getUserFunc: func(ctx context.Context, token string) (string, error) {
-				return "testuser", nil
-			},
-			createForkFunc: func(ctx context.Context, token, sourceOwner, sourceRepo string) (string, error) {
-				return "testuser/cheasee-pi", nil
-			},
-			waitForkFunc: func(ctx context.Context, token, owner, repo string) error {
-				return nil
-			},
-		},
-	}
-}
-
-// setGitIdentity points git config lookups at a hermetic temp config file
-// containing user.name/user.email, so real osGitIdentity lookups are
-// deterministic and never fall through to interactive prompts. Serialized
-// (no t.Parallel) because t.Setenv is process-wide.
-func setGitIdentity(t *testing.T) {
-	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git binary not available")
-	}
-	cfg := filepath.Join(t.TempDir(), "gitconfig")
-	if err := os.WriteFile(cfg, []byte("[user]\n\tname = Test User\n\temail = test@example.com\n"), 0644); err != nil {
-		t.Fatalf("write gitconfig: %v", err)
-	}
-	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
-	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
-}
-
-// unsetGitIdentity points git config lookups at an empty file (no identity),
-// the deterministic no-identity state for fallback tests.
-func unsetGitIdentity(t *testing.T) {
-	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git binary not available")
-	}
-	cfg := filepath.Join(t.TempDir(), "gitconfig")
-	if err := os.WriteFile(cfg, nil, 0644); err != nil {
-		t.Fatalf("write gitconfig: %v", err)
-	}
-	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
-	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
-}
-
-// ──────────────────────────────────────────────
-// Seam stubs for docker/git CLI tests
-// ──────────────────────────────────────────────
-
-// stubDockerLookPath makes the docker binary appear installed until test end.
-func stubDockerLookPath(t *testing.T) {
-	t.Helper()
-	saved := lookPath
-	lookPath = func(_ string) (string, error) { return "/usr/bin/docker", nil }
-	t.Cleanup(func() { lookPath = saved })
-}
-
-// stubDockerCheck stubs the docker seams. daemonErr, when non-nil, makes
-// `docker info` fail; version is the docker version output (versionErr wins
-// over version when set).
-func stubDockerCheck(t *testing.T, daemonErr error, version string, versionErr error) {
-	t.Helper()
-	stubDockerLookPath(t)
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
-		if len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) {
-				if versionErr != nil {
-					return nil, versionErr
-				}
-				return []byte(version), nil
-			}}
-		}
-		return &mockCmd{runFn: func() error { return daemonErr }}
-	}
-	t.Cleanup(func() { runCommandContext = saved })
-}
-
-// redirectConfigDir points the auth config dir at a fresh temp dir so no test
-// touches the real $HOME/.config.
-func redirectConfigDir(t *testing.T) {
-	t.Helper()
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-}
 
 // authJSONExists reports whether auth.json was written to the config dir.
 func authJSONExists(t *testing.T) bool {
@@ -136,22 +45,10 @@ func loadAuthJSON(t *testing.T) *Auth {
 // ──────────────────────────────────────────────
 
 func TestInitUseCase_DockerNotInstalled(t *testing.T) {
-	redirectConfigDir(t)
-	saved := lookPath
-	lookPath = func(_ string) (string, error) { return "", fmt.Errorf("executable not found in $PATH") }
-	defer func() { lookPath = saved }()
-	ports := defaultMocks()
+	testutil.RedirectConfigHome(t)
+	stubLookPath(t, func(_ string) (string, error) { return "", fmt.Errorf("executable not found in $PATH") })
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) { d.NoGitHub = true }))
 	if err == nil {
 		t.Fatal("expected error when Docker not installed")
 	}
@@ -164,20 +61,10 @@ func TestInitUseCase_DockerNotInstalled(t *testing.T) {
 }
 
 func TestInitUseCase_DockerNotRunning(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, fmt.Errorf("Cannot connect to the Docker daemon"), "", nil)
-	ports := defaultMocks()
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) { d.NoGitHub = true }))
 	if err == nil {
 		t.Fatal("expected error when Docker not running")
 	}
@@ -190,20 +77,10 @@ func TestInitUseCase_DockerNotRunning(t *testing.T) {
 }
 
 func TestInitUseCase_DockerVersionTooOld(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "23.0.0", nil)
-	ports := defaultMocks()
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) { d.NoGitHub = true }))
 	if err == nil {
 		t.Fatal("expected error when Docker version too old")
 	}
@@ -216,20 +93,10 @@ func TestInitUseCase_DockerVersionTooOld(t *testing.T) {
 }
 
 func TestInitUseCase_DockerCheckReturnsErr(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "", fmt.Errorf("version check failed"))
-	ports := defaultMocks()
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) { d.NoGitHub = true }))
 	if err == nil {
 		t.Fatal("expected error when Docker version fetch fails")
 	}
@@ -239,21 +106,14 @@ func TestInitUseCase_DockerCheckReturnsErr(t *testing.T) {
 }
 
 func TestInitUseCase_NoDockerCheckFlag(t *testing.T) {
-	redirectConfigDir(t)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		APIKey:         FakeAPIKey,
-		NoDockerCheck:  true,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.NoGitHub = true
+		d.NoDockerCheck = true
+		d.APIKey = FakeAPIKey
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error with --no-docker-check: %v", err)
 	}
@@ -266,22 +126,14 @@ func TestInitUseCase_NoDockerCheckFlag(t *testing.T) {
 }
 
 func TestInitUseCase_HappyPathWithAPIKeyFlag(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		APIKey:         FakeAPIKey,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.NoGitHub = true
+		d.APIKey = FakeAPIKey
+	}))
 	if err != nil {
 		t.Fatalf("unexpected error on happy path: %v", err)
 	}
@@ -295,28 +147,19 @@ func TestInitUseCase_HappyPathWithAPIKeyFlag(t *testing.T) {
 
 func TestInitUseCase_ConfigSaveError(t *testing.T) {
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	// Block the config dir path with a regular file so MkdirAll fails
 	// deterministically (real file I/O, no mock error injection).
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	dir := testutil.RedirectConfigHome(t)
 	if err := os.WriteFile(filepath.Join(dir, "cheasee-pi"), []byte("block"), 0644); err != nil {
 		t.Fatalf("block config dir: %v", err)
 	}
 
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		APIKey:         FakeAPIKey,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.NoGitHub = true
+		d.APIKey = FakeAPIKey
+	}))
 	if err == nil {
 		t.Fatal("expected error when Save fails")
 	}
@@ -326,24 +169,15 @@ func TestInitUseCase_ConfigSaveError(t *testing.T) {
 }
 
 func TestInitUseCase_ContextCancelled(t *testing.T) {
-	redirectConfigDir(t)
-	stubDockerLookPath(t)
+	testutil.RedirectConfigHome(t)
+	stubLookPath(t, func(_ string) (string, error) { return "/usr/bin/docker", nil })
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // immediately cancelled
 
-	ports := defaultMocks()
-
-	err := runInit(ctx, InitDeps{
-		Ports:          ports,
-		APIKey:         FakeAPIKey,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(ctx, initDeps(t, func(d *InitDeps) {
+		d.NoGitHub = true
+		d.APIKey = FakeAPIKey
+	}))
 	if err == nil {
 		t.Fatal("expected error with cancelled context")
 	}
@@ -563,23 +397,16 @@ func TestRunInitAuth_RequestCodeError(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_FullFlow(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   &mockSubmoduleOps{},
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SubmoduleOps = &mockSubmoduleOps{}
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("full flow failed: %v", err)
 	}
@@ -591,24 +418,16 @@ func TestRunInit_FullFlow(t *testing.T) {
 func TestRunInit_NoGitHubFlag(t *testing.T) {
 	// --no-github flag: extract + env + save all run after auth, with the
 	// real in-process adapters (probe, extract, env render, scaffold).
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		APIKey:         FakeAPIKey,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.NoGitHub = true
+		d.APIKey = FakeAPIKey
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("legacy path should work: %v", err)
 	}
@@ -617,7 +436,7 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 		t.Errorf("extract should have run (docker/docker-compose.yml missing): %v", err)
 	}
 	// Real env renderer ran: docker/.env present with host uid/gid and git identity.
-	envVals := readEnvFile(t, workdir)
+	envVals := testutil.ReadEnvFile(t, workdir)
 	if envVals["HOST_UID"] == "" || envVals["HOST_GIT_NAME"] != "Test User" {
 		t.Errorf("expected .env with HOST_UID and git identity, got: %v", envVals)
 	}
@@ -658,7 +477,7 @@ func TestRunInit_ContextCancelledMidFlow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	ports := defaultMocks()
 
 	// Override auth with one that respects cancelled context
@@ -671,16 +490,7 @@ func TestRunInit_ContextCancelledMidFlow(t *testing.T) {
 	// Cancel right after docker check
 	cancel()
 
-	err := runInit(ctx, InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(ctx, initDeps(t, func(d *InitDeps) { d.Ports = ports }))
 	if err == nil {
 		t.Fatal("expected error for cancelled context")
 	}
@@ -691,9 +501,9 @@ func TestRunInit_ContextCancelledMidFlow(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_ForkAlreadyExists(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 	ports := defaultMocks()
 
 	// Override GitHub client to return fork-already-exists
@@ -710,17 +520,12 @@ func TestRunInit_ForkAlreadyExists(t *testing.T) {
 	}
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   &mockSubmoduleOps{},
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.Ports = ports
+		d.SubmoduleOps = &mockSubmoduleOps{}
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("fork-already-exists should not be fatal: %v", err)
 	}
@@ -731,7 +536,7 @@ func TestRunInit_ForkAlreadyExists(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_ForkNon422Error(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
 	ports := defaultMocks()
 
@@ -745,16 +550,11 @@ func TestRunInit_ForkNon422Error(t *testing.T) {
 	}
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.Ports = ports
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+	}))
 	if err == nil {
 		t.Fatal("expected error for non-422 fork error")
 	}
@@ -856,14 +656,7 @@ func TestRunInitSubmodule_SkipAll(t *testing.T) {
 }
 
 func TestRunInitSubmodule_NoOverridesNoPrompt(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-				{Name: "private-pi", Path: "private-pi", URL: "https://github.com/SchneiderDaniel/private-pi.git"},
-			}, nil
-		},
-	}
+	mc := submoduleFixture(false)
 
 	err := runInitSubmodule(context.Background(), mc, t.TempDir(), nil, false, nil, false, nil, nil)
 	if err != nil {
@@ -881,13 +674,7 @@ func TestRunInitSubmodule_NoOverridesNoPrompt(t *testing.T) {
 }
 
 func TestRunInitSubmodule_WithPromptReturnsEmpty(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-			}, nil
-		},
-	}
+	mc := submoduleFixture(true)
 
 	promptFn := func(sms []config.Submodule) (map[string]string, error) {
 		return nil, nil // user accepted all defaults
@@ -906,14 +693,7 @@ func TestRunInitSubmodule_WithPromptReturnsEmpty(t *testing.T) {
 }
 
 func TestRunInitSubmodule_UrlOverridesOne(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-				{Name: "private-pi", Path: "private-pi", URL: "https://github.com/SchneiderDaniel/private-pi.git"},
-			}, nil
-		},
-	}
+	mc := submoduleFixture(false)
 
 	urlOverrides := map[string]string{
 		"flask_blogs": "https://github.com/user/flask_blogs",
@@ -938,16 +718,9 @@ func TestRunInitSubmodule_UrlOverridesOne(t *testing.T) {
 }
 
 func TestRunInitSubmodule_UrlOverridesBoth(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-				{Name: "private-pi", Path: "private-pi", URL: "https://github.com/SchneiderDaniel/private-pi.git"},
-			}, nil
-		},
-		setSubmoduleURLFunc: func(ctx context.Context, repoPath, name, url string) error {
-			return nil
-		},
+	mc := submoduleFixture(false)
+	mc.setSubmoduleURLFunc = func(ctx context.Context, repoPath, name, url string) error {
+		return nil
 	}
 
 	urlOverrides := map[string]string{
@@ -966,14 +739,7 @@ func TestRunInitSubmodule_UrlOverridesBoth(t *testing.T) {
 }
 
 func TestRunInitSubmodule_PromptReturnsOverride(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-				{Name: "private-pi", Path: "private-pi", URL: "https://github.com/SchneiderDaniel/private-pi.git"},
-			}, nil
-		},
-	}
+	mc := submoduleFixture(false)
 
 	promptFn := func(sms []config.Submodule) (map[string]string, error) {
 		return map[string]string{
@@ -994,13 +760,7 @@ func TestRunInitSubmodule_PromptReturnsOverride(t *testing.T) {
 }
 
 func TestRunInitSubmodule_OverridesPrecedePrompt(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-			}, nil
-		},
-	}
+	mc := submoduleFixture(true)
 
 	// Prompt returns one URL, but override wins
 	promptFn := func(sms []config.Submodule) (map[string]string, error) {
@@ -1039,15 +799,9 @@ func TestRunInitSubmodule_ListSubmodulesError(t *testing.T) {
 }
 
 func TestRunInitSubmodule_SetSubmoduleURLError(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-			}, nil
-		},
-		setSubmoduleURLFunc: func(ctx context.Context, repoPath, name, url string) error {
-			return fmt.Errorf("invalid URL")
-		},
+	mc := submoduleFixture(true)
+	mc.setSubmoduleURLFunc = func(ctx context.Context, repoPath, name, url string) error {
+		return fmt.Errorf("invalid URL")
 	}
 
 	urlOverrides := map[string]string{
@@ -1064,15 +818,9 @@ func TestRunInitSubmodule_SetSubmoduleURLError(t *testing.T) {
 }
 
 func TestRunInitSubmodule_InitAndUpdateError(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-			}, nil
-		},
-		initAndUpdateSubmodFunc: func(ctx context.Context, repoPath string) error {
-			return fmt.Errorf("update failed")
-		},
+	mc := submoduleFixture(true)
+	mc.initAndUpdateSubmodFunc = func(ctx context.Context, repoPath string) error {
+		return fmt.Errorf("update failed")
 	}
 
 	err := runInitSubmodule(context.Background(), mc, t.TempDir(), nil, false, nil, false, nil, nil)
@@ -1085,13 +833,7 @@ func TestRunInitSubmodule_InitAndUpdateError(t *testing.T) {
 }
 
 func TestRunInitSubmodule_PromptError(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-			}, nil
-		},
-	}
+	mc := submoduleFixture(true)
 
 	promptFn := func(sms []config.Submodule) (map[string]string, error) {
 		return nil, fmt.Errorf("user cancelled")
@@ -1142,15 +884,9 @@ func TestRunInitSubmodule_EmptySubmoduleList(t *testing.T) {
 }
 
 func TestRunInitSubmodule_OverrideNonExistentSubmodule(t *testing.T) {
-	mc := &mockSubmoduleOps{
-		listSubmodulesFunc: func(ctx context.Context, repoPath string) ([]config.Submodule, error) {
-			return []config.Submodule{
-				{Name: "flask_blogs", Path: "flask_blogs", URL: "https://github.com/SchneiderDaniel/flask_blogs"},
-			}, nil
-		},
-		setSubmoduleURLFunc: func(ctx context.Context, repoPath, name, url string) error {
-			return fmt.Errorf("submodule %q not found in .gitmodules", name)
-		},
+	mc := submoduleFixture(true)
+	mc.setSubmoduleURLFunc = func(ctx context.Context, repoPath, name, url string) error {
+		return fmt.Errorf("submodule %q not found in .gitmodules", name)
 	}
 
 	urlOverrides := map[string]string{
@@ -1182,7 +918,7 @@ func TestRunInitExtract_Success(t *testing.T) {
 func TestRunInitExtract_LogMessage(t *testing.T) {
 	// Capture stderr to verify the log message includes the /docker suffix.
 	dir := t.TempDir()
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		if err := runInitExtract(context.Background(), dir); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1201,31 +937,15 @@ func TestRunInitExtract_LogMessage(t *testing.T) {
 // Env generation tests
 // ──────────────────────────────────────────────
 
-// readEnvFile reads docker/.env and returns its KEY=VALUE lines as a map.
-func readEnvFile(t *testing.T, workdir string) map[string]string {
-	t.Helper()
-	data, err := os.ReadFile(filepath.Join(workdir, "docker", ".env"))
-	if err != nil {
-		t.Fatalf("read docker/.env: %v", err)
-	}
-	vals := make(map[string]string)
-	for _, line := range strings.Split(string(data), "\n") {
-		if k, v, ok := strings.Cut(line, "="); ok {
-			vals[k] = strings.Trim(v, "\"")
-		}
-	}
-	return vals
-}
-
 func TestRunInitEnv_Success(t *testing.T) {
-	setGitIdentity(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
 	if err := runInitEnv(context.Background(), workdir, mockConfirmFn(true, nil)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	vals := readEnvFile(t, workdir)
+	vals := testutil.ReadEnvFile(t, workdir)
 	if vals["HOST_UID"] == "" {
 		t.Error("expected non-empty HOST_UID")
 	}
@@ -1242,14 +962,14 @@ func TestRunInitEnv_Success(t *testing.T) {
 
 func TestRunInitEnv_GitIdentityFallback(t *testing.T) {
 	// Empty git config + declined identity prompt → defaults written.
-	unsetGitIdentity(t)
+	testutil.SetGitConfig(t, "")
 
 	workdir := t.TempDir()
 	if err := runInitEnv(context.Background(), workdir, mockConfirmFn(false, nil)); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	vals := readEnvFile(t, workdir)
+	vals := testutil.ReadEnvFile(t, workdir)
 	if vals["HOST_GIT_NAME"] != "Cheasee-Pi" {
 		t.Errorf("expected default HOST_GIT_NAME 'Cheasee-Pi', got %q", vals["HOST_GIT_NAME"])
 	}
@@ -1265,32 +985,16 @@ func TestRunInitEnv_GitIdentityFallback(t *testing.T) {
 // Scaffold phase tests (real templateSettingsRenderer)
 // ──────────────────────────────────────────────
 
-// readSettingsFile reads .pi/settings.json and returns it as a map.
-func readSettingsFile(t *testing.T, workdir string) map[string]any {
-	t.Helper()
-	data, err := os.ReadFile(filepath.Join(workdir, ".pi", "settings.json"))
-	if err != nil {
-		t.Fatalf("read .pi/settings.json: %v", err)
-	}
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("settings.json is not valid JSON: %v", err)
-	}
-	return raw
-}
-
 func TestRunInitScaffold_IdentityFromConfig(t *testing.T) {
-	setGitIdentity(t)
-	oldProvider := initProvider
-	initProvider = "opencode-go"
-	defer func() { initProvider = oldProvider }()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	withInitProvider(t, "opencode-go")
 
 	workdir := t.TempDir()
 	if err := runInitScaffold(context.Background(), workdir, mockConfirmFn(true, nil)); err != nil {
 		t.Fatalf("scaffold failed: %v", err)
 	}
 
-	raw := readSettingsFile(t, workdir)
+	raw := testutil.ReadSettingsRaw(t, workdir)
 	if raw["defaultProvider"] != "opencode-go" {
 		t.Errorf("expected defaultProvider 'opencode-go', got %v", raw["defaultProvider"])
 	}
@@ -1307,10 +1011,8 @@ func TestRunInitScaffold_IdentityFromConfig(t *testing.T) {
 }
 
 func TestRunInitScaffold_DefaultsOnEmptyIdentity(t *testing.T) {
-	unsetGitIdentity(t)
-	oldProvider := initProvider
-	initProvider = "opencode-go"
-	defer func() { initProvider = oldProvider }()
+	testutil.SetGitConfig(t, "")
+	withInitProvider(t, "opencode-go")
 
 	workdir := t.TempDir()
 	// Declined identity prompt → default name/email written.
@@ -1318,7 +1020,7 @@ func TestRunInitScaffold_DefaultsOnEmptyIdentity(t *testing.T) {
 		t.Fatalf("scaffold failed: %v", err)
 	}
 
-	raw := readSettingsFile(t, workdir)
+	raw := testutil.ReadSettingsRaw(t, workdir)
 	gitID, ok := raw["gitIdentity"].(map[string]any)
 	if !ok {
 		t.Fatal("expected gitIdentity object")
@@ -1387,49 +1089,20 @@ func TestInitDeps_Validate(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestInit_SuccessMessage(t *testing.T) {
-	setGitIdentity(t)
-	// Capture stderr to verify the success message
-	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stderr = w
-
-	// Restore after test
-	defer func() {
-		w.Close()
-		os.Stderr = oldStderr
-	}()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	redirectConfigDir(t)
-	ports := defaultMocks()
+	testutil.RedirectConfigHome(t)
 
-	err = runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		APIKey:         FakeAPIKey,
-		NoDockerCheck:  false,
-		NoGitHub:       true,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork},
-		Workdir:        t.TempDir(),
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
+	output := testutil.CaptureStderr(t, func() {
+		err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+			d.NoGitHub = true
+			d.APIKey = FakeAPIKey
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, err = buf.ReadFrom(r)
-	if err != nil {
-		t.Fatalf("read stderr: %v", err)
-	}
-	output := buf.String()
 
 	if strings.Contains(output, "cheasee-pi start") {
 		t.Error("success message must NOT reference 'cheasee-pi start'")
@@ -1452,10 +1125,7 @@ func TestAuthPerProvider_MarshalHasProviderSlot(t *testing.T) {
 		Provider: "opencode-go",
 	}
 
-	data, err := json.Marshal(auth)
-	if err != nil {
-		t.Fatalf("Marshal failed: %v", err)
-	}
+	data := marshalAuth(t, auth)
 
 	// Must contain the provider-keyed object
 	var raw map[string]any
@@ -1487,10 +1157,7 @@ func TestAuthPerProvider_MarshalNoProviderWritesFlat(t *testing.T) {
 		// Provider is empty — should write flat api_key
 	}
 
-	data, err := json.Marshal(auth)
-	if err != nil {
-		t.Fatalf("Marshal failed: %v", err)
-	}
+	data := marshalAuth(t, auth)
 
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -1516,10 +1183,7 @@ func TestAuthPerProvider_MarshalEmptyProviderNoKey(t *testing.T) {
 		RepoPath:    "/workspace",
 	}
 
-	data, err := json.Marshal(auth)
-	if err != nil {
-		t.Fatalf("Marshal failed: %v", err)
-	}
+	data := marshalAuth(t, auth)
 
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -1590,8 +1254,7 @@ func TestAuthPerProvider_UnmarshalFlatFormat(t *testing.T) {
 }
 
 func TestAuthPerProvider_SaveWritesJqParseableOutput(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{
@@ -1655,8 +1318,7 @@ func TestAuthPerProvider_UnmarshalMalformedJSON(t *testing.T) {
 }
 
 func TestAuthPerProvider_RoundTripWithProvider(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{
@@ -1698,10 +1360,7 @@ func TestAuthPerProvider_MarshalOmitGitHubTokenWhenEmpty(t *testing.T) {
 		Provider: "openai",
 	}
 
-	data, err := json.Marshal(auth)
-	if err != nil {
-		t.Fatalf("Marshal failed: %v", err)
-	}
+	data := marshalAuth(t, auth)
 
 	if bytes.Contains(data, []byte("github_token")) {
 		t.Error("expected no github_token in output when empty")
@@ -1716,8 +1375,7 @@ func TestAuthPerProvider_MarshalOmitGitHubTokenWhenEmpty(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestConfigBackwardCompat_OldAuthLoads(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	dir := testutil.RedirectConfigHome(t)
 
 	// Write old-format auth.json
 	oldDir := filepath.Join(dir, "cheasee-pi")
@@ -1740,8 +1398,7 @@ func TestConfigBackwardCompat_OldAuthLoads(t *testing.T) {
 }
 
 func TestConfigBackwardCompat_RoundTripPreservesNewFields(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", dir)
+	testutil.RedirectConfigHome(t)
 
 	cfg := &fileRepository{}
 	auth := &Auth{
@@ -1778,17 +1435,11 @@ func TestConfigBackwardCompat_RoundTripPreservesNewFields(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestInitCmd_HelpShowsNewFlags(t *testing.T) {
-	rootCmd.SetArgs([]string{"init", "--help"})
-	var buf strings.Builder
-	rootCmd.SetOut(&buf)
-	rootCmd.SetErr(&buf)
-
-	_, err := rootCmd.ExecuteC()
+	output, err := testutil.RunCobra(t, rootCmd, "init", "--help")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	output := buf.String()
 	expectedFlags := []string{"--workdir", "--source-repo", "--no-github", "--client-id", "--provider", "--skip-fork", "--fork-url", "--no-input", "--submodule-url", "--skip-submodules"}
 	for _, flag := range expectedFlags {
 		if !strings.Contains(output, flag) {
@@ -1897,22 +1548,15 @@ func TestRunInitPromptSource_ForkURLMode(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_SkipFork(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModeSkipFork},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SourceFork = SourceForkInput{Mode: ModeSkipFork}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("skip-fork flow failed: %v", err)
 	}
@@ -1922,9 +1566,9 @@ func TestRunInit_SkipFork(t *testing.T) {
 }
 
 func TestRunInit_ForkURL(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	submoduleInited := false
 	ops := &mockSubmoduleOps{
@@ -1955,17 +1599,12 @@ func TestRunInit_ForkURL(t *testing.T) {
 	ports := defaultMocks()
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   ops,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModeUseForkURL, ForkURL: "https://github.com/user/existing-fork.git"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.Ports = ports
+		d.SubmoduleOps = ops
+		d.SourceFork = SourceForkInput{Mode: ModeUseForkURL, ForkURL: "https://github.com/user/existing-fork.git"}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("fork-url flow failed: %v", err)
 	}
@@ -1984,9 +1623,9 @@ func TestRunInit_ForkURL(t *testing.T) {
 }
 
 func TestRunInit_ForkURLSkipsCreateFork(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	forkCalled := false
 	waitForkCalled := false
@@ -2010,17 +1649,12 @@ func TestRunInit_ForkURLSkipsCreateFork(t *testing.T) {
 	ports.GitHub = mockGH
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   &mockSubmoduleOps{},
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModeUseForkURL, ForkURL: "https://github.com/user/existing-fork.git"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.Ports = ports
+		d.SubmoduleOps = &mockSubmoduleOps{}
+		d.SourceFork = SourceForkInput{Mode: ModeUseForkURL, ForkURL: "https://github.com/user/existing-fork.git"}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("fork-url flow failed: %v", err)
 	}
@@ -2033,21 +1667,14 @@ func TestRunInit_ForkURLSkipsCreateFork(t *testing.T) {
 }
 
 func TestRunInit_ForkURLInvalid(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	ports := defaultMocks()
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModeUseForkURL, ForkURL: ""},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SourceFork = SourceForkInput{Mode: ModeUseForkURL, ForkURL: ""}
+		d.Workdir = workdir
+	}))
 	if err == nil {
 		t.Fatal("expected error for invalid fork URL")
 	}
@@ -2061,23 +1688,18 @@ func TestRunInit_ForkURLInvalid(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestRunInit_PostCloneConfirm_Accepted(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   &mockSubmoduleOps{},
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        false,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil, "Configure API keys"),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SubmoduleOps = &mockSubmoduleOps{}
+		d.NoInput = false
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+		d.ConfirmFn = mockConfirmFn(true, nil, "Configure API keys")
+	}))
 	if err != nil {
 		t.Fatalf("post-clone confirm flow failed: %v", err)
 	}
@@ -2087,21 +1709,16 @@ func TestRunInit_PostCloneConfirm_Accepted(t *testing.T) {
 }
 
 func TestRunInit_PostCloneConfirm_Declined(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	ports := defaultMocks()
 
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        false,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(false, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.NoInput = false
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+		d.ConfirmFn = mockConfirmFn(false, nil)
+	}))
 	if err != nil {
 		t.Fatalf("expected nil error (clean exit) when confirm is declined: %v", err)
 	}
@@ -2112,23 +1729,18 @@ func TestRunInit_PostCloneConfirm_Declined(t *testing.T) {
 
 func TestRunInit_PostCloneConfirm_NoInputSkipsPrompt(t *testing.T) {
 	// With noInput=true, the post-clone confirm should be skipped
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	// If confirm were called with false, we'd error (but it won't be called)
 	workdir := t.TempDir()
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   &mockSubmoduleOps{},
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SubmoduleOps = &mockSubmoduleOps{}
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+		d.ConfirmFn = nil
+	}))
 	if err != nil {
 		t.Fatalf("post-clone confirm with noInput=true failed: %v", err)
 	}
@@ -2141,31 +1753,15 @@ func TestRunInit_PostCloneConfirm_NoInputSkipsPrompt(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestSettingsScaffold_WritesCorrectContent(t *testing.T) {
-	scaffold := NewSettingsScaffold()
-	workdir := t.TempDir()
-
-	vals := TemplateSettingsValues{
+	workdir := ScaffoldSettings(t, TemplateSettingsValues{
 		Provider: "opencode-go",
 		GitName:  "Test User",
 		GitEmail: "test@example.com",
 		Memory:   "4G",
 		CPUs:     "4.0",
-	}
+	})
 
-	if err := scaffold.Scaffold(context.Background(), workdir, vals); err != nil {
-		t.Fatalf("Scaffold failed: %v", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(workdir, ".pi", "settings.json"))
-	if err != nil {
-		t.Fatalf("Read settings.json failed: %v", err)
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("settings.json is not valid JSON: %v", err)
-	}
-
+	raw := testutil.ReadSettingsRaw(t, workdir)
 	if raw["defaultProvider"] != "opencode-go" {
 		t.Errorf("expected defaultProvider 'opencode-go', got %v", raw["defaultProvider"])
 	}
@@ -2197,69 +1793,36 @@ func TestSettingsScaffold_WritesCorrectContent(t *testing.T) {
 }
 
 func TestSettingsScaffold_Idempotent(t *testing.T) {
-	scaffold := NewSettingsScaffold()
-	workdir := t.TempDir()
-
-	vals := TemplateSettingsValues{
+	workdir := ScaffoldSettings(t, TemplateSettingsValues{
 		Provider: "opencode-go",
 		GitName:  "Original",
 		GitEmail: "orig@example.com",
 		Memory:   "2G",
 		CPUs:     "2.0",
-	}
-
-	// First call: write file
-	if err := scaffold.Scaffold(context.Background(), workdir, vals); err != nil {
-		t.Fatalf("first Scaffold failed: %v", err)
-	}
+	})
 
 	// Second call: should no-op (file exists)
-	vals2 := TemplateSettingsValues{
+	if err := NewSettingsScaffold().Scaffold(context.Background(), workdir, TemplateSettingsValues{
 		Provider: "overwrite",
 		GitName:  "Overwrite",
 		GitEmail: "overwrite@example.com",
 		Memory:   "8G",
 		CPUs:     "8.0",
-	}
-	if err := scaffold.Scaffold(context.Background(), workdir, vals2); err != nil {
+	}); err != nil {
 		t.Fatalf("second Scaffold failed: %v", err)
 	}
 
 	// Content must still be from first call (unchanged)
-	data, err := os.ReadFile(filepath.Join(workdir, ".pi", "settings.json"))
-	if err != nil {
-		t.Fatalf("Read settings.json failed: %v", err)
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("settings.json is not valid JSON: %v", err)
-	}
-
+	raw := testutil.ReadSettingsRaw(t, workdir)
 	if raw["defaultProvider"] != "opencode-go" {
 		t.Errorf("expected defaultProvider 'opencode-go' (unchanged), got %v", raw["defaultProvider"])
 	}
 }
 
 func TestSettingsScaffold_EmptyValues(t *testing.T) {
-	scaffold := NewSettingsScaffold()
-	workdir := t.TempDir()
+	workdir := ScaffoldSettings(t, TemplateSettingsValues{}) // all empty
 
-	vals := TemplateSettingsValues{} // all empty
-
-	if err := scaffold.Scaffold(context.Background(), workdir, vals); err != nil {
-		t.Fatalf("Scaffold failed: %v", err)
-	}
-
-	data, err := os.ReadFile(filepath.Join(workdir, ".pi", "settings.json"))
-	if err != nil {
-		t.Fatalf("Read settings.json failed: %v", err)
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("settings.json is not valid JSON: %v", err)
-	}
+	raw := testutil.ReadSettingsRaw(t, workdir)
 
 	// Empty values should be empty strings in output
 	if raw["defaultProvider"] != "" {
@@ -2389,12 +1952,10 @@ func TestGitInitializer_ContextCancelled(t *testing.T) {
 	cancel() // immediately cancelled
 
 	// Seam must not be touched for a pre-cancelled ctx.
-	saved := runCommandContext
-	runCommandContext = func(ctx context.Context, name string, arg ...string) runner {
+	stubRunCommandContext(t, func(ctx context.Context, name string, arg ...string) runner {
 		t.Errorf("runCommandContext should not be invoked with cancelled ctx")
 		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitInit(ctx, workdir)
 	if err == nil {
@@ -2462,7 +2023,7 @@ func TestInitRemove_SingleFile(t *testing.T) {
 	}
 
 	// Capture stderr
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		if err := r.Remove(workdir); err != nil {
 			t.Fatalf("Remove failed: %v", err)
 		}
@@ -2488,7 +2049,7 @@ func TestInitRemove_Directory(t *testing.T) {
 		t.Fatalf("create .github dir: %v", err)
 	}
 
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		if err := r.Remove(workdir); err != nil {
 			t.Fatalf("Remove failed: %v", err)
 		}
@@ -2516,7 +2077,7 @@ func TestInitRemove_MultiplePatterns(t *testing.T) {
 		t.Fatalf("write b.md: %v", err)
 	}
 
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		if err := r.Remove(workdir); err != nil {
 			t.Fatalf("Remove failed: %v", err)
 		}
@@ -2602,7 +2163,7 @@ func TestInitRemove_DeepGlob(t *testing.T) {
 		t.Fatalf("write pkg: %v", err)
 	}
 
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		if err := r.Remove(workdir); err != nil {
 			t.Fatalf("Remove failed: %v", err)
 		}
@@ -2676,25 +2237,17 @@ func seedCloneFixture(t *testing.T, workdir string) {
 }
 
 func TestRunInit_RemoverCalled(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
 	seedCloneFixture(t, workdir)
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		SubmoduleOps:   &mockSubmoduleOps{},
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SubmoduleOps = &mockSubmoduleOps{}
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("full flow with remover failed: %v", err)
 	}
@@ -2710,26 +2263,18 @@ func TestRunInit_RemoverCalled(t *testing.T) {
 }
 
 func TestRunInit_RemoverError(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-
-	ports := defaultMocks()
 
 	workdir := t.TempDir()
 	os.MkdirAll(filepath.Join(workdir, ".git"), 0755)
 	if err := os.WriteFile(filepath.Join(workdir, ".initremove"), []byte("unmatched[brackets\n"), 0644); err != nil {
 		t.Fatalf("write .initremove: %v", err)
 	}
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SourceFork = SourceForkInput{Mode: ModePromptFork, SourceRepo: "owner/cheasee-pi"}
+		d.Workdir = workdir
+	}))
 	if err == nil {
 		t.Fatal("expected error when remover fails")
 	}
@@ -2739,24 +2284,16 @@ func TestRunInit_RemoverError(t *testing.T) {
 }
 
 func TestRunInit_RemoverSkipFork(t *testing.T) {
-	redirectConfigDir(t)
+	testutil.RedirectConfigHome(t)
 	stubDockerCheck(t, nil, "24.0.9", nil)
-	setGitIdentity(t)
-
-	ports := defaultMocks()
+	testutil.SetGitConfig(t, testGitIdentityConfig)
 
 	workdir := t.TempDir()
 	seedCloneFixture(t, workdir)
-	err := runInit(context.Background(), InitDeps{
-		Ports:          ports,
-		NoDockerCheck:  false,
-		NoGitHub:       false,
-		NoInput:        true,
-		SourceFork:     SourceForkInput{Mode: ModeSkipFork},
-		Workdir:        workdir,
-		ConfirmFn:      mockConfirmFn(true, nil),
-		InputFn:        mockInputFn("", nil),
-	})
+	err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.SourceFork = SourceForkInput{Mode: ModeSkipFork}
+		d.Workdir = workdir
+	}))
 	if err != nil {
 		t.Fatalf("skip-fork flow failed: %v", err)
 	}
@@ -2768,41 +2305,16 @@ func TestRunInit_RemoverSkipFork(t *testing.T) {
 	}
 }
 
-// captureStderr runs fn and returns any output written to stderr.
-func captureStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	orig := os.Stderr
-	os.Stderr = w
-
-	out := make(chan string, 1)
-	go func() {
-		var buf bytes.Buffer
-		_, _ = buf.ReadFrom(r)
-		out <- buf.String()
-	}()
-
-	fn()
-
-	os.Stderr = orig
-	w.Close()
-	return <-out
-}
 // ──────────────────────────────────────────────
 // gitInit seam tests (runner-level)
 // ──────────────────────────────────────────────
 
 func TestGitInit_SeamArgsCaptured(t *testing.T) {
 	var captured []string
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, arg ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, arg ...string) runner {
 		captured = arg
 		return &mockCmd{}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	workdir := t.TempDir()
 	if err := gitInit(context.Background(), workdir); err != nil {
@@ -2814,13 +2326,11 @@ func TestGitInit_SeamArgsCaptured(t *testing.T) {
 }
 
 func TestGitInit_ErrorWrapsOutput(t *testing.T) {
-	saved := runCommandContext
-	runCommandContext = func(_ context.Context, _ string, _ ...string) runner {
+	stubRunCommandContext(t, func(_ context.Context, _ string, _ ...string) runner {
 		return &mockCmd{combinedFn: func() ([]byte, error) {
 			return []byte("fatal: Invalid path"), fmt.Errorf("exit status 128")
 		}}
-	}
-	defer func() { runCommandContext = saved }()
+	})
 
 	err := gitInit(context.Background(), t.TempDir())
 	if err == nil {

--- a/cmd/cheasee-pi/root_test.go
+++ b/cmd/cheasee-pi/root_test.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
 // builtInCmds are Cobra-internal commands (help, completion) that are exempt
@@ -41,19 +42,11 @@ func TestRootCmd_HasInitSubcommand(t *testing.T) {
 }
 
 func TestRootCmd_HelpContainsAppName(t *testing.T) {
-	rootCmd.SetArgs(nil)
-	rootCmd.SetArgs([]string{"--help"})
-
-	var buf bytes.Buffer
-	rootCmd.SetOut(&buf)
-	rootCmd.SetErr(&buf)
-
-	_, err := rootCmd.ExecuteC()
+	output, err := testutil.RunCobra(t, rootCmd, "--help")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	output := buf.String()
 	if !strings.Contains(output, rootCmd.Use) {
 		t.Errorf("help output should contain app name %q", rootCmd.Use)
 	}
@@ -69,13 +62,10 @@ func TestRootCmd_NoRaspberryPiReference(t *testing.T) {
 }
 
 func TestRootCmd_UnknownFlagError(t *testing.T) {
-	rootCmd.SetArgs([]string{"--unknown-flag"})
-	err := rootCmd.Execute()
+	_, err := testutil.RunCobra(t, rootCmd, "--unknown-flag")
 	if err == nil {
 		t.Error("expected error for unknown flag, got nil")
 	}
-	// Reset args for subsequent tests.
-	rootCmd.SetArgs(nil)
 }
 
 func TestInitCmd_RunE(t *testing.T) {
@@ -161,18 +151,11 @@ func TestRootCmd_Version_IsExpectedRelease(t *testing.T) {
 }
 
 func TestInitCmd_HelpShowsFlags(t *testing.T) {
-	rootCmd.SetArgs([]string{"init", "--help"})
-	var buf bytes.Buffer
-	// Cobra help renders to OutOrStderr — set both.
-	rootCmd.SetOut(&buf)
-	rootCmd.SetErr(&buf)
-
-	_, err := rootCmd.ExecuteC()
+	output, err := testutil.RunCobra(t, rootCmd, "init", "--help")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	output := buf.String()
 	if !strings.Contains(output, "--api-key") {
 		t.Errorf("init --help output should show --api-key flag\n--- output:\n%s", output)
 	}

--- a/cmd/cheasee-pi/settings_test.go
+++ b/cmd/cheasee-pi/settings_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"context"
 	"errors"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
 // fullSchema is the canonical scaffold output with skills/prompts added.
@@ -198,7 +198,7 @@ func TestLoadSettings_missingPiDir(t *testing.T) {
 
 func TestLoadSettings_corruptJSON(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, "{invalid json")
+	testutil.WriteSettingsFile(t, workdir, "{invalid json")
 	if _, err := LoadSettings(workdir); err == nil {
 		t.Fatal("expected error for corrupt JSON, got nil")
 	}
@@ -206,7 +206,7 @@ func TestLoadSettings_corruptJSON(t *testing.T) {
 
 func TestLoadSettings_typeMismatch(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `{"docker": {"memory": 4096}}`)
+	testutil.WriteSettingsFile(t, workdir, `{"docker": {"memory": 4096}}`)
 	if _, err := LoadSettings(workdir); err == nil {
 		t.Fatal("expected error for docker.memory as number, got nil")
 	}
@@ -214,7 +214,7 @@ func TestLoadSettings_typeMismatch(t *testing.T) {
 
 func TestLoadSettings_nonObjectJSON(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `[1,2]`)
+	testutil.WriteSettingsFile(t, workdir, `[1,2]`)
 	if _, err := LoadSettings(workdir); err == nil {
 		t.Fatal("expected error for non-object JSON, got nil")
 	}
@@ -222,7 +222,7 @@ func TestLoadSettings_nonObjectJSON(t *testing.T) {
 
 func TestLoadSettings_emptyObject(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `{}`)
+	testutil.WriteSettingsFile(t, workdir, `{}`)
 	s, err := LoadSettings(workdir)
 	if err != nil {
 		t.Fatalf("empty {} must load without error, got %v", err)
@@ -236,7 +236,7 @@ func TestLoadSettings_lenientUnknownAndCaseVariantKeys(t *testing.T) {
 	workdir := t.TempDir()
 	// Unknown keys and case-variant keys were accepted by the old map reads
 	// (encoding/json matches keys case-insensitively) — v1 compat.
-	writeSettingsFile(t, workdir, `{"DefaultProvider": "openai", "futureKey": 42}`)
+	testutil.WriteSettingsFile(t, workdir, `{"DefaultProvider": "openai", "futureKey": 42}`)
 	s, err := LoadSettings(workdir)
 	if err != nil {
 		t.Fatalf("case-variant/unknown keys must load, got %v", err)
@@ -261,7 +261,7 @@ func TestLoadSettings_lenientUnknownAndCaseVariantKeys(t *testing.T) {
 
 func TestMemoryLimitEnv_present(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `{"docker": {"memory": "4G"}}`)
+	testutil.WriteSettingsFile(t, workdir, `{"docker": {"memory": "4G"}}`)
 	env, ok := memoryLimitEnv(workdir)
 	if !ok {
 		t.Fatal("expected ok=true for docker.memory=4G")
@@ -281,30 +281,25 @@ func TestMemoryLimitEnv_missingFileSilent(t *testing.T) {
 
 func TestMemoryLimitEnv_corruptWarns(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, "{nope")
+	testutil.WriteSettingsFile(t, workdir, "{nope")
 
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	old := os.Stderr
-	os.Stderr = w
-	env, ok := memoryLimitEnv(workdir)
-	w.Close()
-	os.Stderr = old
-	stderr, _ := io.ReadAll(r)
+	var (
+		env string
+		ok  bool
+	)
+	stderr := testutil.CaptureStderr(t, func() { env, ok = memoryLimitEnv(workdir) })
 
 	if ok || env != "" {
 		t.Errorf("corrupt JSON: want (\"\", false), got (%q, %v)", env, ok)
 	}
-	if !strings.Contains(string(stderr), "settings.json") {
+	if !strings.Contains(stderr, "settings.json") {
 		t.Errorf("corrupt JSON must warn on stderr, got: %q", stderr)
 	}
 }
 
 func TestMemoryLimitEnv_emptyMemory(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `{"docker": {"memory": ""}}`)
+	testutil.WriteSettingsFile(t, workdir, `{"docker": {"memory": ""}}`)
 	if env, ok := memoryLimitEnv(workdir); ok || env != "" {
 		t.Errorf("empty memory: want (\"\", false), got (%q, %v)", env, ok)
 	}
@@ -312,7 +307,7 @@ func TestMemoryLimitEnv_emptyMemory(t *testing.T) {
 
 func TestMemoryLimitEnv_noDockerSection(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `{"defaultProvider": "openai"}`)
+	testutil.WriteSettingsFile(t, workdir, `{"defaultProvider": "openai"}`)
 	if env, ok := memoryLimitEnv(workdir); ok || env != "" {
 		t.Errorf("no docker section: want (\"\", false), got (%q, %v)", env, ok)
 	}
@@ -381,7 +376,7 @@ func TestSettingsWriter_missingPISettingsSkipped(t *testing.T) {
 
 func TestSettingsWriter_corruptPISettingsErrors(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, "{nope")
+	testutil.WriteSettingsFile(t, workdir, "{nope")
 	sw := &SettingsWriter{Workdir: workdir}
 	err := sw.WriteDefaultProvider("openai", "gpt-4o")
 	if err == nil || !strings.Contains(err.Error(), ".pi/settings.json") {
@@ -492,7 +487,7 @@ func TestRemoveSubmoduleSettings_missingFileNil(t *testing.T) {
 
 func TestRemoveSubmoduleSettings_corruptFileErrors(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, "{nope")
+	testutil.WriteSettingsFile(t, workdir, "{nope")
 	if err := removeSubmoduleSettings(workdir); err == nil {
 		t.Fatal("expected error for corrupt settings, got nil")
 	}
@@ -504,21 +499,15 @@ func TestRemoveSubmoduleSettings_corruptFileErrors(t *testing.T) {
 
 func TestApplyMemoryLimit_setsEnvAndAnnounces(t *testing.T) {
 	workdir := t.TempDir()
-	writeSettingsFile(t, workdir, `{"docker": {"memory": "4G"}}`)
+	testutil.WriteSettingsFile(t, workdir, `{"docker": {"memory": "4G"}}`)
 
 	cmd := exec.Command("echo") // never run
-	r, w, _ := os.Pipe()
-	old := os.Stderr
-	os.Stderr = w
-	applyMemoryLimit(cmd, workdir)
-	w.Close()
-	os.Stderr = old
-	stderr, _ := io.ReadAll(r)
+	stderr := testutil.CaptureStderr(t, func() { applyMemoryLimit(cmd, workdir) })
 
 	if !slices.Contains(cmd.Env, "CHEASEEPI_MEMORY=4G") {
 		t.Errorf("cmd.Env missing CHEASEEPI_MEMORY=4G, got %v", cmd.Env)
 	}
-	if !strings.Contains(string(stderr), "Using memory limit 4G from settings.json") {
+	if !strings.Contains(stderr, "Using memory limit 4G from settings.json") {
 		t.Errorf("expected announcement on stderr, got: %q", stderr)
 	}
 }
@@ -537,19 +526,13 @@ func TestApplyMemoryLimit_noLimitNoEnv(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestSettingsScaffold_outputLoadsAsTypedSettings(t *testing.T) {
-	scaffold := NewSettingsScaffold()
-	workdir := t.TempDir()
-
-	vals := TemplateSettingsValues{
+	workdir := ScaffoldSettings(t, TemplateSettingsValues{
 		Provider: "opencode-go",
 		GitName:  "Test User",
 		GitEmail: "test@example.com",
 		Memory:   "4G",
 		CPUs:     "4.0",
-	}
-	if err := scaffold.Scaffold(context.Background(), workdir, vals); err != nil {
-		t.Fatalf("Scaffold failed: %v", err)
-	}
+	})
 
 	s, err := LoadSettings(workdir)
 	if err != nil {
@@ -577,12 +560,8 @@ func TestSettingsScaffold_outputLoadsAsTypedSettings(t *testing.T) {
 // ──────────────────────────────────────────────
 
 func TestAuthList_showsSettingsDefault(t *testing.T) {
-	xdg := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdg)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "openai", FakeAPIKey); err != nil {
-		t.Fatal(err)
-	}
+	testutil.RedirectConfigHome(t)
+	seedAuth(t, map[string]string{"openai": FakeAPIKey})
 
 	workdir := t.TempDir()
 	if err := (&Settings{
@@ -592,68 +571,37 @@ func TestAuthList_showsSettingsDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	saved := authListWorkdir
-	authListWorkdir = workdir
-	defer func() { authListWorkdir = saved }()
+	withAuthListWorkdir(t, workdir)
 
-	r, w, _ := os.Pipe()
-	old := os.Stderr
-	os.Stderr = w
-	err := runAuthListE(&cobra.Command{}, nil)
-	w.Close()
-	os.Stderr = old
-	stderr, _ := io.ReadAll(r)
+	var err error
+	stderr := testutil.CaptureStderr(t, func() { err = runAuthListE(&cobra.Command{}, nil) })
 
 	if err != nil {
 		t.Fatalf("auth list: %v", err)
 	}
-	if !strings.Contains(string(stderr), "Default provider (from .pi/settings.json): anthropic") {
+	if !strings.Contains(stderr, "Default provider (from .pi/settings.json): anthropic") {
 		t.Errorf("missing default provider section, got: %q", stderr)
 	}
-	if !strings.Contains(string(stderr), "Default model: claude-sonnet-4-20250514") {
+	if !strings.Contains(stderr, "Default model: claude-sonnet-4-20250514") {
 		t.Errorf("missing default model line, got: %q", stderr)
 	}
 }
 
 func TestAuthList_missingSettingsNoDefaultSection(t *testing.T) {
-	xdg := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdg)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "openai", FakeAPIKey); err != nil {
-		t.Fatal(err)
-	}
+	testutil.RedirectConfigHome(t)
+	seedAuth(t, map[string]string{"openai": FakeAPIKey})
 
-	saved := authListWorkdir
-	authListWorkdir = t.TempDir() // no .pi/settings.json
-	defer func() { authListWorkdir = saved }()
+	withAuthListWorkdir(t, t.TempDir()) // no .pi/settings.json
 
-	r, w, _ := os.Pipe()
-	old := os.Stderr
-	os.Stderr = w
-	err := runAuthListE(&cobra.Command{}, nil)
-	w.Close()
-	os.Stderr = old
-	stderr, _ := io.ReadAll(r)
+	var err error
+	stderr := testutil.CaptureStderr(t, func() { err = runAuthListE(&cobra.Command{}, nil) })
 
 	if err != nil {
 		t.Fatalf("auth list: %v", err)
 	}
-	if strings.Contains(string(stderr), "Default provider") {
+	if strings.Contains(stderr, "Default provider") {
 		t.Errorf("missing settings must not print a default section, got: %q", stderr)
 	}
 }
 
 // ──────────────────────────────────────────────
-// helpers
-// ──────────────────────────────────────────────
-
-func writeSettingsFile(t *testing.T, workdir, content string) {
-	t.Helper()
-	path := filepath.Join(workdir, ".pi", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-}

--- a/cmd/cheasee-pi/template_test.go
+++ b/cmd/cheasee-pi/template_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"os"
-	"os/exec"
 	"os/user"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
 // ──────────────────────────────────────────────
@@ -15,25 +16,12 @@ import (
 // ──────────────────────────────────────────────
 
 func TestEnvRenderer_WritesCorrectLines(t *testing.T) {
-	dir := t.TempDir()
-	dest := filepath.Join(dir, "docker", ".env")
-
-	r := &flatEnvRenderer{}
-	err := r.Render(context.Background(), dest, EnvValues{
+	content := RenderEnv(t, EnvValues{
 		HostUID:  "1000",
 		HostGID:  "1001",
 		GitName:  "Test User",
 		GitEmail: "test@example.com",
 	})
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	data, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read .env: %v", err)
-	}
-	content := string(data)
 
 	if !strings.Contains(content, "HOST_UID=1000") {
 		t.Errorf("missing HOST_UID: %s", content)
@@ -50,25 +38,12 @@ func TestEnvRenderer_WritesCorrectLines(t *testing.T) {
 }
 
 func TestEnvRenderer_ShellEscapesWhitespace(t *testing.T) {
-	dir := t.TempDir()
-	dest := filepath.Join(dir, "docker", ".env")
-
-	r := &flatEnvRenderer{}
-	err := r.Render(context.Background(), dest, EnvValues{
+	content := RenderEnv(t, EnvValues{
 		HostUID:  "1000",
 		HostGID:  "1001",
 		GitName:  "User With Spaces",
 		GitEmail: "test@example.com",
 	})
-	if err != nil {
-		t.Fatalf("Render failed: %v", err)
-	}
-
-	data, err := os.ReadFile(dest)
-	if err != nil {
-		t.Fatalf("read .env: %v", err)
-	}
-	content := string(data)
 
 	// Value with spaces should be quoted
 	if !strings.Contains(content, `HOST_GIT_NAME="User With Spaces"`) {
@@ -311,23 +286,8 @@ func TestEnvValues_Validate(t *testing.T) {
 // GitIdentity adapter tests
 // ──────────────────────────────────────────────
 
-// writeGitConfig writes a global git config file and points git at it
-// hermetically (GIT_CONFIG_GLOBAL, git >= 2.32; system config disabled).
-func writeGitConfig(t *testing.T, content string) {
-	t.Helper()
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Skip("git binary not available")
-	}
-	cfg := filepath.Join(t.TempDir(), "gitconfig")
-	if err := os.WriteFile(cfg, []byte(content), 0644); err != nil {
-		t.Fatalf("write gitconfig: %v", err)
-	}
-	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
-	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
-}
-
 func TestOSGitIdentity_Lookup(t *testing.T) {
-	writeGitConfig(t, "[user]\n\tname = Test User\n\temail = test@example.com\n")
+	testutil.SetGitConfig(t, "[user]\n\tname = Test User\n\temail = test@example.com\n")
 
 	id := &osGitIdentity{}
 	name, email, err := id.Lookup()
@@ -343,7 +303,7 @@ func TestOSGitIdentity_Lookup(t *testing.T) {
 }
 
 func TestOSGitIdentity_NameOnly(t *testing.T) {
-	writeGitConfig(t, "[user]\n\tname = Test User\n")
+	testutil.SetGitConfig(t, "[user]\n\tname = Test User\n")
 
 	id := &osGitIdentity{}
 	name, email, err := id.Lookup()
@@ -359,7 +319,7 @@ func TestOSGitIdentity_NameOnly(t *testing.T) {
 }
 
 func TestOSGitIdentity_NoConfig(t *testing.T) {
-	writeGitConfig(t, "")
+	testutil.SetGitConfig(t, "")
 
 	id := &osGitIdentity{}
 	name, email, err := id.Lookup()

--- a/cmd/cheasee-pi/testutil/testutil.go
+++ b/cmd/cheasee-pi/testutil/testutil.go
@@ -1,0 +1,130 @@
+// Package testutil provides pure scaffolding shared by cmd/cheasee-pi tests:
+// stderr capture, hermetic fs/env fixtures, settings/env file IO, and a
+// parameterized cobra runner. It touches stdlib + cobra only — package-main
+// state (seam vars, package-level commands, renderer value types) stays in
+// the in-package helpers_test.go.
+package testutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// CaptureStderr runs fn and returns any output written to os.Stderr. It
+// restores os.Stderr even when fn panics. Serialized (no t.Parallel) because
+// os.Stderr is process-global.
+func CaptureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	out := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		out <- buf.String()
+	}()
+	defer func() {
+		// Close + restore on the panic path too; harmless double-close after
+		// the normal path already closed w.
+		w.Close()
+		os.Stderr = orig
+	}()
+	fn()
+	// Close the write end so the reader goroutine sees EOF.
+	w.Close()
+	os.Stderr = orig
+	return <-out
+}
+
+// ReadEnvFile reads docker/.env and returns its KEY=VALUE lines as a map,
+// stripping surrounding quotes from values.
+func ReadEnvFile(t *testing.T, workdir string) map[string]string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(workdir, "docker", ".env"))
+	if err != nil {
+		t.Fatalf("read docker/.env: %v", err)
+	}
+	vals := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		if k, v, ok := strings.Cut(line, "="); ok {
+			vals[k] = strings.Trim(v, "\"")
+		}
+	}
+	return vals
+}
+
+// ReadSettingsRaw reads .pi/settings.json and returns it as a map.
+func ReadSettingsRaw(t *testing.T, workdir string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(workdir, ".pi", "settings.json"))
+	if err != nil {
+		t.Fatalf("read .pi/settings.json: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("settings.json is not valid JSON: %v", err)
+	}
+	return raw
+}
+
+// WriteSettingsFile writes .pi/settings.json, creating parent dirs.
+func WriteSettingsFile(t *testing.T, workdir, content string) {
+	t.Helper()
+	path := filepath.Join(workdir, ".pi", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// SetGitConfig points git config lookups at a hermetic temp config file
+// containing content (system config disabled). Skips when git is absent.
+// Serialized (no t.Parallel) because t.Setenv is process-wide.
+func SetGitConfig(t *testing.T, content string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	cfg := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(cfg, []byte(content), 0644); err != nil {
+		t.Fatalf("write gitconfig: %v", err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", cfg)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+}
+
+// RedirectConfigHome points the auth config dir at a fresh temp dir so no
+// test touches the real $HOME/.config. It returns the new config home.
+// Serialized (no t.Parallel) because t.Setenv is process-wide.
+func RedirectConfigHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	return dir
+}
+
+// RunCobra executes cmd with args, capturing stdout. The command must be
+// passed as a parameter — never a package-global command mutated from this
+// package. Serialized (no t.Parallel): RunCobra mutates the command.
+func RunCobra(t *testing.T, cmd *cobra.Command, args ...string) (string, error) {
+	t.Helper()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	_, err := cmd.ExecuteC()
+	return out.String(), err
+}

--- a/cmd/cheasee-pi/testutil/testutil_test.go
+++ b/cmd/cheasee-pi/testutil/testutil_test.go
@@ -1,0 +1,144 @@
+package testutil
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCaptureStderr_capturesAndRestores(t *testing.T) {
+	first := CaptureStderr(t, func() { os.Stderr.WriteString("hello") })
+	if first != "hello" {
+		t.Fatalf("CaptureStderr = %q, want %q", first, "hello")
+	}
+	// Second capture must see only its own output — no leakage from the first.
+	second := CaptureStderr(t, func() { os.Stderr.WriteString("world") })
+	if second != "world" {
+		t.Fatalf("second CaptureStderr = %q, want %q (restore failed)", second, "world")
+	}
+}
+
+func TestCaptureStderr_noOutput(t *testing.T) {
+	if got := CaptureStderr(t, func() {}); got != "" {
+		t.Errorf("CaptureStderr with no writes = %q, want empty", got)
+	}
+}
+
+func TestCaptureStderr_restoresOnPanic(t *testing.T) {
+	func() {
+		defer func() { _ = recover() }()
+		CaptureStderr(t, func() { panic("boom") })
+	}()
+	// os.Stderr must be restored despite the panic — a subsequent capture
+	// works and reports only its own output.
+	if got := CaptureStderr(t, func() { os.Stderr.WriteString("after") }); got != "after" {
+		t.Errorf("CaptureStderr after panic = %q, want %q", got, "after")
+	}
+}
+
+func TestReadEnvFile_stripsQuotesAndSkipsBlankLines(t *testing.T) {
+	workdir := t.TempDir()
+	os.MkdirAll(filepath.Join(workdir, "docker"), 0755)
+	os.WriteFile(filepath.Join(workdir, "docker", ".env"), []byte("A=1\nB=\"two\"\n\nC=three\n"), 0644)
+
+	got := ReadEnvFile(t, workdir)
+	want := map[string]string{"A": "1", "B": "two", "C": "three"}
+	if len(got) != len(want) {
+		t.Fatalf("ReadEnvFile = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("ReadEnvFile[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestReadEnvFile_empty(t *testing.T) {
+	workdir := t.TempDir()
+	os.MkdirAll(filepath.Join(workdir, "docker"), 0755)
+	os.WriteFile(filepath.Join(workdir, "docker", ".env"), nil, 0644)
+	if got := ReadEnvFile(t, workdir); len(got) != 0 {
+		t.Errorf("empty .env should yield empty map, got %v", got)
+	}
+}
+
+func TestWriteSettingsFile_ReadSettingsRaw_roundTripAndOverwrite(t *testing.T) {
+	workdir := t.TempDir()
+	WriteSettingsFile(t, workdir, `{"defaultProvider": "openai"}`)
+	if raw := ReadSettingsRaw(t, workdir); raw["defaultProvider"] != "openai" {
+		t.Errorf("round-trip defaultProvider = %v, want openai", raw["defaultProvider"])
+	}
+	// Re-write overwrites — latest content wins.
+	WriteSettingsFile(t, workdir, `{"defaultProvider": "anthropic"}`)
+	if raw := ReadSettingsRaw(t, workdir); raw["defaultProvider"] != "anthropic" {
+		t.Errorf("overwrite defaultProvider = %v, want anthropic", raw["defaultProvider"])
+	}
+}
+
+func TestSetGitConfig_hermeticSubprocess(t *testing.T) {
+	SetGitConfig(t, "[user]\n\tname = Test User\n\temail = test@example.com\n")
+	if os.Getenv("GIT_CONFIG_GLOBAL") == "" {
+		t.Error("GIT_CONFIG_GLOBAL must point at a temp config file")
+	}
+	if os.Getenv("GIT_CONFIG_SYSTEM") != "/dev/null" {
+		t.Errorf("GIT_CONFIG_SYSTEM = %q, want /dev/null", os.Getenv("GIT_CONFIG_SYSTEM"))
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git binary not available")
+	}
+	out, err := exec.Command("git", "config", "--global", "user.name").Output()
+	if err != nil {
+		t.Fatalf("git config lookup failed: %v", err)
+	}
+	if string(out) != "Test User\n" {
+		t.Errorf("git config user.name = %q, want %q", out, "Test User\n")
+	}
+}
+
+func TestRedirectConfigHome_setsToExistingDir(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/sentinel")
+	got := RedirectConfigHome(t)
+	if got == "" || got == "/sentinel" {
+		t.Errorf("RedirectConfigHome = %q, want a fresh temp dir", got)
+	}
+	if os.Getenv("XDG_CONFIG_HOME") != got {
+		t.Errorf("XDG_CONFIG_HOME = %q, want %q", os.Getenv("XDG_CONFIG_HOME"), got)
+	}
+	if _, err := os.Stat(got); err != nil {
+		t.Errorf("XDG_CONFIG_HOME must point at an existing dir: %v", err)
+	}
+}
+
+func TestRunCobra_outputAndError(t *testing.T) {
+	okCmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.OutOrStdout().Write([]byte("hello"))
+		return nil
+	}}
+	out, err := RunCobra(t, okCmd)
+	if err != nil {
+		t.Fatalf("RunCobra returned error: %v", err)
+	}
+	if out != "hello" {
+		t.Errorf("RunCobra output = %q, want %q", out, "hello")
+	}
+
+	// RunE error: non-nil err, partial output still captured.
+	errCmd := &cobra.Command{RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.OutOrStdout().Write([]byte("partial"))
+		return errors.New("boom")
+	}}
+	out, err = RunCobra(t, errCmd)
+	if err == nil {
+		t.Fatal("RunCobra should return the RunE error")
+	}
+	// Output written before the error must be captured (cobra appends usage
+	// text after it — assert containment, not equality).
+	if !strings.Contains(out, "partial") {
+		t.Errorf("RunCobra partial output = %q, want it to contain %q", out, "partial")
+	}
+}

--- a/cmd/cheasee-pi/up_test.go
+++ b/cmd/cheasee-pi/up_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -196,53 +195,14 @@ func TestOrphanScanBash_echoesKilledPIDs(t *testing.T) {
 // scanOrphans tests — Phase 3
 // ──────────────────────────────────────────────
 
-type mockCmd struct {
-	outputFn   func() ([]byte, error)
-	combinedFn func() ([]byte, error)
-	runFn      func() error
-	// Captured Set* config, for callers that configure the command
-	dir    string
-	env    []string
-	stdout interface{ Write([]byte) (int, error) }
-	stderr interface{ Write([]byte) (int, error) }
-}
-
-func (m *mockCmd) Output() ([]byte, error) {
-	if m.outputFn != nil {
-		return m.outputFn()
-	}
-	return nil, nil
-}
-
-func (m *mockCmd) CombinedOutput() ([]byte, error) {
-	if m.combinedFn != nil {
-		return m.combinedFn()
-	}
-	return nil, nil
-}
-
-func (m *mockCmd) Run() error {
-	if m.runFn != nil {
-		return m.runFn()
-	}
-	return nil
-}
-
-func (m *mockCmd) SetDir(d string)       { m.dir = d }
-func (m *mockCmd) SetEnv(e []string)     { m.env = e }
-func (m *mockCmd) SetStdout(w io.Writer) { m.stdout = w }
-func (m *mockCmd) SetStderr(w io.Writer) { m.stderr = w }
-
 func TestScanOrphans_containerNotRunning(t *testing.T) {
-	saved := execCommand
-	execCommand = func(_ string, _ ...string) cmdIface {
+	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
 		return &mockCmd{
 			outputFn: func() ([]byte, error) {
 				return []byte(""), nil
 			},
 		}
-	}
-	defer func() { execCommand = saved }()
+	})
 
 	count, err := scanOrphans(context.Background(), "cheasee-pi")
 	if err != nil {
@@ -254,9 +214,8 @@ func TestScanOrphans_containerNotRunning(t *testing.T) {
 }
 
 func TestScanOrphans_noOrphans(t *testing.T) {
-	saved := execCommand
 	step := 0
-	execCommand = func(_ string, _ ...string) cmdIface {
+	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
 		step++
 		if step == 1 {
 			return &mockCmd{
@@ -270,8 +229,7 @@ func TestScanOrphans_noOrphans(t *testing.T) {
 				return []byte(""), nil
 			},
 		}
-	}
-	defer func() { execCommand = saved }()
+	})
 
 	count, err := scanOrphans(context.Background(), "cheasee-pi")
 	if err != nil {
@@ -283,9 +241,8 @@ func TestScanOrphans_noOrphans(t *testing.T) {
 }
 
 func TestScanOrphans_countsKilled(t *testing.T) {
-	saved := execCommand
 	step := 0
-	execCommand = func(_ string, _ ...string) cmdIface {
+	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
 		step++
 		if step == 1 {
 			return &mockCmd{
@@ -299,8 +256,7 @@ func TestScanOrphans_countsKilled(t *testing.T) {
 				return []byte("killing 42\nkilling 99\n"), nil
 			},
 		}
-	}
-	defer func() { execCommand = saved }()
+	})
 
 	count, err := scanOrphans(context.Background(), "cheasee-pi")
 	if err != nil {
@@ -312,9 +268,8 @@ func TestScanOrphans_countsKilled(t *testing.T) {
 }
 
 func TestScanOrphans_dockerExecFails(t *testing.T) {
-	saved := execCommand
 	step := 0
-	execCommand = func(_ string, _ ...string) cmdIface {
+	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
 		step++
 		if step == 1 {
 			return &mockCmd{
@@ -328,8 +283,7 @@ func TestScanOrphans_dockerExecFails(t *testing.T) {
 				return nil, fmt.Errorf("container stopped")
 			},
 		}
-	}
-	defer func() { execCommand = saved }()
+	})
 
 	_, err := scanOrphans(context.Background(), "cheasee-pi")
 	if err == nil {
@@ -338,11 +292,10 @@ func TestScanOrphans_dockerExecFails(t *testing.T) {
 }
 
 func TestScanOrphans_constructsDockerExecCommand(t *testing.T) {
-	saved := execCommand
 	var capturedName string
 	var capturedArgs []string
 	step := 0
-	execCommand = func(name string, arg ...string) cmdIface {
+	stubExecCommand(t, func(name string, arg ...string) cmdIface {
 		step++
 		if step == 1 {
 			return &mockCmd{
@@ -358,8 +311,7 @@ func TestScanOrphans_constructsDockerExecCommand(t *testing.T) {
 				return []byte(""), nil
 			},
 		}
-	}
-	defer func() { execCommand = saved }()
+	})
 
 	scanOrphans(context.Background(), "cheasee-pi")
 
@@ -384,15 +336,13 @@ func TestScanOrphans_constructsDockerExecCommand(t *testing.T) {
 }
 
 func TestScanOrphans_dockerPsFails(t *testing.T) {
-	saved := execCommand
-	execCommand = func(_ string, _ ...string) cmdIface {
+	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
 		return &mockCmd{
 			outputFn: func() ([]byte, error) {
 				return nil, fmt.Errorf("docker daemon not running")
 			},
 		}
-	}
-	defer func() { execCommand = saved }()
+	})
 
 	_, err := scanOrphans(context.Background(), "cheasee-pi")
 	if err == nil {
@@ -417,38 +367,21 @@ func indexOf(slice []string, val string) int {
 // buildEnvFlags tests — map shape + passthrough
 // ──────────────────────────────────────────────
 
-// pinPassthroughEnv makes buildEnvFlags hermetic: fresh XDG_CONFIG_HOME,
-// every passthrough env name cleared, and PATH pointing at a failing gh
-// binary so GH_TOKEN extraction can't leak the host's real token into the map.
-func pinPassthroughEnv(t *testing.T) string {
+// buildEnvFlagsOrFatal calls buildEnvFlags, failing the test on error.
+func buildEnvFlagsOrFatal(t *testing.T) map[string]string {
 	t.Helper()
-	xdg := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", xdg)
-	for _, name := range AllEnvVarNames() {
-		t.Setenv(name, "")
-	}
-	bin := t.TempDir()
-	if err := os.WriteFile(filepath.Join(bin, "gh"), []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", bin)
-	return xdg
-}
-
-func TestBuildEnvFlags_happyPath(t *testing.T) {
-	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "openai", FakeAPIKey); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
-	if err := cfg.AddProvider(context.Background(), "anthropic", FakeAPIKeyAlt); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
-
 	env, err := buildEnvFlags(context.Background())
 	if err != nil {
 		t.Fatalf("buildEnvFlags: %v", err)
 	}
+	return env
+}
+
+func TestBuildEnvFlags_happyPath(t *testing.T) {
+	pinPassthroughEnv(t)
+	seedAuth(t, map[string]string{"openai": FakeAPIKey, "anthropic": FakeAPIKeyAlt})
+
+	env := buildEnvFlagsOrFatal(t)
 
 	want := map[string]string{
 		"OPENAI_API_KEY":    FakeAPIKey,
@@ -461,15 +394,9 @@ func TestBuildEnvFlags_happyPath(t *testing.T) {
 
 func TestBuildEnvFlags_resolvesClaudeAlias(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "claude", FakeAPIKeyAlt); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"claude": FakeAPIKeyAlt})
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if got := env["ANTHROPIC_API_KEY"]; got != FakeAPIKeyAlt {
 		t.Errorf("claude alias should map to ANTHROPIC_API_KEY, got %v", env)
 	}
@@ -477,15 +404,9 @@ func TestBuildEnvFlags_resolvesClaudeAlias(t *testing.T) {
 
 func TestBuildEnvFlags_resolvesGoogleAlias(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "google", "xxx"); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"google": "xxx"})
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if got := env["GEMINI_API_KEY"]; got != "xxx" {
 		t.Errorf("google alias should map to GEMINI_API_KEY, got %v", env)
 	}
@@ -493,15 +414,9 @@ func TestBuildEnvFlags_resolvesGoogleAlias(t *testing.T) {
 
 func TestBuildEnvFlags_resolvesOpenCodeAlias(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "opencode", "xxx"); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"opencode": "xxx"})
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if got := env["OPENCODE_API_KEY"]; got != "xxx" {
 		t.Errorf("opencode alias should map to OPENCODE_API_KEY, got %v", env)
 	}
@@ -509,15 +424,9 @@ func TestBuildEnvFlags_resolvesOpenCodeAlias(t *testing.T) {
 
 func TestBuildEnvFlags_resolvesXaiDriftVictim(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "xai", "xxx"); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"xai": "xxx"})
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if got := env["XAI_API_KEY"]; got != "xxx" {
 		t.Errorf("xai should map to XAI_API_KEY, got %v", env)
 	}
@@ -525,18 +434,9 @@ func TestBuildEnvFlags_resolvesXaiDriftVictim(t *testing.T) {
 
 func TestBuildEnvFlags_aliasDupesCollapseToOneKey(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "anthropic", FakeAPIKey); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
-	if err := cfg.AddProvider(context.Background(), "claude", FakeAPIKeyAlt); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"anthropic": FakeAPIKey, "claude": FakeAPIKeyAlt})
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if len(env) != 1 {
 		t.Fatalf("expected exactly one ANTHROPIC_API_KEY entry, got %v", env)
 	}
@@ -548,15 +448,9 @@ func TestBuildEnvFlags_aliasDupesCollapseToOneKey(t *testing.T) {
 
 func TestBuildEnvFlags_unknownProviderPassthrough(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "mystery", "k123"); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"mystery": "k123"})
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if got := env["MYSTERY_API_KEY"]; got != "k123" {
 		t.Errorf("unknown provider should emit MYSTERY_API_KEY, got %v", env)
 	}
@@ -565,10 +459,7 @@ func TestBuildEnvFlags_unknownProviderPassthrough(t *testing.T) {
 func TestBuildEnvFlags_emptyAuthNoEnvs(t *testing.T) {
 	pinPassthroughEnv(t)
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if env == nil {
 		t.Fatal("expected non-nil empty map")
 	}
@@ -595,10 +486,7 @@ func TestBuildEnvFlags_passthroughEnvVars(t *testing.T) {
 	t.Setenv("GH_TOKEN", FakeGitHubToken)
 	t.Setenv("CLOUDFLARE_ACCOUNT_ID", "acct-123")
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if env["GH_TOKEN"] != FakeGitHubToken {
 		t.Errorf("GH_TOKEN not passed through, got %v", env)
 	}
@@ -609,16 +497,10 @@ func TestBuildEnvFlags_passthroughEnvVars(t *testing.T) {
 
 func TestBuildEnvFlags_authWinsOverProcessEnv(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "openai", "from-auth"); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"openai": "from-auth"})
 	t.Setenv("OPENAI_API_KEY", "from-process")
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if env["OPENAI_API_KEY"] != "from-auth" {
 		t.Errorf("auth.json value should win over process env, got %v", env)
 	}
@@ -626,21 +508,15 @@ func TestBuildEnvFlags_authWinsOverProcessEnv(t *testing.T) {
 
 func TestBuildEnvFlags_apiKeyOverride(t *testing.T) {
 	pinPassthroughEnv(t)
-	cfg := &fileRepository{}
-	if err := cfg.AddProvider(context.Background(), "opencode-go", "from-auth"); err != nil {
-		t.Fatalf("seed auth.json: %v", err)
-	}
+	seedAuth(t, map[string]string{"opencode-go": "from-auth"})
 	t.Setenv("OPENCODE_API_KEY", "from-process")
 
 	saved := upAPIKey
-	upAPIKey = FakeUpAPIKey
+	upAPIKey = "session-key"
 	defer func() { upAPIKey = saved }()
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
-	if env["OPENCODE_API_KEY"] != FakeUpAPIKey {
+	env := buildEnvFlagsOrFatal(t)
+	if env["OPENCODE_API_KEY"] != "session-key" {
 		t.Errorf("--api-key should override auth.json and process env, got %v", env)
 	}
 }
@@ -649,14 +525,11 @@ func TestBuildEnvFlags_apiKeyInjectedWithoutProvider(t *testing.T) {
 	pinPassthroughEnv(t)
 
 	saved := upAPIKey
-	upAPIKey = FakeUpAPIKey
+	upAPIKey = "session-key"
 	defer func() { upAPIKey = saved }()
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
-	if env["OPENCODE_API_KEY"] != FakeUpAPIKey {
+	env := buildEnvFlagsOrFatal(t)
+	if env["OPENCODE_API_KEY"] != "session-key" {
 		t.Errorf("--api-key should inject OPENCODE_API_KEY with no opencode provider, got %v", env)
 	}
 }
@@ -664,10 +537,7 @@ func TestBuildEnvFlags_apiKeyInjectedWithoutProvider(t *testing.T) {
 func TestBuildEnvFlags_ghTokenExtractionFailureSwallowed(t *testing.T) {
 	pinPassthroughEnv(t) // PATH points at a failing gh; GH_TOKEN is empty.
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if _, ok := env["GH_TOKEN"]; ok {
 		t.Errorf("failing gh binary should not produce GH_TOKEN, got %v", env)
 	}
@@ -677,10 +547,7 @@ func TestBuildEnvFlags_ignoresUnlistedEnvVars(t *testing.T) {
 	pinPassthroughEnv(t)
 	t.Setenv("SOME_UNRELATED_VAR", "should-not-appear")
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 	if _, ok := env["SOME_UNRELATED_VAR"]; ok {
 		t.Errorf("unlisted env var should not be passed through: %v", env)
 	}
@@ -695,10 +562,7 @@ func TestBuildEnvFlags_allProvidersAgreeWithProviderEnvAliases(t *testing.T) {
 		}
 	}
 
-	env, err := buildEnvFlags(context.Background())
-	if err != nil {
-		t.Fatalf("buildEnvFlags: %v", err)
-	}
+	env := buildEnvFlagsOrFatal(t)
 
 	want := make(map[string]string)
 	for _, name := range ProviderNames() {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1455

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 4m 37s | 244.9K | 27 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 3m 11s | 63.0K | 34 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 46s | 36.9K | 15 | deepseek-v4-flash |
| developer | ✓ SUCCESS (after retry) | 21m 36s | 182.7K | 194 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 4m 22s | 83.1K | 101 | minimax-m3 |

**Total:** 5 agents · 36m 33s · 610.6K tokens · 371 tool calls · 25 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1455
Closes #1455

---
**Note:** PR creation originally failed on rebase conflicts (init_test.go, settings_test.go, up_test.go). Root cause: PR #1456/#1468 (credential-constant testfixtures) landed on main after this branch was cut and rewrote the same test regions. Branch rebased onto origin/main; conflicts resolved semantically (dedup refactor + FakeAPIKey constants merged; 17 stale credential literals swept). Suite green: `go test ./...` passes, test LOC 7300 → 6884 (416-line reduction vs main).