### PR TITLE
feat(#1503): Per-repository container identity with parallel coexistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,5 +59,5 @@ Note: This rule does not apply to git URLs, tarballs, or local paths.
 </package_safety_audit>
 
 <CRITICAL_OVERRIDES>
-- THE MAIN BRANCH IS LOCKED. You are strictly forbidden from committing directly to main. Create branch, push and create PR.
+- THE MAIN BRANCH IS LOCKED. You are strictly forbidden from committing directly to main. Create a worktree, push and create PR.
 </CRITICAL_OVERRIDES>

--- a/cmd/cheasee-pi/clean.go
+++ b/cmd/cheasee-pi/clean.go
@@ -4,50 +4,72 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
-var cleanName string
-
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
-	Short: "Kill orphaned pi sessions and prune Docker garbage (dangling images + build cache)",
-	Long: `Kill orphaned pi processes inside the Cheasee-Pi Docker container and
-prune dangling Docker images and build cache from old rebuilds.
+	Short: "Remove all Cheasee-Pi containers and prune Docker garbage (dangling images + build cache)",
+	Long: `Remove every Cheasee-Pi container (all repositories), kill orphaned pi
+processes inside the running ones, and prune dangling Docker images and
+build cache from old rebuilds.
+
+Containers are enumerated by compose project: every container belonging to a
+cheasee-pi project (the per-repo project cheasee-pi-<repo> plus the legacy
+shared project cheasee-pi — main container and codeflow sidecar alike) is
+removed. Other containers are never touched.
 
 Pi processes orphaned by disconnected docker exec sessions accumulate RAM.
-Run this when memory usage is high. Only kills processes reparented to PID 1
-(orphans) — interactive sessions are NOT affected.
-Dangling images and build cache (intermediate layers) are pruned.
-Use 'cheasee-pi start' to start a fresh session after cleaning.
+The orphan scan runs against each running Cheasee-Pi container first; only
+processes reparented to PID 1 (orphans) are killed — interactive sessions
+are NOT affected. Dangling images and build cache (intermediate layers) are
+pruned. Use 'cheasee-pi start' to start a fresh session after cleaning.
 
 Examples:
-  cheasee-pi clean               # kill orphaned pi + prune Docker garbage
-  cheasee-pi clean --name mypi   # specify container name`,
+  cheasee-pi clean               # remove all cheasee-pi containers + prune Docker garbage`,
 	DisableAutoGenTag: true,
 	RunE:              runCleanE,
 }
 
 func init() {
 	rootCmd.AddCommand(cleanCmd)
-	cleanCmd.Flags().StringVar(&cleanName, "name", "cheasee-pi", "Container name")
 }
 
