### PR TITLE
fix: close code-scanning alerts in codeflow server.py

### DIFF
--- a/cmd/cheasee-pi/embedded/docker/codeflow/server.py
+++ b/cmd/cheasee-pi/embedded/docker/codeflow/server.py
@@ -280,7 +280,7 @@ class Handler(BaseHTTPRequestHandler):
             for pat, repl in _UI_REWRITES:
                 data = pat.sub(lambda _: repl, data)
         self.send_response(200)
-        self.send_header("Content-Type", _mime(os.path.basename(target)))
+        self.send_header("Content-Type", _mime(os.path.basename(target)).replace("\r", "").replace("\n", ""))
         self.send_header("Content-Length", str(len(data)))
         self.end_headers()
         self.wfile.write(data)
@@ -306,42 +306,49 @@ class Handler(BaseHTTPRequestHandler):
 
         if rest[0] == "contents":
             rel = "/".join(rest[1:])
-            # Inline normalization + prefix check (CodeQL path-injection
-            # sanitizer only recognizes guards in the calling function).
             root = os.path.realpath(REPO_ROOT)
             target = os.path.realpath(os.path.join(root, rel.lstrip("/")))
-            if target != root and not target.startswith(root + os.sep):
+            if target == root:
+                # Repo root itself: allowed. Use the untainted constant so
+                # CodeQL sees the guard below as the only tainted path.
+                self._list_contents(root, "")
+                return
+            if not target.startswith(root + os.sep):
                 self._not_found()
                 return
-            if os.path.isdir(target):
-                entries = []
-                for name in sorted(os.listdir(target)):
-                    full = os.path.join(target, name)
-                    rel_child = os.path.join(rel, name) if rel else name
-                    if os.path.isdir(full):
-                        if rel_child in SUBMODULE_DIRS:
-                            continue  # submodule excluded unless INCLUDE_SUBMODULES
-                        entries.append({"type": "dir", "path": rel_child, "name": name})
-                    elif os.path.isfile(full):
-                        try:
-                            size = os.path.getsize(full)
-                        except OSError:
-                            size = 0
-                        entries.append({"type": "file", "path": rel_child, "name": name, "size": size})
-                self._json(entries)
-                return
-            if os.path.isfile(target):
-                try:
-                    with open(target, "rb") as fh:
-                        raw = fh.read()
-                except OSError:
-                    self._not_found()
-                    return
-                self._json({"content": base64.b64encode(raw).decode(), "encoding": "base64"})
-                return
-            self._not_found()
+            self._list_contents(target, rel)
             return
 
+        self._not_found()
+
+    def _list_contents(self, target, rel):
+        """Serve GET /contents/{rel}: dir listing or base64 file."""
+        if os.path.isdir(target):
+            entries = []
+            for name in sorted(os.listdir(target)):
+                full = os.path.join(target, name)
+                rel_child = os.path.join(rel, name) if rel else name
+                if os.path.isdir(full):
+                    if rel_child in SUBMODULE_DIRS:
+                        continue  # submodule excluded unless INCLUDE_SUBMODULES
+                    entries.append({"type": "dir", "path": rel_child, "name": name})
+                elif os.path.isfile(full):
+                    try:
+                        size = os.path.getsize(full)
+                    except OSError:
+                        size = 0
+                    entries.append({"type": "file", "path": rel_child, "name": name, "size": size})
+            self._json(entries)
+            return
+        if os.path.isfile(target):
+            try:
+                with open(target, "rb") as fh:
+                    raw = fh.read()
+            except OSError:
+                self._not_found()
+                return
+            self._json({"content": base64.b64encode(raw).decode(), "encoding": "base64"})
+            return
         self._not_found()
 
     def log_message(self, format, *args):  # quiet


### PR DESCRIPTION
Closes the 8 open code-scanning alerts (7x py/path-injection, 1x py/http-response-splitting) on `cmd/cheasee-pi/embedded/docker/codeflow/server.py`.

## Root cause

Prior attempt `5c159ab` (codeflow fix) deleted `_safe_path` and inlined the guard, but CodeQL still flags:

1. **py/path-injection (x7)** — the inline `if target != root and not target.startswith(root + os.sep):` guard is not a recognized sanitizer. CodeQL's `SafeAccessCheck` barrier only applies when the `startswith` guard is the *only* path reaching the sink; the `and`-compound leaves a tainted `target == root` path through.
2. **py/http-response-splitting (x1)** — `_mime(os.path.basename(target))` in the Content-Type header: `basename()` does not stop taint; the header-injection query only recognizes `.replace("\n", ...)` as a sanitizer.

## Fix

- `_api`: early-return the repo-root case using the untainted `root` constant, then a standalone `realpath` + `startswith` prefix guard as the only tainted path to the sinks. Listing body extracted to `_list_contents()`.
- `_serve_ui_file`: strip CR/LF from the Content-Type header value.

## Verification

- CodeQL CLI **2.26.2** (the version code-scanning uses) reports **0 results** for the file (was 8).
- Live server tests: traversal attempts → 404, legit paths (root listing, dir, file, UI, trees) → 200, Content-Type header intact.
- `py_compile` passes; `test/docker-tree-sync.test.sh` 33/33.