### PR TITLE
fix(deps): resolve dependabot alerts for undici and brace-expansion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
 		"": {
 			"name": "main",
 			"version": "0.4",
-			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "^0.79.1",
@@ -1698,13 +1697,6 @@
 			"version": "1.1.38",
 			"license": "MIT"
 		},
-		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-			"version": "8.5.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=22.19.0"
-			}
-		},
 		"node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
 			"license": "MIT",
@@ -2540,7 +2532,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -3515,6 +3509,15 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
 	"description": "---",
 	"main": "index.js",
 	"scripts": {
-		"postinstall": "node scripts/fix-vulns.mjs",
 		"test": "node --experimental-strip-types --test docker/test/docker-convenience-scripts.test.mts .pi/extensions/caveman/test/dead-code-removal.test.ts .pi/extensions/session-logger/test/session-logger-files.test.mts .pi/extensions/session-logger/test/session-logger-remove-waitForFile.test.mts .pi/extensions/session-logger/test/session-logger-stats.test.mts .pi/extensions/session-logger/test/session-logger.test.mts test/session-query.test.mts test/docs-daily-usage.test.mts test/extensions-load.test.mts test/ranked-map-removed.test.mts test/execution-protocols.test.mts .pi/extensions/context-info/test/context-info.test.mts .pi/extensions/context-info/test/context-status-bar.test.mts .pi/extensions/structural-analyzer/test/structural-analyzer.test.mts .pi/extensions/supervisor/test/supervisor-extensions.test.mts .pi/extensions/supervisor/test/supervisor-process-context-info.test.mts .pi/extensions/lsp-auditor/test/lsp-auditor.test.mts .pi/extensions/lsp-auditor/test/lsp-auditor-settings.test.mts .pi/extensions/format-on-save/test/format-on-save.test.mts .pi/extensions/tsc-checkpoint/test/tsc-checkpoint.test.mts .pi/extensions/supervisor/test/tsc-decisions.test.mts .pi/extensions/supervisor/test/output.test.mts .pi/extensions/supervisor/test/pipeline/pr-creation.test.mts .pi/extensions/supervisor/test/pipeline/stages.test.mts .pi/extensions/supervisor/test/pipeline/stages-split.test.mts .pi/extensions/supervisor/test/pipeline/handler-entry.test.mts .pi/extensions/supervisor/test/pipeline/handler-shared.test.mts .pi/extensions/supervisor/test/pipeline/handler-structure.test.mts .pi/extensions/supervisor/test/gate-failure-context.test.mts",
 		"tsc:extensions": "tsc --noEmit --project .pi/tsconfig.json",
 		"pi": "pi"
@@ -34,10 +33,11 @@
 		"typescript": "^6.0.3"
 	},
 	"overrides": {
-		"brace-expansion": "5.0.8",
+		"brace-expansion": "5.0.9",
+		"undici": "^8.9.0",
 		"protobufjs": "7.6.5",
 		"minimatch": {
-			"brace-expansion": "5.0.8"
+			"brace-expansion": "5.0.9"
 		},
 		"@google/genai": {
 			"protobufjs": "7.6.5"


### PR DESCRIPTION
Closes all 6 open dependabot security alerts.

- **brace-expansion** 5.0.8 → 5.0.9 (GHSA-rgw5-rvv9-x895, HIGH — DoS bypassing CVE-2026-14257 mitigation)
- **undici** 8.5.0 → 8.10.0 via override (GHSA-4cwx-7wf7-3272, GHSA-8xcm-r25x-g524, GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5 — fixed in 8.9.0)
- removed stale `postinstall` ref to nonexistent `scripts/fix-vulns.mjs` (never existed in git; broke npm install)

`npm audit`: 0 vulnerabilities. Same-major bumps only (undici 8.x, brace-expansion 5.x).