-// pruneDanglingImages removes all dangling (<none>:<none>) Docker images.
-// Tagged/in-use images are never affected.
-func pruneDanglingImages() {
-	ls := exec.Command("docker", "images", "--filter", "dangling=true", "-q")
-	out, err := ls.Output()
-	if err != nil || len(out) == 0 {
-		return
+// cleanContainer is one Cheasee-Pi compose container discovered by clean.
+type cleanContainer struct {
+	name    string
+	running bool
+}
+
+// cheaseePiContainers enumerates every container belonging to a cheasee-pi
+// compose project (project "cheasee-pi" or "cheasee-pi-<repo>"): all workspace
+// containers — main + codeflow sidecar — plus the legacy shared container.
+// One docker ps -a format line per container; containers without the compose
+// project label (plain docker run) are never matched.
+func cheaseePiContainers() ([]cleanContainer, error) {
+	cmd := execCommand("docker", "ps", "-a", "--format", `{{.Names}}\t{{.State}}\t{{index .Labels "com.docker.compose.project"}}`)
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker ps: %w", err)
 	}
-	cmd := exec.Command("docker", "image", "prune", "-f")
-	if err := cmd.Run(); err != nil {
-		return
+	var found []cleanContainer
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) != 3 {
+			continue
+		}
+		name, state, project := parts[0], parts[1], parts[2]
+		if project == "" || !strings.HasPrefix(project, "cheasee-pi") {
+			continue
+		}
+		found = append(found, cleanContainer{name: name, running: state == "running"})
 	}
-	fmt.Fprintf(os.Stderr, "  ✓ Pruned dangling Docker images\n")
+	return found, nil
 }
 
 func runCleanE(cmd *cobra.Command, _ []string) error {
@@ -56,24 +78,47 @@ func runCleanE(cmd *cobra.Command, _ []string) error {
 		ctx = context.Background()
 	}
 
-	// Default container name follows the workspace repo slug (like start);
-	// --name overrides verbatim.
-	if !cmd.Flags().Changed("name") {
-		if wd, err := os.Getwd(); err == nil {
-			if root, ok := findWorkspaceRoot(wd); ok {
-				cleanName = containerName(root)
-			}
-		}
+	containers, err := cheaseePiContainers()
+	if err != nil {
+		return fmt.Errorf("enumerate containers: %w", err)
 	}
 
-	killed, err := scanOrphans(ctx, cleanName)
-	if err != nil {
-		return fmt.Errorf("clean: %w", err)
+	// Orphan scan first: kills pi processes reparented to PID 1 in every
+	// running Cheasee-Pi container (the same scan start runs pre-exec).
+	killed := 0
+	for _, c := range containers {
+		if !c.running {
+			continue
+		}
+		n, err := scanOrphans(ctx, c.name)
+		if err != nil {
+			return fmt.Errorf("orphan scan %s: %w", c.name, err)
+		}
+		killed += n
 	}
 	if killed > 0 {
 		fmt.Fprintf(os.Stderr, "  ✓ Killed %d orphaned pi process(es)\n", killed)
-	} else {
+	} else if len(containers) > 0 {
 		fmt.Fprintf(os.Stderr, "  ℹ No orphaned pi processes found\n")
+	}
+
+	// Remove every discovered container; a container vanishing between
+	// enumeration and removal (No such container) is tolerated.
+	var rmErrs []string
+	for _, c := range containers {
+		cmd := execCommand("docker", "rm", "-f", c.name)
+		out, err := cmd.CombinedOutput()
+		if err != nil && !strings.Contains(string(out), "No such container") {
+			rmErrs = append(rmErrs, fmt.Sprintf("%s: %v", c.name, err))
+		}
+	}
+	if len(containers) > 0 {
+		fmt.Fprintf(os.Stderr, "  ✓ Removed %d Cheasee-Pi container(s)\n", len(containers))
+	} else {
+		fmt.Fprintf(os.Stderr, "  ℹ No Cheasee-Pi containers found\n")
+	}
+	if len(rmErrs) > 0 {
+		return fmt.Errorf("docker rm: %s", strings.Join(rmErrs, "; "))
 	}
 
 	pruneDanglingImages()
@@ -82,13 +127,26 @@ func runCleanE(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+// pruneDanglingImages removes all dangling (<none>:<none>) Docker images.
+// Tagged/in-use images are never affected.
+func pruneDanglingImages() {
+	ls := execCommand("docker", "images", "--filter", "dangling=true", "-q")
+	out, err := ls.Output()
+	if err != nil || len(out) == 0 {
+		return
+	}
+	cmd := execCommand("docker", "image", "prune", "-f")
+	if _, err := cmd.Output(); err != nil {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "  ✓ Pruned dangling Docker images\n")
+}
+
 // pruneBuildCache removes the Docker buildx build cache.
 // Safe to run unconditionally — fast when empty.
 func pruneBuildCache() {
-	cmd := exec.Command("docker", "buildx", "prune", "-f")
-	if err := cmd.Run(); err == nil {
+	cmd := execCommand("docker", "buildx", "prune", "-f")
+	if _, err := cmd.Output(); err == nil {
 		fmt.Fprintf(os.Stderr, "  ✓ Pruned Docker build cache\n")
 	}
 }
-
-

--- a/cmd/cheasee-pi/clean_test.go
+++ b/cmd/cheasee-pi/clean_test.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
+)
+
+// ──────────────────────────────────────────────
+// clean: container enumeration (compose project label)
+// ──────────────────────────────────────────────
+
+func TestCheaseePiContainers_parsesAndFilters(t *testing.T) {
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		if len(arg) == 0 || arg[0] != "ps" {
+			t.Fatalf("expected docker ps, got %v", arg)
+		}
+		if !slices.Contains(arg, "-a") {
+			t.Fatalf("enumeration must list all containers (-a), got %v", arg)
+		}
+		return &mockCmd{outputFn: func() ([]byte, error) {
+			// name \t state \t compose project label — two workspace containers
+			// (main + codeflow sidecar), one legacy shared container, one
+			// non-cheasee-pi project, one compose-less container.
+			return []byte(
+				"cheasee-pi-repoa\trunning\tcheasee-pi-repoa\n" +
+					"codeflow-repoa\trunning\tcheasee-pi-repoa\n" +
+					"cheasee-pi\texited\tcheasee-pi\n" +
+					"other-app\trunning\tother-app\n" +
+					"plain\trunning\t\n",
+			), nil
+		}}
+	})
+
+	containers, err := cheaseePiContainers()
+	if err != nil {
+		t.Fatalf("cheaseePiContainers: %v", err)
+	}
+	if len(containers) != 3 {
+		t.Fatalf("expected 3 cheasee-pi containers (workspace main + codeflow + legacy), got %d: %v", len(containers), containers)
+	}
+	byName := map[string]bool{}
+	for _, c := range containers {
+		byName[c.name] = c.running
+	}
+	if !byName["cheasee-pi-repoa"] {
+		t.Errorf("workspace main container must be enumerated (running), got %v", byName)
+	}
+	if !byName["codeflow-repoa"] {
+		t.Errorf("codeflow sidecar must be enumerated (running), got %v", byName)
+	}
+	if byName["cheasee-pi"] {
+		t.Errorf("legacy stopped container must be enumerated as not running, got %v", byName)
+	}
+	if _, ok := byName["other-app"]; ok {
+		t.Errorf("non-cheasee-pi project container must be excluded, got %v", byName)
+	}
+	if _, ok := byName["plain"]; ok {
+		t.Errorf("compose-less container must be excluded, got %v", byName)
+	}
+}
+
+func TestCheaseePiContainers_dockerPsFails(t *testing.T) {
+	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
+		return &mockCmd{outputFn: func() ([]byte, error) {
+			return nil, fmt.Errorf("docker daemon not running")
+		}}
+	})
+
+	if _, err := cheaseePiContainers(); err == nil {
+		t.Fatal("expected error when docker ps fails, got nil")
+	}
+}
+
+// ──────────────────────────────────────────────
+// clean: full flow — orphan scan + rm + prune
+// ──────────────────────────────────────────────
+
+// stubCleanDocker stubs the execCommand seam for runCleanE: docker ps -a
+// enumeration, per-container orphan-scan calls, docker rm, and the prune
+// commands. Records every rm invocation.
+func stubCleanDocker(t *testing.T, rmErr error) *[][]string {
+	t.Helper()
+	var rmCalls [][]string
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		switch {
+		case len(arg) > 0 && arg[0] == "ps" && slices.Contains(arg, "-a"):
+			// Enumeration: one running workspace container + one stopped legacy.
+			return &mockCmd{outputFn: func() ([]byte, error) {
+				return []byte("cheasee-pi-repoa\trunning\tcheasee-pi-repoa\ncheasee-pi\texited\tcheasee-pi\n"), nil
+			}}
+		case len(arg) > 0 && arg[0] == "ps":
+			// scanOrphans' running check — the workspace container is running.
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("cheasee-pi-repoa"), nil }}
+		case len(arg) > 0 && arg[0] == "exec":
+			// Orphan scan inside the running container kills one orphan.
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte("killing 42\n"), nil }}
+		case len(arg) > 0 && arg[0] == "rm":
+			rmCalls = append(rmCalls, append([]string{}, arg...))
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte(""), rmErr }}
+		case len(arg) > 0 && arg[0] == "images":
+			// pruneDanglingImages: dangling images exist → prune runs.
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("sha256:abc\n"), nil }}
+		default:
+			return &mockCmd{} // docker image prune / buildx prune succeed
+		}
+	})
+	return &rmCalls
+}
+
+func TestRunCleanE_removesAllCheaseePiContainers(t *testing.T) {
+	rmCalls := stubCleanDocker(t, nil)
+
+	stderr := testutil.CaptureStderr(t, func() {
+		if err := runCleanE(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runCleanE: %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "✓ Killed 1 orphaned pi process(es)") {
+		t.Errorf("orphan scan must report the killed process, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "✓ Removed 2 Cheasee-Pi container(s)") {
+		t.Errorf("clean must report the removed containers, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "✓ Pruned dangling Docker images") {
+		t.Errorf("clean must prune dangling images, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "✓ Pruned Docker build cache") {
+		t.Errorf("clean must prune build cache, got: %q", stderr)
+	}
+
+	// Every enumerated container — running workspace one and stopped legacy —
+	// is force-removed; the non-cheasee-pi project never reaches rm.
+	if len(*rmCalls) != 2 {
+		t.Fatalf("expected docker rm for 2 containers, got %d: %v", len(*rmCalls), *rmCalls)
+	}
+	for _, call := range *rmCalls {
+		if len(call) != 3 || call[0] != "rm" || call[1] != "-f" {
+			t.Errorf("rm invocation must be `docker rm -f <name>`, got %v", call)
+		}
+	}
+	if !slices.ContainsFunc(*rmCalls, func(c []string) bool { return c[2] == "cheasee-pi-repoa" }) {
+		t.Errorf("running workspace container must be removed, got %v", *rmCalls)
+	}
+	if !slices.ContainsFunc(*rmCalls, func(c []string) bool { return c[2] == "cheasee-pi" }) {
+		t.Errorf("stopped legacy container must be removed, got %v", *rmCalls)
+	}
+}
+
+func TestRunCleanE_orphanScanOnlyRunningContainers(t *testing.T) {
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		switch {
+		case len(arg) > 0 && arg[0] == "ps" && slices.Contains(arg, "-a"):
+			return &mockCmd{outputFn: func() ([]byte, error) {
+				return []byte("cheasee-pi-repoa\trunning\tcheasee-pi-repoa\ncheasee-pi-repob\texited\tcheasee-pi-repob\n"), nil
+			}}
+		case len(arg) > 0 && arg[0] == "ps":
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("cheasee-pi-repoa"), nil }}
+		case len(arg) > 0 && arg[0] == "exec":
+			if len(arg) > 1 && arg[1] == "cheasee-pi-repob" {
+				t.Errorf("orphan scan must only run inside running containers (repob is stopped), got exec for %v", arg)
+			}
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte(""), nil }}
+		case len(arg) > 0 && arg[0] == "rm":
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte(""), nil }}
+		default:
+			return &mockCmd{}
+		}
+	})
+
+	stderr := testutil.CaptureStderr(t, func() {
+		if err := runCleanE(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runCleanE: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "✓ Removed 2 Cheasee-Pi container(s)") {
+		t.Errorf("both containers must be removed, got: %q", stderr)
+	}
+}
+
+func TestRunCleanE_toleratesVanishedContainer(t *testing.T) {
+	// A container removed between enumeration and rm reports "No such
+	// container" — clean must not fail on it.
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		switch {
+		case len(arg) > 0 && arg[0] == "ps" && slices.Contains(arg, "-a"):
+			return &mockCmd{outputFn: func() ([]byte, error) {
+				return []byte("cheasee-pi-repoa\trunning\tcheasee-pi-repoa\n"), nil
+			}}
+		case len(arg) > 0 && arg[0] == "ps":
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("cheasee-pi-repoa"), nil }}
+		case len(arg) > 0 && arg[0] == "exec":
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte(""), nil }}
+		case len(arg) > 0 && arg[0] == "rm":
+			return &mockCmd{combinedFn: func() ([]byte, error) {
+				return []byte("Error: No such container: cheasee-pi-repoa"), fmt.Errorf("exit status 1")
+			}}
+		default:
+			return &mockCmd{}
+		}
+	})
+
+	if err := runCleanE(&cobra.Command{}, nil); err != nil {
+		t.Fatalf("clean must tolerate a vanished container, got %v", err)
+	}
+}
+
+func TestRunCleanE_rmFailureFails(t *testing.T) {
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		switch {
+		case len(arg) > 0 && arg[0] == "ps" && slices.Contains(arg, "-a"):
+			return &mockCmd{outputFn: func() ([]byte, error) {
+				return []byte("cheasee-pi-repoa\trunning\tcheasee-pi-repoa\n"), nil
+			}}
+		case len(arg) > 0 && arg[0] == "ps":
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("cheasee-pi-repoa"), nil }}
+		case len(arg) > 0 && arg[0] == "exec":
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte(""), nil }}
+		case len(arg) > 0 && arg[0] == "rm":
+			return &mockCmd{combinedFn: func() ([]byte, error) {
+				return []byte("permission denied"), fmt.Errorf("exit status 1")
+			}}
+		default:
+			return &mockCmd{}
+		}
+	})
+
+	err := runCleanE(&cobra.Command{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "docker rm") {
+		t.Fatalf("expected rm failure to fail clean, got %v", err)
+	}
+}
+
+func TestRunCleanE_noContainers(t *testing.T) {
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		if len(arg) > 0 && arg[0] == "ps" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte(""), nil }}
+		}
+		return &mockCmd{}
+	})
+
+	stderr := testutil.CaptureStderr(t, func() {
+		if err := runCleanE(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runCleanE: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "ℹ No Cheasee-Pi containers found") {
+		t.Errorf("empty enumeration must announce no containers, got: %q", stderr)
+	}
+}
+
+// sanity: runCleanE takes a context for the orphan scan without panicking.
+func TestRunCleanE_contextPassed(t *testing.T) {
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		return &mockCmd{}
+	})
+	ctx := context.Background()
+	cmd := &cobra.Command{}
+	cmd.SetContext(ctx)
+	if err := runCleanE(cmd, nil); err != nil {
+		t.Fatalf("runCleanE: %v", err)
+	}
+}

