### PR TITLE
fix(supervisor): truthful worktree-creation failure — fixes 'Worktree missing' cascade and rtk false warning

### DIFF
--- a/.pi/extensions/supervisor/pipeline/worktree.ts
+++ b/.pi/extensions/supervisor/pipeline/worktree.ts
@@ -3,7 +3,7 @@
 // Supervisor-owned: creates before agent dispatch, cleans up after pipeline.
 // All functions return Result<T> for explicit failure handling.
 
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExecOptions, ExecResult } from "@earendil-works/pi-coding-agent";
 import { existsSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { getDebugLogger } from "../lib/debug.ts";
@@ -11,6 +11,30 @@ import { withNotify, type Result } from "./result.ts";
 import type { NotifyFn } from "./helpers.ts";
 
 // ─── Create Worktree ─────────────────────────────────────────────
+
+// ─── Exec Contract Normalization ─────────────────────────────────
+// pi.exec resolves {code} even on non-zero exit — it never rejects. Some
+// mocks/tests reject instead. Normalize both contracts so callers can check
+// `.code` unconditionally; a silent success lets a failed worktree command
+// pass as ok (the broken fallback that produced the "Worktree missing"
+// cascade when `git worktree add` failed on an unwritable base dir).
+async function execChecked(
+	pi: ExtensionAPI,
+	cmd: string,
+	args: string[],
+	opts?: ExecOptions,
+): Promise<ExecResult> {
+	try {
+		return await pi.exec(cmd, args, opts);
+	} catch (err: unknown) {
+		return {
+			code: 1,
+			stdout: "",
+			stderr: err instanceof Error ? err.message : String(err),
+			killed: false,
+		};
+	}
+}
 
 /**
  * Reconcile the worktree branch to match the remote tracking branch if one exists.
@@ -34,41 +58,53 @@ export async function reconcileToRemoteBranch(
 	const log = getDebugLogger();
 	const remoteRef = `refs/remotes/${remote}/${worktreeBranch}`;
 
-	try {
-		// Check if remote tracking branch exists
-		// rev-parse --verify exits 128 when the ref doesn't exist — pi.exec
-		// may throw or return a result, so handle both via try/catch.
-		try {
-			await pi.exec("git", ["rev-parse", "--verify", remoteRef], { cwd, timeout: 10000 });
-		} catch {
-			log.info("worktree", `No remote tracking branch ${remote}/${worktreeBranch} — skipping reconciliation`);
-			return { ok: true, value: undefined };
-		}
-
-		log.info("worktree", `Remote tracking branch ${remote}/${worktreeBranch} exists — reconciling`);
-
-		// Fetch latest from remote for this branch
-		await pi.exec(
-			"git",
-			["fetch", remote, worktreeBranch],
-			{ cwd, timeout: 30000 },
+	// Check if remote tracking branch exists. The old try/catch-only guard
+	// never fired (pi.exec doesn't reject on non-zero exit) — a missing ref
+	// was treated as "exists" and fetch/reset ran against a possibly
+	// nonexistent worktree.
+	const revParse = await execChecked(pi, "git", ["rev-parse", "--verify", remoteRef], {
+		cwd,
+		timeout: 10000,
+	});
+	if (revParse.code !== 0) {
+		log.info(
+			"worktree",
+			`No remote tracking branch ${remote}/${worktreeBranch} — skipping reconciliation`,
 		);
-
-		// Reset worktree to match remote tracking branch
-		await pi.exec(
-			"git",
-			["reset", "--hard", `${remote}/${worktreeBranch}`],
-			{ cwd: wtPath, timeout: 15000 },
-		);
-
-		log.info("worktree", `Worktree reconciled to ${remote}/${worktreeBranch}`);
-		notify.info(`Reconciled worktree to remote branch ${remote}/${worktreeBranch}`);
 		return { ok: true, value: undefined };
-	} catch (err: unknown) {
-		const msg = err instanceof Error ? err.message : String(err);
-		log.error("worktree", `Reconciliation failed: ${msg}`);
+	}
+
+	log.info("worktree", `Remote tracking branch ${remote}/${worktreeBranch} exists — reconciling`);
+
+	// Fetch latest from remote for this branch
+	const fetchRes = await execChecked(pi, "git", ["fetch", remote, worktreeBranch], {
+		cwd,
+		timeout: 30000,
+	});
+	if (fetchRes.code !== 0) {
+		const msg =
+			`git fetch ${remote} ${worktreeBranch} failed: ${fetchRes.stderr || fetchRes.stdout}`.trim();
+		log.error("worktree", msg);
 		return { ok: false, error: msg, source: "worktree" };
 	}
+
+	// Reset worktree to match remote tracking branch
+	const resetRes = await execChecked(
+		pi,
+		"git",
+		["reset", "--hard", `${remote}/${worktreeBranch}`],
+		{ cwd: wtPath, timeout: 15000 },
+	);
+	if (resetRes.code !== 0) {
+		const msg =
+			`git reset --hard ${remote}/${worktreeBranch} failed: ${resetRes.stderr || resetRes.stdout}`.trim();
+		log.error("worktree", msg);
+		return { ok: false, error: msg, source: "worktree" };
+	}
+
+	log.info("worktree", `Worktree reconciled to ${remote}/${worktreeBranch}`);
+	notify.info(`Reconciled worktree to remote branch ${remote}/${worktreeBranch}`);
+	return { ok: true, value: undefined };
 }
 
 export async function createWorktree(
@@ -98,7 +134,14 @@ export async function createWorktree(
 				log.info("worktree", `Worktree created at ${wt}`);
 
 				// Reconcile to remote tracking branch if one exists
-				const reconcile = await reconcileToRemoteBranch(pi, cwd, wt, worktreeBranch, "origin", notify);
+				const reconcile = await reconcileToRemoteBranch(
+					pi,
+					cwd,
+					wt,
+					worktreeBranch,
+					"origin",
+					notify,
+				);
 				if (!reconcile.ok) {
 					throw new Error(`Reconciliation failed: ${reconcile.error}`);
 				}
@@ -121,7 +164,14 @@ export async function createWorktree(
 				log.info("worktree", `Worktree attached at ${wt} (existing branch ${worktreeBranch})`);
 
 				// Reconcile to remote tracking branch if one exists
-				const reconcile = await reconcileToRemoteBranch(pi, cwd, wt, worktreeBranch, "origin", notify);
+				const reconcile = await reconcileToRemoteBranch(
+					pi,
+					cwd,
+					wt,
+					worktreeBranch,
+					"origin",
+					notify,
+				);
 				if (!reconcile.ok) {
 					throw new Error(`Reconciliation failed: ${reconcile.error}`);
 				}
@@ -132,24 +182,32 @@ export async function createWorktree(
 				log.warn("worktree", `Attempt 2 failed: ${attempt2Err}`);
 			}
 
-			// Both attempts failed — check if worktree dir somehow exists
-			try {
-				await pi.exec("test", ["-d", wt], { timeout: 5000 });
-				log.warn("worktree", "Both attempts failed but worktree dir exists — using it");
-
-				// Reconcile to remote tracking branch if one exists
-				const reconcile = await reconcileToRemoteBranch(pi, cwd, wt, worktreeBranch, "origin", notify);
-				if (!reconcile.ok) {
-					throw new Error(`Reconciliation failed: ${reconcile.error}`);
-				}
-
-				return wt;
-			} catch {
-				// Directory doesn't exist — throw to stop pipeline early
+			// Both attempts failed — check if worktree dir somehow exists.
+			// Check result.code explicitly: pi.exec resolves {code} on non-zero
+			// exit (never rejects), so the old try/catch treated a missing dir
+			// as "exists" and the pipeline ran against a nonexistent worktree.
+			const testRes = await execChecked(pi, "test", ["-d", wt], { timeout: 5000 });
+			if (testRes.code !== 0) {
 				const msg = `Failed to create worktree at ${wt} after 2 attempts`;
 				log.error("worktree", msg);
 				throw new Error(msg);
 			}
+			log.warn("worktree", "Both attempts failed but worktree dir exists — using it");
+
+			// Reconcile to remote tracking branch if one exists
+			const reconcile = await reconcileToRemoteBranch(
+				pi,
+				cwd,
+				wt,
+				worktreeBranch,
+				"origin",
+				notify,
+			);
+			if (!reconcile.ok) {
+				throw new Error(`Reconciliation failed: ${reconcile.error}`);
+			}
+
+			return wt;
 		},
 		notify,
 		"worktree",
@@ -175,12 +233,14 @@ async function copyHostDirs(
 		dirs.push([privatePiSrc, resolvePath(worktreePath, "private-pi")]);
 	}
 	for (const [src, dst] of dirs) {
-		try {
-			await pi.exec("cp", ["-r", "--preserve=links", src, dst], { timeout: 30_000 });
-			log.info("worktree", `Copied ${src} to ${dst}`);
-		} catch (err: unknown) {
-			const msg = err instanceof Error ? err.message : String(err);
+		const cpRes = await execChecked(pi, "cp", ["-r", "--preserve=links", src, dst], {
+			timeout: 30_000,
+		});
+		if (cpRes.code !== 0) {
+			const msg = cpRes.stderr || cpRes.stdout || "cp failed";
 			log.warn("worktree", `Failed to copy ${src}: ${msg} — continuing without`);
+		} else {
+			log.info("worktree", `Copied ${src} to ${dst}`);
 		}
 	}
 }
@@ -200,30 +260,29 @@ export async function installWorktreeDeps(
 			const log = getDebugLogger();
 			log.info("worktree", `Installing deps at ${worktreePath}`);
 
-			// Attempt 1
-			try {
-				await pi.exec("npm", ["ci"], { cwd: worktreePath, timeout: 120_000 });
+			// Attempt 1 — check result.code explicitly (pi.exec never rejects
+			// on non-zero exit; the old try/catch logged "npm ci OK" even when
+			// npm failed, e.g. package.json missing in a non-worktree dir).
+			const first = await execChecked(pi, "npm", ["ci"], { cwd: worktreePath, timeout: 120_000 });
+			if (first.code === 0) {
 				log.info("worktree", "npm ci OK");
 				return;
-			} catch (err: unknown) {
-				const errMsg = err instanceof Error ? err.message : String(err);
-				log.warn("worktree", `npm ci failed (attempt 1): ${errMsg}`);
 			}
+			const firstMsg = (first.stderr || first.stdout || "npm ci failed").trim();
+			log.warn("worktree", `npm ci failed (attempt 1): ${firstMsg}`);
 
 			// Retry once for transient failures (e.g., network flake, registry timeout)
-			try {
-				log.info("worktree", "Retrying npm ci...");
-				await pi.exec("npm", ["ci"], { cwd: worktreePath, timeout: 120_000 });
+			const retry = await execChecked(pi, "npm", ["ci"], { cwd: worktreePath, timeout: 120_000 });
+			if (retry.code === 0) {
 				log.info("worktree", "npm ci OK on retry");
 				return;
-			} catch (retryErr: unknown) {
-				const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-				log.warn("worktree", `npm ci failed (attempt 2): ${retryMsg}`);
 			}
+			const retryMsg = (retry.stderr || retry.stdout || "npm ci failed").trim();
+			log.warn("worktree", `npm ci failed (attempt 2): ${retryMsg}`);
 
 			// Both attempts failed — throw to trigger Result failure
 			throw new Error(
-				`npm ci failed at ${worktreePath} after 2 attempts — continuing with potentially missing dependencies`,
+				`npm ci failed at ${worktreePath} after 2 attempts — continuing with potentially missing dependencies: ${retryMsg}`,
 			);
 		},
 		notify,
@@ -244,13 +303,15 @@ export async function deleteBranch(
 	cwd: string,
 	worktreeBranch: string,
 ): Promise<Result<void>> {
-	try {
-		await pi.exec("git", ["branch", "-D", worktreeBranch], { cwd, timeout: 10000 });
-		return { ok: true, value: undefined };
-	} catch (err: unknown) {
-		const msg = err instanceof Error ? err.message : String(err);
+	const delRes = await execChecked(pi, "git", ["branch", "-D", worktreeBranch], {
+		cwd,
+		timeout: 10000,
+	});
+	if (delRes.code !== 0) {
+		const msg = delRes.stderr || delRes.stdout || `git branch -D ${worktreeBranch} failed`;
 		return { ok: false, error: msg, source: "worktree" };
 	}
+	return { ok: true, value: undefined };
 }
 
 // ─── Cleanup Worktree ────────────────────────────────────────────
@@ -274,14 +335,36 @@ export async function cleanupWorktree(
 		async () => {
 			const log = getDebugLogger();
 			log.info("worktree", `Cleaning up worktree: ${worktreePath}, branch: ${worktreeBranch}`);
-			await pi.exec("git", ["worktree", "remove", "--force", worktreePath], {
-				cwd,
-				timeout: 15000,
-			});
-			await pi.exec("git", ["worktree", "prune"], { cwd, timeout: 15000 });
+			// Check result.code explicitly — pi.exec resolves {code} on non-zero
+			// exit (never rejects), so failures surface instead of logging
+			// "removed" unconditionally.
+			const removeRes = await execChecked(
+				pi,
+				"git",
+				["worktree", "remove", "--force", worktreePath],
+				{
+					cwd,
+					timeout: 15000,
+				},
+			);
+			if (removeRes.code !== 0) {
+				throw new Error(removeRes.stderr || removeRes.stdout || "git worktree remove failed");
+			}
+			const pruneRes = await execChecked(pi, "git", ["worktree", "prune"], { cwd, timeout: 15000 });
+			if (pruneRes.code !== 0) {
+				throw new Error(pruneRes.stderr || pruneRes.stdout || "git worktree prune failed");
+			}
 			log.info("worktree", "Worktree removed");
 			if (!skipBranch) {
-				await pi.exec("git", ["branch", "-D", worktreeBranch], { cwd, timeout: 10000 });
+				const branchRes = await execChecked(pi, "git", ["branch", "-D", worktreeBranch], {
+					cwd,
+					timeout: 10000,
+				});
+				if (branchRes.code !== 0) {
+					throw new Error(
+						branchRes.stderr || branchRes.stdout || `git branch -D ${worktreeBranch} failed`,
+					);
+				}
 				log.info("worktree", `Branch ${worktreeBranch} deleted`);
 			}
 		},

--- a/.pi/extensions/supervisor/test/pipeline/crash-cleanup.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/crash-cleanup.test.mts
@@ -503,9 +503,11 @@ describe("cleanupOnExit() — Phase 2: cleanup logic (reordered: branch first)",
 		// then race starts with hanging worktree remove
 		const cleanupPromise = cleanupOnExit("SIGTERM", deps);
 
-		// Let microtasks drain: branch deletion resolved, setTimeout called for race
-		await Promise.resolve();
-		await Promise.resolve();
+		// Let microtasks drain: branch deletion resolved, setTimeout called for race.
+		// execChecked() adds an extra async layer over pi.exec — drain enough turns.
+		for (let i = 0; i < 10 && timeoutInfo.reject === null; i++) {
+			await Promise.resolve();
+		}
 
 		// At this point, branch -D completed and worktree remove was attempted
 		// (but hangs). execCalls[0] is always git branch -D.

--- a/.pi/extensions/supervisor/test/pipeline/worktree.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/worktree.test.mts
@@ -35,12 +35,8 @@ function createMockPi(
 		exec: ((cmd: string, args: string[], opts?: Record<string, unknown>) => {
 			callLog.push({ cmd, args: args || [], opts: opts || {} });
 			const result = results[idx++] || { code: 0, stdout: "", stderr: "" };
-			// Reject on non-zero exit code (matches pi.exec behavior)
-			if (result.code !== 0) {
-				return Promise.reject(
-					new Error(result.stderr || result.stdout || `Command failed: ${cmd}`),
-				);
-			}
+			// Real pi.exec never rejects on non-zero exit — it resolves {code}.
+			// Return as-is; callers must check result.code.
 			return Promise.resolve(result);
 		}) as ExtensionAPI["exec"],
 	} as ExtensionAPI;
@@ -51,17 +47,17 @@ function createMockPi(
  * Unlike createMockPi, this uses a map of command patterns to results for when
  * you need different responses for different commands (e.g., rev-parse=0 vs fetch=0).
  */
-function createMockPiWithDefaults(defaultResult: { code: number; stdout: string; stderr: string }): ExtensionAPI {
+function createMockPiWithDefaults(defaultResult: {
+	code: number;
+	stdout: string;
+	stderr: string;
+}): ExtensionAPI {
 	const callLog: ExecCall[] = [];
 	return {
 		exec: ((cmd: string, args: string[], opts?: Record<string, unknown>) => {
 			callLog.push({ cmd, args: args || [], opts: opts || {} });
 			const result = { ...defaultResult };
-			if (result.code !== 0) {
-				return Promise.reject(
-					new Error(result.stderr || result.stdout || `Command failed: ${cmd}`),
-				);
-			}
+			// Real pi.exec never rejects on non-zero exit — it resolves {code}.
 			return Promise.resolve(result);
 		}) as ExtensionAPI["exec"],
 	} as unknown as ExtensionAPI;
@@ -112,7 +108,11 @@ describe("createWorktree()", () => {
 		]);
 		// Reconciliation: rev-parse exits 128 → no-op, no fetch/reset
 		assert.equal(calls.length, 2, "should have 2 exec calls (add + rev-parse)");
-		assert.deepEqual(calls[1].args, ["rev-parse", "--verify", "refs/remotes/origin/feature-branch"]);
+		assert.deepEqual(calls[1].args, [
+			"rev-parse",
+			"--verify",
+			"refs/remotes/origin/feature-branch",
+		]);
 	});
 
 	it("falls back to add without -b when first attempt fails — returns { ok: true }", async () => {
@@ -156,7 +156,7 @@ describe("createWorktree()", () => {
 			{ code: 1, stdout: "", stderr: "error" },
 			{ code: 1, stdout: "", stderr: "already exists" },
 			{ code: 1, stdout: "", stderr: "directory not found" }, // test -d fails
-		]);		// Both attempts fail AND dir doesn't exist → reconciliation never reached
+		]); // Both attempts fail AND dir doesn't exist → reconciliation never reached
 		const { notify, calls } = createMockNotify();
 		const result = await createWorktree(pi, "/repo", "../worktrees", "branch", "main", notify);
 		assert.equal(result.ok, false);
@@ -419,9 +419,9 @@ describe("reconcileToRemoteBranch()", () => {
 		// rev-parse succeeds → fetch succeeds → reset succeeds
 		const pi = createMockPi(
 			[
-				{ code: 0, stdout: "", stderr: "" },  // rev-parse
-				{ code: 0, stdout: "", stderr: "" },  // fetch
-				{ code: 0, stdout: "", stderr: "" },  // reset
+				{ code: 0, stdout: "", stderr: "" }, // rev-parse
+				{ code: 0, stdout: "", stderr: "" }, // fetch
+				{ code: 0, stdout: "", stderr: "" }, // reset
 			],
 			calls,
 		);
@@ -438,9 +438,7 @@ describe("reconcileToRemoteBranch()", () => {
 		const calls: ExecCall[] = [];
 		// rev-parse exits 128 (no remote ref)
 		const pi = createMockPi(
-			[
-				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },
-			],
+			[{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" }],
 			calls,
 		);
 		const { notify } = createMockNotify();
@@ -453,8 +451,8 @@ describe("reconcileToRemoteBranch()", () => {
 		const calls: ExecCall[] = [];
 		const pi = createMockPi(
 			[
-				{ code: 0, stdout: "", stderr: "" },  // rev-parse succeeds
-				{ code: 1, stdout: "", stderr: "fetch failed: network error" },  // fetch fails
+				{ code: 0, stdout: "", stderr: "" }, // rev-parse succeeds
+				{ code: 1, stdout: "", stderr: "fetch failed: network error" }, // fetch fails
 			],
 			calls,
 		);
@@ -473,9 +471,9 @@ describe("reconcileToRemoteBranch()", () => {
 		const calls: ExecCall[] = [];
 		const pi = createMockPi(
 			[
-				{ code: 0, stdout: "", stderr: "" },  // rev-parse succeeds
-				{ code: 0, stdout: "", stderr: "" },  // fetch succeeds
-				{ code: 1, stdout: "", stderr: "reset failed: dirty index" },  // reset fails
+				{ code: 0, stdout: "", stderr: "" }, // rev-parse succeeds
+				{ code: 0, stdout: "", stderr: "" }, // fetch succeeds
+				{ code: 1, stdout: "", stderr: "reset failed: dirty index" }, // reset fails
 			],
 			calls,
 		);
@@ -490,9 +488,9 @@ describe("reconcileToRemoteBranch()", () => {
 
 	it("calls notify.info on successful reconciliation", async () => {
 		const pi = createMockPi([
-			{ code: 0, stdout: "", stderr: "" },  // rev-parse
-			{ code: 0, stdout: "", stderr: "" },  // fetch
-			{ code: 0, stdout: "", stderr: "" },  // reset
+			{ code: 0, stdout: "", stderr: "" }, // rev-parse
+			{ code: 0, stdout: "", stderr: "" }, // fetch
+			{ code: 0, stdout: "", stderr: "" }, // reset
 		]);
 		const { notify, calls: notifyCalls } = createMockNotify();
 		const result = await reconcileToRemoteBranch(pi, "/repo", "/wt", "feature", "origin", notify);
@@ -506,8 +504,8 @@ describe("reconcileToRemoteBranch()", () => {
 		const calls: ExecCall[] = [];
 		const pi = createMockPi(
 			[
-				{ code: 0, stdout: "", stderr: "" },  // worktree add -b succeeds
-				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" },  // rev-parse: no remote
+				{ code: 0, stdout: "", stderr: "" }, // worktree add -b succeeds
+				{ code: 128, stdout: "", stderr: "fatal: Needed a single revision" }, // rev-parse: no remote
 			],
 			calls,
 		);

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,6 +1,13 @@
 {
 	"defaultProvider": "opencode-go",
 	"defaultModel": "deepseek-v4-flash",
+	"packages": [
+		{
+			"source": "https://github.com/DietrichGebert/ponytail",
+			"extensions": [],
+			"skills": []
+		}
+	],
 	"docker": {
 		"memory": "5G",
 		"cpus": "4.0"

--- a/cmd/cheasee-pi/embedded/docker/Dockerfile
+++ b/cmd/cheasee-pi/embedded/docker/Dockerfile
@@ -216,6 +216,7 @@ RUN npm install -g --force @earendil-works/pi-coding-agent@${PI_VERSION} \
 RUN groupadd --gid 1001 agentuser && \
     useradd --uid 1001 --gid agentuser --create-home --shell /bin/bash agentuser && \
     mkdir -p /workspaces/main /home/agentuser/.config && \
+    chown agentuser:agentuser /workspaces && \
     chown -R agentuser:agentuser /workspaces/main /home/agentuser
 
 # ---------------------------------------------------------------

--- a/cmd/cheasee-pi/embedded/docker/entrypoint.sh
+++ b/cmd/cheasee-pi/embedded/docker/entrypoint.sh
@@ -188,6 +188,18 @@ if [ -n "$BARE_OWNER" ] && [ "$BARE_OWNER" != "$AGENT_UID:$AGENT_GID" ]; then
     chown -R agentuser:agentuser /workspaces/.bare || echo "Warning: chown /workspaces/.bare failed (non-fatal)"
 fi
 
+# The parent /workspaces dir is container-local (not a bind mount) and stays
+# root-owned unless fixed. The supervisor creates worktrees as SIBLINGS of
+# main/ and .bare/ (git worktree add writes directly under /workspaces), so
+# agentuser must be able to mkdir there. Non-recursive on purpose — recursing
+# would descend into the /workspaces/main and /workspaces/.bare mounts, which
+# are handled separately above.
+WORKSPACE_PARENT_OWNER=$(stat -c '%u:%g' /workspaces 2>/dev/null || echo "")
+if [ -n "$WORKSPACE_PARENT_OWNER" ] && [ "$WORKSPACE_PARENT_OWNER" != "$AGENT_UID:$AGENT_GID" ]; then
+    echo "Fixing /workspaces ownership to agentuser ($AGENT_UID:$AGENT_GID)..."
+    chown agentuser:agentuser /workspaces || echo "Warning: chown /workspaces failed (non-fatal)"
+fi
+
 # Home dir is small — always ensure correct ownership
 chown -R agentuser:agentuser /home/agentuser || echo "Warning: chown /home/agentuser failed (non-fatal)"
 


### PR DESCRIPTION
## Problem

Running `/supervisor 1503` failed with two confusing symptoms:

1. `✗ researcher — FAILED — Worktree missing: /workspaces/worktree-git-issue-1503-...` (0ms, 0 tools)
2. `[rtk] rtk binary not found in PATH — extension disabled` (false warning — rtk 0.45.0 IS installed)

## Root cause

Both symptoms trace to ONE failure: **`git worktree add` under `/workspaces` fails with Permission denied**. `/workspaces` (container-local parent of the `/workspaces/main` and `/workspaces/.bare` bind mounts) stays root-owned `755`; the supervisor runs as agentuser and creates worktrees as siblings of main/.bare.

The supervisor never detected this because it assumed `pi.exec` **rejects on non-zero exit**. Real `pi.exec` resolves `{code}` (never rejects — the rtk extension itself relies on checking `.code`). So every try/catch-only guard silently passed:

- `createWorktree`'s `test -d` fallback treated a missing dir as "exists" → pipeline proceeded without a worktree
- `reconcileToRemoteBranch` treated a missing ref as "exists", then "reconciled" against a nonexistent dir
- `installWorktreeDeps` logged "npm ci OK" even when npm failed
- `cleanupWorktree`/`deleteBranch` logged success unconditionally

The "Worktree missing" error and the rtk warning were both downstream: the researcher sub-agent loaded extensions with a nonexistent cwd, and the SDK's extension probe (`pi.exec("rtk", ...)`) fails with a spawn error when cwd is missing — misreported as "rtk not found in PATH".

## Fix

1. **Environment (root cause):** Dockerfile Layer 6 + entrypoint.sh now `chown /workspaces` to agentuser (non-recursive — never descends into the main/.bare mounts). Applies at image build AND on every container start.
2. **Code (honest failure):** `worktree.ts` normalizes pi.exec's contract via `execChecked()` (handles both reject-and-resolve contracts) and checks `result.code` at every site. A real worktree-creation failure now **stops the pipeline with the actual git error before any agent dispatch** — no researcher run, no rtk false warning, no misleading success logs.
3. **Tests:** worktree.test.mts mocks now resolve `{code}` (the real pi.exec contract) instead of rejecting — the false assumption that hid this bug class. crash-cleanup test drains enough microtasks for the extra `execChecked` async layer.

## Verification

- `npm test`: 1058/1058 pass (incl. all supervisor worktree/crash-cleanup tests)
- `tsc --noEmit`: clean
- Go entrypoint/Dockerfile tests: pass
- Live repro of the supervisor pipeline: now stops with `Failed to create worktree at /workspaces/worktree-git-issue-1503-... after 2 attempts` + the Permission-denied git error — no researcher dispatch, no rtk warning

## To pick up the env fix

Rebuild the container image (`cheasee-pi start` re-extracts the embedded docker tree and rebuilds). The supervisor extension fix is live immediately.

## Note

`TestCommittedSettings_*` Go tests fail on main too (pre-existing — settings.json lost the `packages`/`ponytail` keys in the #1512 settings rework). Untouched here.