### PR TITLE
fix(structural-search): honor directory param in ast-grep search

### DIFF
--- a/.pi/extensions/structural-analyzer/index.ts
+++ b/.pi/extensions/structural-analyzer/index.ts
@@ -128,10 +128,17 @@ export default function structuralAnalyzer(pi: ExtensionAPI): void {
 						"See ast-grep docs for full list.",
 				}),
 			),
+			directory: Type.Optional(
+				Type.String({
+					description:
+						"Directory to scope the search to (absolute or relative to cwd). " +
+						"Defaults to the current working directory.",
+				}),
+			),
 		}),
 		renderResult: renderStructuralSearchResult as any,
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
-			const { pattern } = params;
+			const { pattern, directory } = params;
 			const language =
 				params.language ?? (await detectLanguage(pi.exec.bind(pi), ctx.cwd)) ?? DEFAULT_LANGUAGE;
 
@@ -142,7 +149,7 @@ export default function structuralAnalyzer(pi: ExtensionAPI): void {
 			}
 
 			// Check cache before executing
-			const cacheKey = makeCacheKey(pattern, language, ctx.cwd);
+			const cacheKey = makeCacheKey(pattern, language, directory ?? ctx.cwd);
 			const cached = getCache(cacheKey);
 			if (cached) {
 				return cached;
@@ -162,6 +169,7 @@ export default function structuralAnalyzer(pi: ExtensionAPI): void {
 				language,
 				"--no-ignore=hidden",
 			];
+			if (directory) args.push(directory);
 
 			const result = await pi.exec(binary, args, {
 				cwd: ctx.cwd,


### PR DESCRIPTION
## Problem

`structural_search` tool's `directory` parameter was ignored — a scoped query for `.pi/extensions/rtk` returned matches from 6 unrelated directories.

## Root cause

Two layers:
1. `directory` was **missing from the tool parameter schema** — unknown keys silently dropped, so scoping was impossible.
2. Even if it had arrived, the ast-grep args never included a search path (`--path` doesn't exist in ast-grep 0.45.1; positional PATHS is the correct form).

## Fix

- Add optional `directory` param to the schema
- Pass it as positional path to `ast-grep run` (scopes search when provided, unchanged default = cwd)
- Scope the result cache key to include the directory

## Verification

- `npm run tsc:extensions` clean
- Direct CLI: `ast-grep run --pattern 'console.warn($A)' --json=stream --lang ts --no-ignore=hidden .pi/extensions/rtk` → exactly 2 matches, both in rtk/index.ts (was 20 repo-wide)
- Extension tests: 116/116 pass

Note: takes effect on next session start (extension modules load once at session start).