--- a/cmd/cheasee-pi/down.go
+++ b/cmd/cheasee-pi/down.go
@@ -13,13 +13,16 @@ var downCmd = &cobra.Command{
 	Use:     "down",
 	Aliases: []string{"stop"},
 	Short:   "Stop and remove the Docker container",
-	Long: `Stop and remove the Cheasee-Pi Docker container via docker compose down.
+	Long: `Stop and remove the Docker container belonging to this workspace.
 
-The compose file resolves from the CLI-managed cache dir (same project name
-'cheasee-pi' as start), so down works from any directory.
+The compose project is the workspace's per-repo project (cheasee-pi-<repo>,
+resolved from the CLI-managed cache dir like start), so down only stops and
+removes this workspace's container — parallel workspaces with other
+repositories keep running untouched. Outside a workspace, the legacy shared
+'cheasee-pi' project is targeted.
 
 Examples:
-  cheasee-pi down                # stop default container`,
+  cheasee-pi down                # stop current workspace's container`,
 	DisableAutoGenTag: true,
 	RunE:              runDownE,
 }

--- a/cmd/cheasee-pi/embedded/docker/docker-compose.yml
+++ b/cmd/cheasee-pi/embedded/docker/docker-compose.yml
@@ -9,6 +9,13 @@
 # Usage (via wrapper):
 #   cheasee-pi start
 #
