### PR TITLE
docs: add community standards (CoC, contributing guide, PR template)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+A clear and concise description of what this pull request changes and why.
+
+## Related issue
+
+Closes #<!-- issue number -->
+
+## Changes
+
+- <!-- change 1 -->
+- <!-- change 2 -->
+
+## Testing
+
+- [ ] `npm test` passes
+- [ ] `npm run tsc:extensions` passes
+- [ ] Tests cover the changes (where applicable)
+
+## Checklist
+
+- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
+- [ ] No sensitive data committed (secrets, credentials, tokens)
+- [ ] PR description clearly states what changed and why

--- a/.github/workflows/pr-welcome.yml
+++ b/.github/workflows/pr-welcome.yml
@@ -25,7 +25,7 @@ jobs:
             --body-file - <<WELCOME
           ## 👋 Welcome, @${{ github.event.pull_request.user.login }}!
 
-          Thanks for submitting this PR to AgentCastle. A maintainer will review it shortly.
+          Thanks for submitting this PR to Cheasee-Pi. A maintainer will review it shortly.
 
           ### Quick checklist
           - [ ] Commits follow [conventional-commits](https://www.conventionalcommits.org/)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[@SchneiderDaniel](https://github.com/SchneiderDaniel).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to Cheasee-Pi
+
+Cheasee-Pi is an open-source project, and every contribution strengthens the
+harness for its users. Contributions of any form are welcome — bug reports,
+feature requests, documentation improvements, and code changes alike. This
+guide describes the process we follow for proposing and merging changes.
+
+## Ways to contribute
+
+- **Reporting bugs** — Open an issue using the
+  [bug report template](https://github.com/SchneiderDaniel/cheasee-pi/issues/new?template=bug_report.md).
+  Reproducible steps and environment details accelerate the diagnosis
+  considerably.
+- **Proposing features** — Open an issue using the
+  [feature request template](https://github.com/SchneiderDaniel/cheasee-pi/issues/new?template=feature_request.md).
+  A clear problem statement and a description of the proposed solution
+  provide the maintainers with the context required for an assessment.
+- **Asking questions** — Discussions and clarifying questions belong in the
+  [AgentCastle Discussions](https://github.com/SchneiderDaniel/agentcastle/discussions).
+- **Submitting pull requests** — Code changes follow the workflow described
+  below.
+
+Before starting substantial work, we recommend opening an issue first. This
+practice aligns the implementation with the maintainers' intentions and
+prevents the disappointment of a rejected pull request.
+
+## Getting started
+
+1. Fork the repository on GitHub.
+2. Clone the fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/cheasee-pi.git
+   cd cheasee-pi
+   ```
+3. Add the upstream repository for synchronization:
+   ```bash
+   git remote add upstream https://github.com/SchneiderDaniel/cheasee-pi.git
+   ```
+
+## Development workflow
+
+Cheasee-Pi uses [git worktrees](https://git-scm.com/docs/git-worktree) to give
+each change its own isolated working directory. This practice keeps `main`
+clean and prevents parallel changes from interfering with one another.
+
+We recommend the same workflow for external contributions:
+
+1. Create a feature worktree from a fresh `main`:
+   ```bash
+   git fetch upstream
+   git worktree add -b feature/my-change ../cheasee-pi-my-change upstream/main
+   cd ../cheasee-pi-my-change
+   ```
+2. Implement the change. Commit messages follow the
+   [Conventional Commits](https://www.conventionalcommits.org/) specification:
+   ```bash
+   git add -A
+   git commit -m "feat: add new capability"
+   git commit -m "fix: resolve edge case in ..."
+   ```
+   Common prefixes are `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, and
+   `chore:`.
+3. Push the branch and open a pull request:
+   ```bash
+   git push origin feature/my-change
+   ```
+4. Remove the worktree once the pull request is merged:
+   ```bash
+   cd ../cheasee-pi
+   git worktree remove --force ../cheasee-pi-my-change
+   ```
+
+## Building and testing
+
+All tests run with the standard Node.js test runner:
+
+```bash
+npm test
+```
+
+TypeScript validation for the extension layer runs separately:
+
+```bash
+npm run tsc:extensions
+```
+
+The full test suite executes before every merge, so we ask that contributors
+run both commands locally and confirm a clean result before opening a pull
+request. New logic of non-trivial complexity is expected to arrive with
+corresponding tests.
+
+## Submitting a pull request
+
+Each pull request should satisfy the following checklist:
+
+- The description states clearly what changed and why.
+- The description references the related issue, for example `Closes #123`.
+- The commit messages follow Conventional Commits.
+- `npm test` passes.
+- `npm run tsc:extensions` passes.
+- Tests cover the changes where applicable.
+- No sensitive data is committed — no secrets, credentials, or tokens.
+
+The repository provides a
+[pull request template](https://github.com/SchneiderDaniel/cheasee-pi/blob/main/.github/PULL_REQUEST_TEMPLATE.md)
+that mirrors this checklist.
+
+## Review process
+
+Maintainers aim to review pull requests within 2-3 business days. Review
+feedback arrives as comments on the pull request, and we appreciate a
+responsive iteration. The `main` branch is protected; all changes merge
+through the pull request workflow after the automated checks pass.
+
+## Reporting security issues
+
+Security vulnerabilities are handled separately and confidentially. Please do
+not open a public issue for a vulnerability. The responsible disclosure
+process is described in the [security policy](docs/security.md).
+
+## Code of conduct
+
+Participation in this project is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md). We expect every contributor to uphold
+its standards; reports of unacceptable behavior are handled promptly by the
+maintainers.


### PR DESCRIPTION
## Description

Adds the three missing community-standard items from the GitHub community profile (https://github.com/SchneiderDaniel/cheasee-pi/community):

- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1, enforcement contact @SchneiderDaniel
- **CONTRIBUTING.md** — fork/worktree workflow, Conventional Commits, test commands, review process, security disclosure pointer. Fixes the broken README badge that already links to this file.
- **.github/PULL_REQUEST_TEMPLATE.md** — description/issue/changes/testing/checklist skeleton

Issue templates and security policy already exist; the community page flag for issue templates was stale.

## Changes

- Add `CODE_OF_CONDUCT.md`
- Add `CONTRIBUTING.md`
- Add `.github/PULL_REQUEST_TEMPLATE.md`

## Testing

Docs-only change — no tests affected.