### PR TITLE
feat(#1504): [Feature] One-shot first run: init, build and start pi in a single invocation

### DIFF
--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -37,6 +37,12 @@ var newInitDeps = func(workdir string) InitDeps {
 // It is a constant so both the CLI and documentation stay in sync.
 const nextStepHint = "cheasee-pi start"
 
+// initTimeout bounds a single init invocation — device-flow OAuth polling
+// dominates the window. Shared by standalone init (runInitE) and start-
+// triggered init (runUpE's empty-folder branch) so both cap the auth window
+// identically instead of polling until the ~900 s device-code expiry.
+const initTimeout = 5 * time.Minute
+
 var (
 	initAPIKey        string
 	initNoDockerCheck bool
@@ -70,8 +76,13 @@ type InitDeps struct {
 	ClientID      string
 	RepoURL       string
 	Workdir       string
-	ConfirmFn     func(string) (bool, error)
-	InputFn       func(title, placeholder string) (string, error)
+	// InStartFlow marks init as triggered by `cheasee-pi start`'s empty-folder
+	// branch: the completion message drops the standalone "Next step:
+	// cheasee-pi start" hint because start continues automatically. Zero value
+	// (false) = standalone init, backward compatible.
+	InStartFlow bool
+	ConfirmFn   func(string) (bool, error)
+	InputFn     func(title, placeholder string) (string, error)
 }
 
 // Validate checks that all required dependencies for the active path are non-nil.
@@ -132,7 +143,7 @@ func runInitE(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(context.Background(), 5*time.Minute)
+		ctx, cancel = context.WithTimeout(context.Background(), initTimeout)
 		defer cancel()
 	}
 
@@ -225,28 +236,48 @@ func runInit(ctx context.Context, deps InitDeps) error {
 		}
 	}
 
-	// Phase 6: Scaffold cheasee-settings.json (never overwrites)
-	if err := runInitScaffold(ctx, deps); err != nil {
-		return fmt.Errorf("settings scaffold: %w", err)
-	}
-
-	// Phase 7: Save auth config
-	if err := cfg.Save(ctx, auth); err != nil {
-		return fmt.Errorf("save auth config: %w", err)
-	}
-
-	path, _ := cfg.Path()
-	fmt.Fprintf(os.Stderr, "  ✓ Auth config saved to %s\n", path)
-
-	// Phase 8: API key setup for pi providers (interactive only)
-	if !deps.NoInput {
-		if err := runInitAPIKeys(ctx, cfg, deps.Workdir, deps.ConfirmFn); err != nil {
-			return fmt.Errorf("API key setup: %w", err)
+	// Phases 6-8 (scaffold → save auth → API key setup) run post-clone; a
+	// failure here would strand a folder that both init (non-empty probe) and
+	// start (WorkspaceRefuse) refuse — the freshly cloned residue (worktree +
+	// sibling .bare) is removed before the error surfaces. The empty-folder
+	// probe guarantees only freshly cloned + scaffolded files exist, so removal
+	// cannot destroy user data.
+	postCloneErr := func() error {
+		// Phase 6: Scaffold cheasee-settings.json (never overwrites)
+		if err := runInitScaffold(ctx, deps); err != nil {
+			return fmt.Errorf("settings scaffold: %w", err)
 		}
+
+		// Phase 7: Save auth config
+		if err := cfg.Save(ctx, auth); err != nil {
+			return fmt.Errorf("save auth config: %w", err)
+		}
+
+		path, _ := cfg.Path()
+		fmt.Fprintf(os.Stderr, "  ✓ Auth config saved to %s\n", path)
+
+		// Phase 8: API key setup for pi providers (interactive only)
+		if !deps.NoInput {
+			if err := runInitAPIKeys(ctx, cfg, deps.Workdir, deps.ConfirmFn); err != nil {
+				return fmt.Errorf("API key setup: %w", err)
+			}
+		}
+		return nil
+	}()
+	if postCloneErr != nil {
+		removeInitResidue(deps.Workdir)
+		return postCloneErr
 	}
 
-	fmt.Fprintf(os.Stderr, "\n✅ Init complete! Next step:\n")
-	fmt.Fprintf(os.Stderr, "   %s\n", nextStepHint)
+	// Completion message. Standalone `cheasee-pi init` points at the next
+	// step; start-triggered init (InStartFlow) continues into start
+	// automatically, so no second-invocation hint is printed.
+	if deps.InStartFlow {
+		fmt.Fprintf(os.Stderr, "\n✅ Init complete.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "\n✅ Init complete! Next step:\n")
+		fmt.Fprintf(os.Stderr, "   %s\n", nextStepHint)
+	}
 	return nil
 }
 

--- a/cmd/cheasee-pi/init_clone.go
+++ b/cmd/cheasee-pi/init_clone.go
@@ -104,3 +104,22 @@ func gitCloneWorktree(ctx context.Context, repoURL, workdir string) error {
 	fmt.Fprintf(os.Stderr, "  ✓ Cloned (bare + worktree) to %s\n", workdir)
 	return nil
 }
+
+// removeInitResidue best-effort cleans a half-initialized workspace after a
+// post-clone init failure (scaffold/auth-save/API-key phase): the main
+// worktree plus the sibling .bare. The empty-folder probe guarantees only
+// freshly cloned + scaffolded files exist in the workdir, so removal cannot
+// destroy user data. Missing worktree/.bare is a silent no-op (best-effort
+// by contract); mirrors gitCloneWorktree's clone-failure cleanup paths.
+func removeInitResidue(workdir string) {
+	bareDir := filepath.Join(filepath.Dir(workdir), ".bare")
+
+	fmt.Fprintf(os.Stderr, "  ⚠ Init failed — removing incomplete workspace residue (worktree + .bare).\n")
+
+	// Prune the bare's worktree registration first (best-effort — a
+	// stubbed/incomplete worktree errors here, harmless), then remove the
+	// worktree dir and the sibling .bare outright.
+	_ = runCommandContext(context.Background(), "git", "--git-dir", bareDir, "worktree", "remove", "--force", workdir).Run()
+	os.RemoveAll(workdir)
+	os.RemoveAll(bareDir)
+}

--- a/cmd/cheasee-pi/init_clone_test.go
+++ b/cmd/cheasee-pi/init_clone_test.go
@@ -367,6 +367,38 @@ func TestGitCloneWorktree_realGitMasterDefault(t *testing.T) {
 	}
 }
 
+// ──────────────────────────────────────────────
+// removeInitResidue (post-clone failure cleanup)
+// ──────────────────────────────────────────────
+
+func TestRemoveInitResidue_realGitLayout(t *testing.T) {
+	// Adapter: on a real git worktree layout, removeInitResidue removes the
+	// worktree dir (incl. its .git file) plus the sibling .bare.
+	src := gitRemoteFixture(t, "main")
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "main")
+	bareDir := cloneWorktreeLayout(t, src, parent, workdir)
+
+	removeInitResidue(workdir)
+
+	if _, err := os.Stat(workdir); !os.IsNotExist(err) {
+		t.Errorf("removeInitResidue must remove the worktree dir: %v", err)
+	}
+	if _, err := os.Stat(bareDir); !os.IsNotExist(err) {
+		t.Errorf("removeInitResidue must remove the sibling .bare: %v", err)
+	}
+}
+
+func TestRemoveInitResidue_missingIsNoOp(t *testing.T) {
+	// Best-effort by contract: nothing was ever cloned → silent no-op, no
+	// error, no panic, parent untouched.
+	parent := t.TempDir()
+	removeInitResidue(filepath.Join(parent, "ws"))
+	if _, err := os.Stat(parent); err != nil {
+		t.Errorf("parent must be untouched: %v", err)
+	}
+}
+
 func TestGitCloneWorktree_e2eWorktreeFix(t *testing.T) {
 	// Acceptance "verified by execution": after clone+scaffold+gitignore
 	// append, running worktree-fix.sh against the fixture layout (via its

--- a/cmd/cheasee-pi/init_scaffold_test.go
+++ b/cmd/cheasee-pi/init_scaffold_test.go
@@ -194,3 +194,30 @@ func TestInit_SuccessMessage(t *testing.T) {
 		t.Error("success message must contain the checkmark and 'Init complete'")
 	}
 }
+
+func TestInit_SuccessMessageInStartFlow(t *testing.T) {
+	// Start-triggered init (InStartFlow) prints "✅ Init complete" WITHOUT the
+	// standalone "Next step: cheasee-pi start" hint — start continues into
+	// the launch automatically.
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	testutil.RedirectConfigHome(t)
+
+	output := testutil.CaptureStderr(t, func() {
+		err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
+			d.NoGitHub = true
+			d.APIKey = FakeAPIKey
+			d.InStartFlow = true
+		}))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	if !strings.Contains(output, "✅ Init complete") {
+		t.Error("success message must contain the checkmark and 'Init complete'")
+	}
+	if strings.Contains(output, "Next step:") || strings.Contains(output, "cheasee-pi start") {
+		t.Errorf("start-triggered init must not print the second-invocation hint, got: %q", output)
+	}
+}

--- a/cmd/cheasee-pi/init_split_test.go
+++ b/cmd/cheasee-pi/init_split_test.go
@@ -26,6 +26,7 @@ var initSplitFiles = []string{
 // decl placed in the wrong file (or renamed) fails the test.
 var wantInitDecls = map[string]string{
 	"const:nextStepHint": "init.go",
+	"const:initTimeout":  "init.go",
 	"var:initAPIKey,initNoDockerCheck,initWorkdir,initNoGitHub,initClientID,initProvider,initNoInput,initRepoURL": "init.go",
 	"var:newInitDeps":     "init.go",
 	"type:InitPorts":      "init.go",
@@ -38,7 +39,8 @@ var wantInitDecls = map[string]string{
 	"func:runInitProbe":   "init.go",
 	"func:resolveRepoURL": "init.go",
 
-	"func:gitCloneWorktree": "init_clone.go",
+	"func:gitCloneWorktree":  "init_clone.go",
+	"func:removeInitResidue": "init_clone.go",
 
 	"func:runInitAuth":    "init_auth.go",
 	"func:runInitAPIKeys": "init_auth.go",
@@ -220,6 +222,7 @@ var runInitFlowDecls = map[string]string{
 // TestRunInitScaffold before TestRunInitProbe).
 var testSplitRules = []prefixRule{
 	{"TestGitCloneWorktree", "init_clone_test.go"},
+	{"TestRemoveInitResidue", "init_clone_test.go"},
 	{"TestParseGitHubURL", "init_clone_test.go"},
 	{"TestRedactToken", "init_clone_test.go"},
 	{"TestRunInitAuth", "init_auth_test.go"},

--- a/cmd/cheasee-pi/init_usecase_test.go
+++ b/cmd/cheasee-pi/init_usecase_test.go
@@ -3,11 +3,15 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cli/oauth/api"
+	"github.com/cli/oauth/device"
+
+	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
 func TestInitUseCase_DockerNotInstalled(t *testing.T) {
@@ -194,6 +198,74 @@ func TestInitProbe_SettingsPresentRefuses(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "cheasee-pi start") {
 		t.Errorf("refusal should point at `cheasee-pi start`, got: %v", err)
+	}
+}
+
+func TestInitUseCase_PostCloneFailureCleansResidue(t *testing.T) {
+	// A post-clone init failure (API-key phase) removes the freshly cloned
+	// worktree + sibling .bare, announces the cleanup, and leaves the folder
+	// empty — otherwise both init (non-empty probe) and start (WorkspaceRefuse)
+	// would refuse the stranded folder.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	stubInitGit(t)
+
+	deps := initDepsWithRepoURL(t, workdir, func(d *InitDeps) {
+		d.ConfirmFn = mockConfirmFn(false, fmt.Errorf("declined"))
+	})
+	stderr := testutil.CaptureStderr(t, func() {
+		err := runInit(context.Background(), deps)
+		if err == nil || !strings.Contains(err.Error(), "API key setup") {
+			t.Fatalf("expected API-key setup failure, got %v", err)
+		}
+	})
+
+	if !strings.Contains(stderr, "removing incomplete workspace residue") {
+		t.Errorf("cleanup must be announced to stderr, got: %q", stderr)
+	}
+	if _, statErr := os.Stat(workdir); !os.IsNotExist(statErr) {
+		t.Errorf("post-clone failure must remove the worktree: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, ".bare")); !os.IsNotExist(statErr) {
+		t.Errorf("post-clone failure must remove .bare: %v", statErr)
+	}
+}
+
+func TestInitUseCase_PreCloneFailureLeavesNoResidue(t *testing.T) {
+	// Pre-clone failure (device-flow/auth error) → no cleanup call and no
+	// .bare created (nothing to remove).
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	deps := initDeps(t, func(d *InitDeps) {
+		d.Workdir = workdir
+		d.NoInput = false
+		d.InputFn = mockInputFn("owner/repo", nil)
+		d.Ports = InitPorts{Auth: &mockAuthenticator{
+			waitFunc: func(ctx context.Context, code *device.CodeResponse) (*api.AccessToken, error) {
+				return nil, fmt.Errorf("device flow wait failed: user cancelled")
+			},
+		}}
+	})
+
+	err := runInit(context.Background(), deps)
+	if err == nil || !strings.Contains(err.Error(), "GitHub authentication failed") {
+		t.Fatalf("expected auth failure, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, ".bare")); !os.IsNotExist(statErr) {
+		t.Errorf("pre-clone failure must leave no .bare: %v", statErr)
 	}
 }
 

--- a/cmd/cheasee-pi/installation_doc_test.go
+++ b/cmd/cheasee-pi/installation_doc_test.go
@@ -113,6 +113,41 @@ func TestInstallationDoc_GoCliPathVersion(t *testing.T) {
 	}
 }
 
+// TestInstallationDoc_OneShotFirstRun verifies the empty-folder gate bullet
+// describes the single-invocation flow (init + start in one run) — the
+// two-step "run start again" handoff is gone.
+func TestInstallationDoc_OneShotFirstRun(t *testing.T) {
+	data, err := os.ReadFile(docPath())
+	if err != nil {
+		t.Fatalf("reading docs/installation.md: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "then you run `start` again") {
+		t.Error("installation.md must not describe a two-step first run (run start again)")
+	}
+	if !strings.Contains(content, "same invocation") {
+		t.Error("installation.md should describe the one-shot continuation (init + start in the same invocation)")
+	}
+}
+
+// TestDailyUsageDoc_OneShotFirstRun verifies daily-usage.md describes the
+// single-invocation auto-init continuation instead of a two-step handoff.
+func TestDailyUsageDoc_OneShotFirstRun(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "daily-usage.md"))
+	if err != nil {
+		t.Fatalf("reading docs/daily-usage.md: %v", err)
+	}
+	content := string(data)
+
+	if strings.Contains(content, "auto-inits first.") {
+		t.Error("daily-usage.md must not describe auto-init as a standalone step (no continuation)")
+	}
+	if !strings.Contains(content, "same invocation") {
+		t.Error("daily-usage.md should describe the single-invocation auto-init continuation")
+	}
+}
+
 // TestInstallationDoc_Path verifies that Step 5 bullet 8 of the installation
 // doc matches the path that config.go:fileRepository.configPath() actually
 // writes to — the XDG user config dir, not the legacy ~/.pi/agent/auth.json.
@@ -126,7 +161,7 @@ func TestInstallationDoc_Path(t *testing.T) {
 	// The doc must use the XDG user config directory path (matches
 	// filepath.Join(userConfigDir, "cheasee-pi", "auth.json") in config.go).
 	if !strings.Contains(content, "cheasee-pi/auth.json") &&
-		!strings.Contains(content, "cheasee-pi" + string(os.PathSeparator) + "auth.json") {
+		!strings.Contains(content, "cheasee-pi"+string(os.PathSeparator)+"auth.json") {
 		t.Error("Step 5 bullet 8 should reference cheasee-pi/auth.json (XDG path suffix from config.go)")
 	}
 

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -36,8 +36,9 @@ CLI-managed cache dir; the dedicated cheasee-settings.json (gitignored,
 machine-local) is the initialized marker.
 
 Empty folder → runs cheasee-pi init first (bare clone + main worktree +
-cheasee-settings.json). Non-empty folder without cheasee-settings.json is
-refused — run 'cheasee-pi init' in an empty folder.
+cheasee-settings.json), then continues into start in the same invocation.
+Non-empty folder without cheasee-settings.json is refused — run 'cheasee-pi
+init' in an empty folder.
 
 The image clones the cheasee-pi repo at build time (Dockerfile ARG
 CHEASEE_REF) for its .pi resources. Reads provider API keys from
@@ -88,17 +89,41 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	// firstRun marks the one-shot path: init ran in this invocation, so the
+	// pre-exec confirmation announces the workspace setup (init's own
+	// completion message drops the standalone next-step hint via InStartFlow).
+	firstRun := false
 	if state == WorkspaceEmpty {
 		if upDryRun {
-			fmt.Fprintf(os.Stderr, "  ℹ %s is empty — would run `cheasee-pi init` (bare clone + main worktree + cheasee-settings.json), then `cheasee-pi start` again.\n", workdir)
+			fmt.Fprintf(os.Stderr, "  ℹ %s is empty — would run `cheasee-pi init` (bare clone + main worktree + cheasee-settings.json), then `cheasee-pi start` — init and start in one invocation.\n", workdir)
 			return nil
 		}
 		fmt.Fprintf(os.Stderr, "  ℹ %s is empty — running `cheasee-pi init` first...\n", workdir)
-		if err := runInit(ctx, newInitDeps(workdir)); err != nil {
-			return fmt.Errorf("auto-init failed: %w", err)
+		// Init is time-bounded (device-flow OAuth polling dominates the window);
+		// the continuation after it stays unbounded — image build + npm install
+		// legitimately exceed 5 minutes.
+		initCtx, cancel := context.WithTimeout(ctx, initTimeout)
+		deps := newInitDeps(workdir)
+		deps.InStartFlow = true
+		initErr := runInit(initCtx, deps)
+		cancel()
+		if initErr != nil {
+			return fmt.Errorf("auto-init failed: %w", initErr)
 		}
-		fmt.Fprintf(os.Stderr, "  ℹ Init complete — run `cheasee-pi start` again to launch pi.\n")
-		return nil
+		firstRun = true
+
+		// Re-resolve the workspace state: the continuation needs the resolved
+		// root for container name / compose mounts (the empty state resolved
+		// root=""), and the re-classification fails closed when init left no
+		// settings marker — a worktree without cheasee-settings.json is a
+		// folder both init and start refuse.
+		root, state, err = resolveStartWorkspace(workdir)
+		if err != nil {
+			return err
+		}
+		if state != WorkspaceInitialized {
+			return fmt.Errorf("auto-init left %q non-empty without cheasee-settings.json — remove the worktree/.bare residue and re-run `cheasee-pi start` in an empty folder", workdir)
+		}
 	}
 	if state == WorkspaceRefuse {
 		return fmt.Errorf("not initialized: %q is not empty and has no cheasee-settings.json — run `cheasee-pi init` in an empty folder first", workdir)
@@ -201,7 +226,12 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(os.Stderr, "  ✓ Killed %d orphaned pi process(es)\n", len(killed))
 	}
 
-	// Phase 8: exec pi
+	// Phase 8: exec pi — the one-shot confirmation must print BEFORE the
+	// blocking exec (a post-exec message would only appear when the session
+	// ends).
+	if firstRun {
+		fmt.Fprintf(os.Stderr, "  ✓ Workspace set up — starting pi...\n")
+	}
 	execErr := execPIContainer(upName, envMap, target)
 
 	// The docker exec client just exited (user quit or disconnected). Reap the

--- a/cmd/cheasee-pi/up_flow_test.go
+++ b/cmd/cheasee-pi/up_flow_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -161,10 +162,6 @@ func stubAutoInitDeps(t *testing.T) {
 	t.Cleanup(func() { newInitDeps = saved })
 }
 
-// ──────────────────────────────────────────────
-// Phase 1: workspace classifier (entity)
-// ──────────────────────────────────────────────
-
 func TestClassifyWorkspace_empty(t *testing.T) {
 	state, err := classifyWorkspace(t.TempDir())
 	if err != nil {
@@ -284,6 +281,9 @@ func TestRunUpE_dryRunOnEmptyFolder(t *testing.T) {
 	if !strings.Contains(stderr, "would run `cheasee-pi init`") {
 		t.Errorf("dry-run on empty must announce the would-be init, got: %q", stderr)
 	}
+	if !strings.Contains(stderr, "one invocation") {
+		t.Errorf("dry-run on empty must describe the one-shot continuation, got: %q", stderr)
+	}
 	if _, err := os.Stat(filepath.Join(workdir, "cheasee-settings.json")); !os.IsNotExist(err) {
 		t.Errorf("dry-run must not scaffold cheasee-settings.json: %v", err)
 	}
@@ -329,9 +329,21 @@ func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
 	setUpRunMode(t, workdir, false)
 	testutil.RedirectConfigHome(t)
 	testutil.SetGitConfig(t, testGitIdentityConfig)
+	// Stub order matters: stubUpFlow installs the execCommand/runCommandContext
+	// seams the continuation needs and must sit before stubInitGit so init's
+	// clone chains to stubUpFlow's docker/version handlers.
 	stubDockerCheck(t, nil, "24.0.9", nil)
+	c := stubUpFlow(t, workdir, false)
 	stubInitGit(t)
 	stubAutoInitDeps(t)
+	exec := stubExecPIContainer(t)
+	// Ordering pin: the one-shot confirmation must print BEFORE the blocking
+	// exec (a post-exec message would only appear when the session ends).
+	savedExec := execPIContainer
+	execPIContainer = func(name string, env map[string]string, target string) error {
+		fmt.Fprintf(os.Stderr, "EXEC-INVOKED\n")
+		return savedExec(name, env, target)
+	}
 
 	stderr := testutil.CaptureStderr(t, func() {
 		if err := runUpE(&cobra.Command{}, nil); err != nil {
@@ -345,8 +357,17 @@ func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
 	if !strings.Contains(stderr, "Cloned (bare + worktree)") {
 		t.Errorf("user should see the clone notice during auto-init, got: %q", stderr)
 	}
-	if !strings.Contains(stderr, "run `cheasee-pi start` again") {
-		t.Errorf("auto-init must hand off to a second start, got: %q", stderr)
+	if strings.Contains(stderr, "run `cheasee-pi start` again") {
+		t.Errorf("one-shot start must not hand off to a second start, got: %q", stderr)
+	}
+	if strings.Contains(stderr, "Next step:") {
+		t.Errorf("start-triggered init must not print the standalone next-step hint, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "starting pi") {
+		t.Errorf("one-shot start must confirm pi is starting, got: %q", stderr)
+	}
+	if i, j := strings.Index(stderr, "starting pi"), strings.Index(stderr, "EXEC-INVOKED"); i < 0 || j < 0 || i > j {
+		t.Errorf("'starting pi' confirmation must precede the exec invocation, stderr: %q", stderr)
 	}
 	// Init artifacts: worktree checked out, sibling .bare, settings at root.
 	if _, err := os.Stat(filepath.Join(workdir, "cheasee-settings.json")); err != nil {
@@ -360,6 +381,30 @@ func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
 	}
 	if !authJSONExists(t) {
 		t.Error("auto-init must save auth.json")
+	}
+
+	// Continuation: compose build + up from the cache dir with the two sibling
+	// mounts, then exec into the derived container.
+	if len(c.composeArgs) != 2 {
+		t.Errorf("one-shot start must build + up via compose, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
+	}
+	cacheDir, err := CacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	composeFile := filepath.Join(cacheDir, "docker-compose.yml")
+	if len(c.composeArgs) == 2 && (!slices.Contains(c.composeArgs[0], composeFile) || !slices.Contains(c.composeArgs[1], "up")) {
+		t.Errorf("compose must build + up from the cache dir, got %v", c.composeArgs)
+	}
+	if exec.name != containerName(workdir) || exec.target != "/workspaces/main" {
+		t.Errorf("exec must target -w /workspaces/main in container %q, got name=%q target=%q", containerName(workdir), exec.name, exec.target)
+	}
+	upEnv := c.composeCmds[1].env
+	if !slices.Contains(upEnv, "WORKSPACE_HOST_PATH="+workdir) {
+		t.Errorf("up env must carry WORKSPACE_HOST_PATH=%s, got %v", workdir, upEnv)
+	}
+	if !slices.Contains(upEnv, "WORKSPACE_BARE_PATH="+filepath.Join(parent, ".bare")) {
+		t.Errorf("up env must carry WORKSPACE_BARE_PATH=%s, got %v", filepath.Join(parent, ".bare"), upEnv)
 	}
 }
 
@@ -375,8 +420,10 @@ func TestRunUpE_autoInitMatchesRunInit(t *testing.T) {
 	testutil.RedirectConfigHome(t)
 	testutil.SetGitConfig(t, testGitIdentityConfig)
 	stubDockerCheck(t, nil, "24.0.9", nil)
+	stubUpFlow(t, dirA, false)
 	stubInitGit(t)
 	stubAutoInitDeps(t)
+	stubExecPIContainer(t)
 
 	if err := runUpE(&cobra.Command{}, nil); err != nil {
 		t.Fatalf("runUpE: %v", err)
@@ -406,6 +453,208 @@ func TestRunUpE_autoInitMatchesRunInit(t *testing.T) {
 	}
 }
 
+func TestRunUpE_autoInitMissingMarkerFailsClosed(t *testing.T) {
+	// init returns nil but leaves no settings marker (ConfirmFn deletes
+	// cheasee-settings.json during the API-key phase and declines) → the
+	// post-init re-resolution re-classifies the folder as non-initialized and
+	// start fails closed naming the residue; no compose, no exec.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	setUpRunMode(t, workdir, false)
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	c := stubUpFlow(t, workdir, false)
+	stubInitGit(t)
+	stubExecPIContainer(t)
+	saved := newInitDeps
+	newInitDeps = func(wd string) InitDeps {
+		deps := initDepsWithRepoURL(t, wd)
+		deps.ConfirmFn = func(title string) (bool, error) {
+			if strings.Contains(title, "Configure API keys") {
+				_ = os.Remove(filepath.Join(wd, "cheasee-settings.json"))
+				return false, nil
+			}
+			return true, nil
+		}
+		return deps
+	}
+	t.Cleanup(func() { newInitDeps = saved })
+
+	err := runUpE(&cobra.Command{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "worktree/.bare residue") {
+		t.Fatalf("expected fail-closed error naming the residue, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cheasee-pi start") {
+		t.Errorf("refusal should point at re-running start in an empty folder, got %v", err)
+	}
+	if len(c.composeArgs) != 0 {
+		t.Errorf("missing marker must never reach compose, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
+	}
+}
+
+func TestRunUpE_autoInitFailureSurfaces(t *testing.T) {
+	// init fails in the API-key phase → error wrapped 'auto-init failed' and
+	// the freshly cloned residue (worktree + .bare) is cleaned to an empty
+	// folder; no compose, no exec.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	setUpRunMode(t, workdir, false)
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	c := stubUpFlow(t, workdir, false)
+	stubInitGit(t)
+	stubExecPIContainer(t)
+	saved := newInitDeps
+	newInitDeps = func(wd string) InitDeps {
+		deps := initDepsWithRepoURL(t, wd)
+		deps.ConfirmFn = mockConfirmFn(false, fmt.Errorf("declined"))
+		return deps
+	}
+	t.Cleanup(func() { newInitDeps = saved })
+
+	stderr := testutil.CaptureStderr(t, func() {
+		err := runUpE(&cobra.Command{}, nil)
+		if err == nil || !strings.Contains(err.Error(), "auto-init failed") {
+			t.Fatalf("expected 'auto-init failed' wrap, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "API key setup") {
+			t.Errorf("error should carry the underlying API-key setup failure, got %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "removing incomplete workspace residue") {
+		t.Errorf("cleanup must be announced to stderr, got: %q", stderr)
+	}
+	// Residue cleaned: worktree + .bare removed, folder left empty.
+	if _, statErr := os.Stat(workdir); !os.IsNotExist(statErr) {
+		t.Errorf("failed auto-init must remove the worktree residue: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(parent, ".bare")); !os.IsNotExist(statErr) {
+		t.Errorf("failed auto-init must remove .bare: %v", statErr)
+	}
+	if len(c.composeArgs) != 0 {
+		t.Errorf("failed init must not reach compose, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
+	}
+}
+
+func TestRunUpE_autoInitContinuationDockerRecheck(t *testing.T) {
+	// runInit's docker check (call 1) passes; the continuation's re-check
+	// (call 2) fails → error surfaces post-init, no compose. The re-check is
+	// a UX gate after a long OAuth stall, not a correctness requirement.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	setUpRunMode(t, workdir, false)
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubInitGit(t)
+	stubAutoInitDeps(t)
+	stubExecPIContainer(t)
+
+	var infoCalls int
+	saved := runCommandContext
+	stubRunCommandContext(t, func(ctx context.Context, name string, arg ...string) runner {
+		if name == "docker" && len(arg) > 0 && arg[0] == "info" {
+			infoCalls++
+			if infoCalls > 1 {
+				return &mockCmd{runFn: func() error { return fmt.Errorf("Cannot connect to the Docker daemon") }}
+			}
+			return &mockCmd{}
+		}
+		if name == "docker" && len(arg) > 0 && arg[0] == "version" {
+			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("24.0.9"), nil }}
+		}
+		return saved(ctx, name, arg...)
+	})
+	stubLookPath(t, func(_ string) (string, error) { return "/usr/bin/docker", nil })
+	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
+		return &mockCmd{}
+	})
+
+	err := runUpE(&cobra.Command{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "not running") {
+		t.Fatalf("expected continuation docker-check failure, got %v", err)
+	}
+	if infoCalls != 2 {
+		t.Errorf("docker check must run twice on the one-shot path (init + continuation), got %d", infoCalls)
+	}
+}
+
+func TestRunUpE_autoInitPreCancelledFailsFast(t *testing.T) {
+	// A pre-cancelled parent ctx propagates into the 5-min initTimeout child
+	// ctx → auto-init fails fast with the ctx error; no compose, no exec.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	setUpRunMode(t, workdir, false)
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	c := stubUpFlow(t, workdir, false)
+	stubInitGit(t)
+	stubAutoInitDeps(t)
+	stubExecPIContainer(t)
+
+	cmd := &cobra.Command{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cmd.SetContext(ctx)
+
+	err := runUpE(cmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("expected fast ctx cancellation, got %v", err)
+	}
+	if len(c.composeArgs) != 0 {
+		t.Errorf("cancelled auto-init must not reach compose, got %d invocations", len(c.composeArgs))
+	}
+}
+
+func TestRunUpE_autoInitDsStoreOnlyFolder(t *testing.T) {
+	// A Finder-touched folder (.DS_Store only) classifies as empty and takes
+	// the same one-shot path.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(workdir, ".DS_Store"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	setUpRunMode(t, workdir, false)
+	testutil.RedirectConfigHome(t)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	c := stubUpFlow(t, workdir, false)
+	stubInitGit(t)
+	stubAutoInitDeps(t)
+	exec := stubExecPIContainer(t)
+
+	if err := runUpE(&cobra.Command{}, nil); err != nil {
+		t.Fatalf("runUpE: %v", err)
+	}
+	if len(c.composeArgs) != 2 {
+		t.Errorf(".DS_Store-only folder must take the one-shot path (build + up), got %d: %v", len(c.composeArgs), c.composeArgs)
+	}
+	if exec.name != containerName(workdir) {
+		t.Errorf(".DS_Store-only one-shot must exec into %q, got %q", containerName(workdir), exec.name)
+	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 1: workspace classifier (entity)
+// ──────────────────────────────────────────────
+
 func TestRunUpE_fullFlowRunsContainer(t *testing.T) {
 	_, root := mkWorkspace(t, `{"docker": {"memory": "2G", "cpus": "2.0"}, "gitIdentity": {"name": "Test User", "email": "test@example.com"}}`)
 	setUpRunMode(t, root, false)
@@ -424,6 +673,11 @@ func TestRunUpE_fullFlowRunsContainer(t *testing.T) {
 	}
 	if strings.Contains(stderr, "Created .pi/settings.json") {
 		t.Errorf("start must not announce a .pi/settings.json scaffold, got: %q", stderr)
+	}
+	// Regression: the one-shot confirmation is auto-init-only — an initialized
+	// workspace start must not print it.
+	if strings.Contains(stderr, "starting pi") {
+		t.Errorf("initialized-workspace start must not print the first-run confirmation, got: %q", stderr)
 	}
 
 	// Compose invoked from the version-keyed cache dir: build then up.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,9 @@ The repo root is bind-mounted at `/workspaces/main`. Host UID/GID are mapped to 
 `cheasee-pi start` gates on the workspace state instead of “is a git repo”:
 
 - **Empty folder** → auto-runs `cheasee-pi init` (repo-URL prompt → bare clone
-  to `<parent>/.bare` + `worktree add --detach` → `cheasee-settings.json`).
+  to `<parent>/.bare` + `worktree add --detach` → `cheasee-settings.json`),
+  then falls through into the normal start phases in the same invocation
+  (docker check → compose up → exec pi).
 - **`cheasee-settings.json` present** → initialized; runs normally.
 - **Non-empty folder without settings** → refused (“not initialized; run
   `cheasee-pi init` in an empty folder”).

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -26,7 +26,8 @@ Before running pi via Docker, ensure the following are in place:
 - **First-time build complete** — the Docker image must be built at least once. See [Start](#start-the-container) below.
 - **A cheasee-pi workspace** — run `cheasee-pi init` in an empty folder to set
   one up (bare clone + main worktree + `cheasee-settings.json`), or just run
-  `cheasee-pi start` in an empty folder — it auto-inits first.
+  `cheasee-pi start` in an empty folder — it auto-inits first and continues
+  into start in the same invocation.
 
 The container mounts `~/.config/gh/` read-write, so host GitHub authentication works
 automatically inside the container.
@@ -136,9 +137,10 @@ cheasee-pi
 ```
 
 `cheasee-pi` (no subcommand, alias `start`) gates on the workspace: empty
-folder → auto-runs `cheasee-pi init`; `cheasee-settings.json` present → runs;
-non-empty folder without settings → refused with a hint to run init. It then
-starts the container if needed, reads `~/.config/cheasee-pi/auth.json`,
+folder → auto-runs `cheasee-pi init` and continues into start in the same
+invocation; `cheasee-settings.json` present → runs; non-empty folder without
+settings → refused with a hint to run init. It then starts the container if
+needed, reads `~/.config/cheasee-pi/auth.json`,
 injects API keys as env vars, and launches pi with your repo mounted at
 `/workspaces/main`.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,7 +106,8 @@ cheasee-pi start
 `cheasee-pi` (alias `start`) gates on the workspace state:
 
 - **Empty folder** → auto-runs `cheasee-pi init` (repo URL prompt, bare clone
-  + main worktree, `cheasee-settings.json`), then you run `start` again
+  + main worktree, `cheasee-settings.json`), then continues into `start` in
+  the same invocation — one command sets the workspace up and starts pi
 - **`cheasee-settings.json` present** → initialized workspace; runs normally
 - **Non-empty folder without `cheasee-settings.json`** → refused with
   “not initialized; run `cheasee-pi init` in an empty folder”


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1504

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 8m 22s | 134.4K | 70 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 54s | 57.1K | 46 | minimax-m3 |

**Total:** 2 agents · 10m 15s · 191.5K tokens · 116 tool calls · 4 failed (3%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1504
Closes #1504