+# The compose project is per-repository: `cheasee-pi start` sets
+# COMPOSE_PROJECT_NAME to cheasee-pi-<repo> (derived from the workspace's
+# bare-clone remote), so two workspaces with different repositories run as
+# independent compose projects with independent containers. The top-level
+# name: below is only the fallback for direct compose usage without the CLI
+# (and for the pre-per-repo single-container setup).
+#
 # Direct usage (compose resolves relative paths against this file's dir):
 #   docker compose -f <cacheDir>/docker-compose.yml up -d --build
 #   docker exec -it cheasee-pi /bin/bash -c 'cd /workspaces/main && pi'
@@ -61,9 +68,11 @@ services:
     #
     #   http://localhost:8470/?repo=local/workspace&run=1
     #
-    # Port mapping: host side via CODEFLOW_PORT (default 8470), container side
-    # from the "port" key in config.json (default 8470) — keep them in sync
-    # when changing either.
+    # Port mapping: host side via CODEFLOW_PORT — `cheasee-pi start` derives a
+    # per-repo port (8470 + repo-slug hash, 8470–9469) so parallel containers
+    # don't collide on the fixed default; an explicit CODEFLOW_PORT env var
+    # overrides. Container side from the "port" key in config.json (default
+    # 8470) — keep them in sync when changing either.
     build:
       context: codeflow
     container_name: ${CODEFLOW_CONTAINER:-codeflow}

--- a/cmd/cheasee-pi/settings_test.go
+++ b/cmd/cheasee-pi/settings_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -451,6 +452,10 @@ func TestApplyComposeEnv_ignoresPISettings(t *testing.T) {
 	if !slices.Contains(cmd.env, "CODEFLOW_CONTAINER="+codeflowContainerName(workdir)) {
 		t.Errorf("CODEFLOW_CONTAINER must carry the repo-slug codeflow name, got %v", cmd.env)
 	}
+	// No workspace root (no cheasee-settings.json) → legacy shared project.
+	if !slices.Contains(cmd.env, "COMPOSE_PROJECT_NAME=cheasee-pi") {
+		t.Errorf("outside a workspace the compose project must fall back to 'cheasee-pi', got %v", cmd.env)
+	}
 }
 
 func TestApplyComposeEnv_readsCheaseeSettings(t *testing.T) {
@@ -469,6 +474,73 @@ func TestApplyComposeEnv_readsCheaseeSettings(t *testing.T) {
 
 	if !strings.Contains(stderr, "Using memory limit 4G from cheasee-settings.json") {
 		t.Errorf("memory limit announcement missing, got: %q", stderr)
+	}
+}
+
+// Per-repo compose project: inside a workspace the project is the repo-slug
+// container name, so parallel workspaces are independent compose projects.
+func TestApplyComposeEnv_setsPerRepoComposeProject(t *testing.T) {
+	workdir := t.TempDir()
+	testutil.WriteCheaseeSettingsFile(t, workdir, `{}`)
+
+	cmd := &mockCmd{}
+	applyComposeEnv(cmd, workdir, containerName(workdir))
+
+	want := containerName(workdir)
+	if !slices.Contains(cmd.env, "COMPOSE_PROJECT_NAME="+want) {
+		t.Errorf("COMPOSE_PROJECT_NAME must carry the per-repo project %q, got %v", want, cmd.env)
+	}
+}
+
+func TestComposeProject_fallsBackOutsideWorkspace(t *testing.T) {
+	if got := composeProject(t.TempDir()); got != "cheasee-pi" {
+		t.Errorf("composeProject outside a workspace = %q, want cheasee-pi", got)
+	}
+}
+
+// Codeflow host port derivation: deterministic per repo, inside the derived
+// range, distinct across repositories, and skipped when CODEFLOW_PORT is set.
+func TestCodeflowPort_deterministicAndInRange(t *testing.T) {
+	rootA := t.TempDir()
+
+	portA := codeflowPort(rootA)
+	if codeflowPort(rootA) != portA {
+		t.Errorf("codeflowPort must be deterministic per workspace, got %q then %q", portA, codeflowPort(rootA))
+	}
+	n, err := strconv.Atoi(portA)
+	if err != nil || n < codeflowPortBase || n >= codeflowPortBase+codeflowPortSpan {
+		t.Errorf("codeflowPort %q must be an int in [%d, %d)", portA, codeflowPortBase, codeflowPortBase+codeflowPortSpan)
+	}
+
+	// Distinct repo slugs → distinct derived ports (fixed inputs, so this is
+	// deterministic — a collision would be a genuine defect worth catching).
+	slugA, slugB := "repo-alpha", "repo-beta"
+	if pA, pB := codeflowPortForSlug(slugA), codeflowPortForSlug(slugB); pA == pB {
+		t.Errorf("distinct slugs must derive distinct ports, both %q", pA)
+	}
+}
+
+// Explicit CODEFLOW_PORT wins over the derivation: applyComposeEnv must not
+// append a second, derived CODEFLOW_PORT when the process env already sets it.
+func TestCodeflowPort_envOverrideWins(t *testing.T) {
+	workdir := t.TempDir()
+	testutil.WriteCheaseeSettingsFile(t, workdir, `{}`)
+	t.Setenv("CODEFLOW_PORT", "9999")
+
+	cmd := &mockCmd{}
+	applyComposeEnv(cmd, workdir, containerName(workdir))
+
+	count := 0
+	for _, e := range cmd.env {
+		if strings.HasPrefix(e, "CODEFLOW_PORT=") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("explicit CODEFLOW_PORT must not be overridden by a derived value, got %d CODEFLOW_PORT entries: %v", count, cmd.env)
+	}
+	if !slices.Contains(cmd.env, "CODEFLOW_PORT=9999") {
+		t.Errorf("explicit CODEFLOW_PORT=9999 must pass through, got %v", cmd.env)
 	}
 }
 

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -3,11 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -369,6 +371,42 @@ func codeflowContainerName(workspaceRoot string) string {
 	return "codeflow-" + repoSlug(workspaceRoot)
 }
 
+// composeProject is the compose project name for a workspace: the per-repo
+// project "cheasee-pi-<repo>" inside a workspace (parallel repos = parallel
+// compose projects = independent containers, so `up`/`down` in one workspace
+// never touches another's container), falling back to the legacy shared
+// project "cheasee-pi" outside a workspace (`down` from a non-workspace
+// directory keeps targeting the old single container).
+func composeProject(workspaceRoot string) string {
+	if _, err := os.Stat(cheaseeSettingsPath(workspaceRoot)); err == nil {
+		return containerName(workspaceRoot)
+	}
+	return "cheasee-pi"
+}
+
+// codeflowPortBase is the lowest host port codeflowPort derives from;
+// codeflowPortSpan yields 1000 distinct per-repo ports (8470–9469).
+const (
+	codeflowPortBase = 8470
+	codeflowPortSpan = 1000
+)
+
+// codeflowPort derives a host port for the codeflow sidecar from the repo
+// slug: codeflowPortBase + fnv32a(slug) mod codeflowPortSpan. Deterministic
+// per repository, so parallel workspaces bind different host ports; an
+// explicit CODEFLOW_PORT env var overrides the derivation.
+func codeflowPort(workspaceRoot string) string {
+	return codeflowPortForSlug(repoSlug(workspaceRoot))
+}
+
+// codeflowPortForSlug is codeflowPort's slug-level core, separated for tests
+// that want a port for a fixed slug without a workspace fixture.
+func codeflowPortForSlug(slug string) string {
+	h := fnv.New32a()
+	h.Write([]byte(slug))
+	return strconv.Itoa(codeflowPortBase + int(h.Sum32()%codeflowPortSpan))
+}
+
 // repoSlug is the docker-safe repo name for a workspace: the sibling bare
 // repo's remote URL repository name when resolvable, else the workspace
 // basename. Lowercased, non-alphanumerics → '-'
@@ -421,7 +459,18 @@ func applyComposeEnv(cmd runner, workspaceHostPath, containerName string) {
 		// distinct containers (compose interpolates them into container_name).
 		"CHEASEEPI_CONTAINER="+containerName,
 		"CODEFLOW_CONTAINER="+codeflowContainerName(workspaceHostPath),
+		// Per-repo compose project (COMPOSE_PROJECT_NAME outranks the top-level
+		// name: in the compose file — env is the only reliable interpolation
+		// point for the project name): parallel workspaces are separate compose
+		// projects, so up/down/clean in one never touches another's containers.
+		"COMPOSE_PROJECT_NAME="+composeProject(workspaceHostPath),
 	)
+	// Codeflow host port: derived per repo (8470 + slug hash) so parallel
+	// containers don't collide on the fixed default; CODEFLOW_PORT from the
+	// process env (already in os.Environ) overrides the derivation.
+	if os.Getenv("CODEFLOW_PORT") == "" {
+		env = append(env, "CODEFLOW_PORT="+codeflowPort(workspaceHostPath))
+	}
 	if os.Getenv("CHEASEEPI_SELINUX_RELABEL") == "1" {
 		env = append(env, "VOLUME_RELABEL=:Z")
 		fmt.Fprintf(os.Stderr, "  ℹ SELinux relabeling enabled: appending :Z to bind mounts\n")

--- a/docker/test/cli-install-smoke.test.mts
+++ b/docker/test/cli-install-smoke.test.mts
@@ -416,10 +416,10 @@ describe("CLI install smoke", { timeout: 600_000 }, () => {
 
 	it("checkpoint 9 — cheasee-pi down removes container", () => {
 		// down resolves the per-repo compose project (cheasee-pi-<slug>) from
-		// the workspace root like start — no --workdir needed. The workspace
-		// root is found via cheasee-settings.json and the slug via the seeded
-		// sibling bare repo's remote, matching checkpoint 5's project exactly.
-		const result = exec(`"${BINARY_PATH}" down`, { timeout: 60_000 });
+		// the workspace root like start — run inside the workspace so
+		// findWorkspaceRoot finds cheasee-settings.json, and the slug via the
+		// seeded sibling bare repo's remote, matching checkpoint 5's project.
+		const result = exec(`"${BINARY_PATH}" down`, { timeout: 60_000, cwd: workdir });
 		assert.strictEqual(result.status, 0, `down exited ${result.status}: ${result.stderr}`);
 		assert.ok(
 			result.stderr.includes("Container stopped and removed"),

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,8 +52,8 @@ Or manually from the [latest release](https://github.com/SchneiderDaniel/cheasee
 cheasee-pi init           # empty-folder setup: repo URL, auth, bare clone + worktree,
                           # scaffold gitignored cheasee-settings.json
 cheasee-pi start          # empty folder → auto-init; workspace → start pi (default)
-cheasee-pi down           # stop and remove container
-cheasee-pi clean          # kill orphaned pi sessions + prune Docker garbage
+cheasee-pi down           # stop and remove current workspace's container
+cheasee-pi clean          # remove all cheasee-pi containers (all repos) + prune garbage
 cheasee-pi build          # rebuild container image (Dockerfile/entrypoint changes)
 cheasee-pi auth add       # add API key for a provider
 cheasee-pi auth list      # list configured providers/keys

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -85,10 +85,14 @@ docker compose -f ~/.cache/cheasee-pi/<version>/docker-compose.yml up -d
 
 The stack includes a local CodeFlow service: a browser-based visualizer that renders
 the workspace's module dependency graph, call structure, and architecture (tree-sitter
-AST parsing, 18 languages). It starts automatically with `docker compose up -d` and
-serves on port 8470.
+AST parsing, 18 languages). It starts automatically with `docker compose up -d`.
 
-Open it in the browser:
+The host port is derived per repository: `cheasee-pi start` maps it to
+8470 + a stable hash of the repo slug (range 8470–9469), so parallel workspaces
+with different repositories never collide on the same host port. An explicit
+`CODEFLOW_PORT` environment variable overrides the derivation.
+
+Open it in the browser (default port 8470 for a single-workspace setup):
 
 ```
 http://localhost:8470/?repo=local/workspace&run=1
@@ -106,12 +110,13 @@ read-only, editable without rebuilding the image):
 
 | Key | Default | Purpose |
 | --- | --- | --- |
-| `port` | `8470` | Listen port; keep the compose mapping (`CODEFLOW_PORT:8470`) in sync when changed |
+| `port` | `8470` | Container-side listen port; keep the compose mapping in sync when changed (host side is per-repo via `CODEFLOW_PORT`) |
 | `host` | `0.0.0.0` | Bind address; `127.0.0.1` restricts access to localhost |
 | `exclude_dirs` | `[".git", "node_modules", "ignore"]` | Directory names skipped during the file walk |
 
 Configuration changes take effect on the next `docker compose up -d` (no rebuild
-required). The compose port mapping uses `CODEFLOW_PORT` for the host side.
+required). The compose port mapping uses `CODEFLOW_PORT` for the host side; the CLI
+derives a per-repo default when the variable is unset.
 
 ### Limitations
 
@@ -158,11 +163,16 @@ docker exec -it \
 > **Tip:** For automatic API key injection from `~/.config/cheasee-pi/auth.json`, use
 > `cheasee-pi start` instead.
 
-## Parallel sessions
+## Parallel workspaces
 
-You can run multiple pi sessions against the same container simultaneously from
-different terminals. Each `docker exec` creates an independent process on the same
-container — they do not share a TUI or stdin.
+Each workspace (folder with its own repository) runs its own container: the
+container name and compose project are derived from the repository
+(`cheasee-pi-<repo>`), so two workspaces with different repositories keep
+their containers running side by side — `start`, `down`, and the orphan scan
+in one workspace never touch another's container. Within one workspace you can
+run multiple pi sessions against the same container simultaneously from
+different terminals. Each `docker exec` creates an independent process on the
+same container — they do not share a TUI or stdin.
 
 ```bash
 # Terminal 1
@@ -175,7 +185,7 @@ docker exec -it --user agentuser -w /workspaces/main cheasee-pi pi
 ### Stale process cleanup
 
 Pi processes can become orphaned if a `docker exec` session disconnects or the
-wrapper is killed before cleanup runs. These accumulate RAM (150–280 MB each).
+wrapper is killed before cleanup runs. These accumulate RAM (150–280 MB each).
 
 **Cleanup command:**
 
@@ -183,8 +193,11 @@ wrapper is killed before cleanup runs. These accumulate RAM (150–280 MB each
 cheasee-pi clean
 ```
 
-This scans for processes reparented to PID 1 and kills them. It only targets
-orphans — interactive sessions are **not** affected.
+This removes **all** Cheasee-Pi containers (every repository's workspace
+container plus the codeflow sidecars), first killing orphaned pi processes
+inside the running ones, then pruning dangling images and build cache. It only
+targets orphans — interactive sessions are **not** affected — and only
+containers belonging to a `cheasee-pi` compose project are removed.
 
 **Automatic pre-start cleanup:** `cheasee-pi start` / `cheasee-pi up` runs the
 same orphan scan before launching pi, so orphans are always cleaned between
@@ -198,8 +211,10 @@ sessions.
 cheasee-pi down
 ```
 
-`cheasee-pi down` (alias `cheasee-pi stop`) stops and removes the container via
-`docker compose down` (resolved from the CLI cache dir, same project name as start).
+`cheasee-pi down` (alias `cheasee-pi stop`) stops and removes the container of
+the current workspace via `docker compose down` — the compose project is the
+workspace's per-repo project (`cheasee-pi-<repo>`), so parallel workspaces
+with other repositories keep running untouched.
 
 ### Full teardown (removes container)
 


### PR DESCRIPTION
## Description

Fixes the fixed single-container identity so multiple workspaces with different repositories can run in parallel, each with its own container.

Per-repository container names already existed (`cheasee-pi-<repo>`); this PR makes the rest of the lifecycle per-repository too:

- **Compose project name** is now derived per repository (`COMPOSE_PROJECT_NAME=cheasee-pi-<repo>`, set by the CLI). Parallel workspaces are independent compose projects — `start`/`down` in one workspace never recreates or removes another's container (the root cause of the original collision: a shared project with per-repo `container_name` still made the second `up` take over the first workspace's container). Outside a workspace, `down` falls back to the legacy `cheasee-pi` project.
- **`cheasee-pi clean`** now enumerates every container belonging to a `cheasee-pi` compose project (per-repo projects + the legacy shared one; main container and codeflow sidecar alike), kills orphaned pi processes inside the running ones, removes them all, and prunes dangling images + build cache. Previously it never removed containers and only scanned the current workspace.
- **CodeFlow host port** is derived per repo (8470 + fnv32a(slug) % 1000, range 8470–9469) so parallel containers do not bind the same host port. An explicit `CODEFLOW_PORT` env var still overrides.
- `cheasee-pi start --name` remains a verbatim override for the container name.

## Related issue

Closes #1503

## Changes

- `cmd/cheasee-pi/up.go` — `applyComposeEnv` sets per-repo `COMPOSE_PROJECT_NAME` and derived `CODEFLOW_PORT`; new `composeProject`/`codeflowPort` helpers
- `cmd/cheasee-pi/clean.go` — rewrite: enumerate by compose project label, orphan-scan running containers, `docker rm -f` all, prune
- `cmd/cheasee-pi/down.go` — help text documents per-workspace targeting
- `cmd/cheasee-pi/embedded/docker/docker-compose.yml` — comments document the per-repo project and port derivation
- `cmd/cheasee-pi/clean_test.go` (new), `settings_test.go` — enumeration/filter, clean flow (scan→rm→prune), project fallback, port derivation + override tests
- `docs/daily-usage.md`, `docs/README.md` — parallel-workspace, clean, down, and codeflow port documentation

## Testing

- [x] `go build ./cmd/cheasee-pi/` passes
- [x] `go test ./cmd/cheasee-pi/ -count=1` passes (full suite, including the new clean/port/project tests)
- [ ] `npm test` passes
- [ ] `npm run tsc:extensions` passes
- [x] Tests cover the changes (where applicable)

## Checklist

- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] No sensitive data committed (secrets, credentials, tokens)
- [x] PR description clearly states what changed and why

## Notes for the reviewer

The supervisor worktree-creation failure that triggered the manual intervention has a separate root cause: the container image predates commit 2682d023 (which added `chown agentuser:agentuser /workspaces` to the Dockerfile **and** the entrypoint fallback for `/workspaces`). The fix is already at HEAD — restart/rebuild the container image to pick it up. No code change was needed for it.
