### PR TITLE
feat(#1526): [Feature] Per-issue supervisor run lock: restore parallel pipelines on different issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 private-pi/
 
 .pi/sessions
-.pi/supervisor-state.json
+.pi/supervisor-state*.json
+.pi/supervisor-run*.json
 .pi/state/session-extensions.json
 node_modules
 tmp

--- a/.pi/extensions/supervisor/pipeline/handler/index.ts
+++ b/.pi/extensions/supervisor/pipeline/handler/index.ts
@@ -10,7 +10,12 @@ import { preparePipelineContext, runPreflight } from "./preflight.ts";
 import { runAgentLoop } from "./agent-loop.ts";
 import { runPostPipelinePhase } from "./post-pipeline.ts";
 import { cleanupWorktree } from "../worktree.ts";
-import { acquireRunLock, deleteCheckpointFile, releaseRunLock } from "../state-checkpoint.ts";
+import {
+	acquireRunLock,
+	deleteCheckpointFile,
+	isAnyOtherPipelineLive,
+	releaseRunLock,
+} from "../state-checkpoint.ts";
 import { sendPipelineError } from "../notifications.ts";
 import { getDebugLogger, resetDebugLogger } from "../../lib/debug.ts";
 
@@ -49,9 +54,10 @@ async function runSupervisorPipeline(
 	if (!runCtx) return;
 
 	try {
-		// One pipeline per repo — a concurrent run would race on the same
+		// One pipeline per issue — two runs of the same issue race on the same
 		// worktree path (second run reuses the live worktree, first finisher
 		// removes it under the other's agent). Refuse to start instead.
+		// Different issues get different worktree paths and run in parallel.
 		const lockRes = acquireRunLock(runCtx.ctx.cwd, runCtx.issueNum);
 		if (!lockRes.ok) {
 			runCtx.collector.push("handler", "error", lockRes.error);
@@ -81,7 +87,7 @@ async function runSupervisorPipeline(
 		}
 		// Delete checkpoint file on error (idempotent)
 		{
-			const delResult = deleteCheckpointFile(runCtx.ctx.cwd);
+			const delResult = deleteCheckpointFile(runCtx.ctx.cwd, runCtx.issueNum);
 			if (!delResult.ok) {
 				getDebugLogger().warn(
 					"handler",
@@ -100,11 +106,15 @@ async function runSupervisorPipeline(
 		);
 	} finally {
 		// Release the run lock (idempotent — only removed if we own it)
-		releaseRunLock(runCtx.ctx.cwd);
+		releaseRunLock(runCtx.ctx.cwd, runCtx.issueNum);
 
-		// Clear supervisor issue data from footer (any outcome)
+		// Clear supervisor issue data from footer (any outcome) — but only
+		// when no OTHER pipeline is live: with two same-host terminals, the
+		// first finisher must not clear the second run's footer.
 		// Uses shared pi.events bus instead of dynamic import.
-		pi.events.emit("supervisor:issue-data", null);
+		if (!isAnyOtherPipelineLive(runCtx.ctx.cwd, runCtx.issueNum)) {
+			pi.events.emit("supervisor:issue-data", null);
+		}
 
 		// Teardown signal handlers so they don't leak beyond pipeline
 		if (runCtx.crashCleanup) {

--- a/.pi/extensions/supervisor/pipeline/handler/post-pipeline.ts
+++ b/.pi/extensions/supervisor/pipeline/handler/post-pipeline.ts
@@ -162,7 +162,7 @@ export async function handlePostPipeline(
 			}
 		}
 		// Delete checkpoint file on pipeline completion (idempotent)
-		const delResult = deleteCheckpointFile(ctx.cwd);
+		const delResult = deleteCheckpointFile(ctx.cwd, issueNum);
 		if (!delResult.ok) {
 			getDebugLogger().warn("handler", `Failed to delete checkpoint: ${delResult.error}`);
 		}

--- a/.pi/extensions/supervisor/pipeline/state-checkpoint.ts
+++ b/.pi/extensions/supervisor/pipeline/state-checkpoint.ts
@@ -10,6 +10,14 @@
 // State transitions: pre-tsc → pre-lsp → pre-auditor → completed
 // On completion, the state file is deleted.
 //
+// Both the run lock and the checkpoint are keyed per issue:
+//   .pi/supervisor-run-<issueNum>.json
+//   .pi/supervisor-state-<issueNum>.json
+// Two pipelines on DIFFERENT issues run in parallel (worktree paths are
+// per-issue); two pipelines on the SAME issue still serialize on the
+// per-issue lock. The scanner also matches the legacy bare-name
+// `supervisor-state.json` so a mid-upgrade orphan is still cleaned up.
+//
 // Boundaries:
 //   - state-checkpoint.ts — file format, write atomicity, staleness logic
 //   - handler.ts — startup cleanup, auditor checkpoint, completion delete
@@ -46,7 +54,15 @@ export interface SupervisorCheckpointState {
 
 // ─── Constants ─────────────────────────────────────────────────────
 
-const STATE_FILE_NAME = "supervisor-state.json";
+/**
+ * Matches per-issue checkpoint names (`supervisor-state-1503.json`) plus
+ * the legacy bare-name file (`supervisor-state.json`) left behind by the
+ * pre-per-issue build. The `.tmp` suffix never matches.
+ */
+const STATE_FILE_RE = /^supervisor-state(?:-\d+)?\.json$/;
+
+/** Matches per-issue run lock files: `supervisor-run-1503.json`. */
+const RUN_LOCK_FILE_RE = /^supervisor-run-(\d+)\.json$/;
 
 /**
  * Default max age for stale checkpoint detection: 1 hour.
@@ -55,18 +71,39 @@ const STATE_FILE_NAME = "supervisor-state.json";
  */
 const DEFAULT_MAX_AGE_MS = 3_600_000; // 1 hour
 
+/** Bounded retries for the run-lock steal race (read → unlink → write). */
+const MAX_ACQUIRE_ATTEMPTS = 3;
+
 // ─── Internal Helpers ─────────────────────────────────────────────
 
-function stateFilePath(cwd: string): string {
-	return resolve(cwd, ".pi", STATE_FILE_NAME);
+function checkpointFilePath(cwd: string, issueNum: number): string {
+	return resolve(cwd, ".pi", `supervisor-state-${issueNum}.json`);
 }
 
 function isCheckpointName(val: string): val is CheckpointName {
 	return val === "pre-tsc" || val === "pre-lsp" || val === "pre-auditor";
 }
 
+/** All matching state files directly inside a `.pi` directory. */
+function stateFilesInPiDir(piDir: string): string[] {
+	const results: string[] = [];
+	try {
+		if (!existsSync(piDir)) {
+			return results;
+		}
+		for (const f of readdirSync(piDir)) {
+			if (STATE_FILE_RE.test(f)) {
+				results.push(join(piDir, f));
+			}
+		}
+	} catch {
+		// Unreadable — no files found
+	}
+	return results;
+}
+
 /**
- * Recursively find all `supervisor-state.json` files under a directory.
+ * Recursively find all `supervisor-state*.json` files under a directory.
  * Scans direct child directories only (1 level deep) — worktree dirs are
  * flat under worktreeBase.
  */
@@ -76,28 +113,16 @@ function findStateFiles(baseDir: string): string[] {
 		const entries = readdirSync(baseDir, { withFileTypes: true });
 		for (const entry of entries) {
 			if (entry.isDirectory()) {
-				const statePath = join(baseDir, entry.name, ".pi", STATE_FILE_NAME);
-				if (existsSync(statePath)) {
-					results.push(statePath);
-				}
-			}
-			// Also check directly in baseDir (state file could be in baseDir/.pi/)
-			if (entry.name === ".pi" && entry.isDirectory()) {
-				const statePath = join(baseDir, ".pi", STATE_FILE_NAME);
-				if (existsSync(statePath)) {
-					results.push(statePath);
-				}
+				// Worktree subdir: <wt>/.pi/supervisor-state*.json
+				results.push(...stateFilesInPiDir(join(baseDir, entry.name, ".pi")));
 			}
 		}
-		// Also check baseDir/.pi/supervisor-state.json directly
-		const directStatePath = join(baseDir, ".pi", STATE_FILE_NAME);
-		if (existsSync(directStatePath)) {
-			results.push(directStatePath);
-		}
+		// Also baseDir/.pi directly
+		results.push(...stateFilesInPiDir(join(baseDir, ".pi")));
 	} catch {
 		// Directory doesn't exist or can't be read — no files found
 	}
-	return results;
+	return [...new Set(results)];
 }
 
 // ─── Pure Functions ───────────────────────────────────────────────
@@ -167,7 +192,9 @@ export function readCheckpointFileFromPath(filePath: string): SupervisorCheckpoi
 }
 
 /**
- * Write checkpoint state atomically to `.pi/supervisor-state.json`.
+ * Write checkpoint state atomically to `.pi/supervisor-state-<issueNum>.json`.
+ * The file name derives from `state.issueNum`, so parallel pipelines on
+ * different issues never clobber each other's checkpoint.
  *
  * Atomic pattern: write to temp file → rename (atomic on same filesystem).
  * This prevents truncated JSON on crash mid-write.
@@ -178,8 +205,8 @@ export function readCheckpointFileFromPath(filePath: string): SupervisorCheckpoi
  */
 export function writeCheckpointFile(cwd: string, state: SupervisorCheckpointState): Result<void> {
 	const stateDir = resolve(cwd, ".pi");
-	const targetPath = resolve(stateDir, STATE_FILE_NAME);
-	const tmpPath = resolve(stateDir, `${STATE_FILE_NAME}.tmp`);
+	const targetPath = checkpointFilePath(cwd, state.issueNum);
+	const tmpPath = resolve(stateDir, `supervisor-state-${state.issueNum}.json.tmp`);
 
 	try {
 		// Ensure .pi directory exists
@@ -217,15 +244,15 @@ export function writeCheckpointFile(cwd: string, state: SupervisorCheckpointStat
 }
 
 /**
- * Delete the checkpoint state file at `.pi/supervisor-state.json`.
+ * Delete the checkpoint state file at `.pi/supervisor-state-<issueNum>.json`.
  * Idempotent — returns ok even if the file doesn't exist.
  */
-export function deleteCheckpointFile(cwd: string): Result<void> {
-	const filePath = stateFilePath(cwd);
+export function deleteCheckpointFile(cwd: string, issueNum: number): Result<void> {
+	const filePath = checkpointFilePath(cwd, issueNum);
 	try {
 		if (existsSync(filePath)) {
 			unlinkSync(filePath);
-			getDebugLogger().info("state-checkpoint", "Checkpoint file deleted");
+			getDebugLogger().info("state-checkpoint", "Checkpoint file deleted", { issueNum });
 		}
 		return { ok: true, value: undefined };
 	} catch (err: unknown) {
@@ -236,24 +263,24 @@ export function deleteCheckpointFile(cwd: string): Result<void> {
 }
 
 // ─── Run Lock ────────────────────────────────────────────────────
-// One pipeline per repo, enforced. The supervisor design is single-run:
-// a shared .pi/supervisor-state.json, one shared bare repo and one shared
-// worktree base. Nothing enforced it — with N pi terminals open, two runs
-// of the same issue raced on the same worktree path: the second run's
-// createWorktree silently reused the live worktree (dir-exists fallback)
-// and whichever run finished first removed the worktree under the other's
-// agent ("Working directory does not exist" / "Worktree missing").
-// The lock is PID-backed: a crashed run leaves a dead PID behind, and the
-// next run takes over instead of waiting out a timestamp.
+// One pipeline per issue, enforced. Worktree paths are per-issue
+// (`worktree-git-issue-<num>-<slug>`), so two runs of DIFFERENT issues
+// never race on a worktree and run in parallel. Two runs of the SAME
+// issue still race on the same worktree path (the second run's
+// createWorktree silently reuses the live worktree, and whichever run
+// finishes first removes it under the other's agent) — that race is what
+// the per-issue lock guards. The lock is PID-backed: a crashed run leaves
+// a dead PID behind, and the next run takes over instead of waiting out a
+// timestamp.
 
-export interface RunLock {
+interface RunLock {
 	pid: number;
 	issueNum: number;
 	startedAt: string; // ISO 8601
 }
 
-function runLockPath(cwd: string): string {
-	return resolve(cwd, ".pi", "supervisor-run.json");
+function runLockPath(cwd: string, issueNum: number): string {
+	return resolve(cwd, ".pi", `supervisor-run-${issueNum}.json`);
 }
 
 /** True if a process with this PID exists (same container → same PID namespace). */
@@ -285,14 +312,19 @@ function readRunLock(path: string): RunLock | null {
 }
 
 /**
- * Acquire the per-repo run lock. Fails (ok:false) when another pipeline
- * is live; steals the lock when the holder's PID is dead (crashed run).
- * Atomic via `wx` (exclusive create) — a simultaneous-acquire race loses
- * cleanly and the loser re-checks the winner's liveness.
+ * Acquire the per-issue run lock. Fails (ok:false) when another pipeline
+ * for the SAME issue is live; steals the lock when the holder's PID is
+ * dead (crashed run). Atomic via `wx` (exclusive create).
+ *
+ * Steal-race loop: read → unlink → write is not atomic; if two runs steal
+ * the same stale lock simultaneously, one wins the `wx` create and the
+ * loser's write gets EEXIST. The loop re-checks the winner's liveness (a
+ * fresh winner is live → clean "already running" error) and retries a
+ * still-stale lock, bounded by MAX_ACQUIRE_ATTEMPTS.
  */
 export function acquireRunLock(cwd: string, issueNum: number): Result<void> {
 	const stateDir = resolve(cwd, ".pi");
-	const path = runLockPath(cwd);
+	const path = runLockPath(cwd, issueNum);
 	const ownLock: RunLock = {
 		pid: process.pid,
 		issueNum,
@@ -302,30 +334,40 @@ export function acquireRunLock(cwd: string, issueNum: number): Result<void> {
 		if (!existsSync(stateDir)) {
 			mkdirSync(stateDir, { recursive: true });
 		}
-		const writeLock = () => writeFileSync(path, JSON.stringify(ownLock), { flag: "wx" });
-		try {
-			writeLock();
-			return { ok: true, value: undefined };
-		} catch (err: unknown) {
-			if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
-				throw err;
+		for (let attempt = 0; attempt < MAX_ACQUIRE_ATTEMPTS; attempt++) {
+			try {
+				writeFileSync(path, JSON.stringify(ownLock), { flag: "wx" });
+				return { ok: true, value: undefined };
+			} catch (err: unknown) {
+				if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+					throw err;
+				}
+			}
+			// Lock exists — live holder blocks, dead holder gets taken over
+			const existing = readRunLock(path);
+			if (existing && pidAlive(existing.pid)) {
+				return {
+					ok: false,
+					error:
+						`Another supervisor pipeline is already running (pid ${existing.pid}, issue #${existing.issueNum}, started ${existing.startedAt}). ` +
+						"One pipeline at a time per repo — wait for it to finish or stop it first.",
+					source: "run-lock",
+				};
+			}
+			// Stale lock (crashed holder) — steal it and retry the write.
+			try {
+				unlinkSync(path);
+			} catch {
+				// Another acquirer stole it between read and unlink — loop
+				// retries and re-checks the winner's liveness.
 			}
 		}
-		// Lock exists — live holder blocks, dead holder gets taken over
-		const existing = readRunLock(path);
-		if (existing && pidAlive(existing.pid)) {
-			return {
-				ok: false,
-				error:
-					`Another supervisor pipeline is already running (pid ${existing.pid}, issue #${existing.issueNum}, started ${existing.startedAt}). ` +
-					"One pipeline at a time per repo — wait for it to finish or stop it first.",
-				source: "run-lock",
-			};
-		}
-		// Stale lock (crashed holder) — steal it
-		unlinkSync(path);
-		writeLock();
-		return { ok: true, value: undefined };
+		// Persistent EEXIST (unstealable path) — give up after bounded retries.
+		return {
+			ok: false,
+			error: `Failed to acquire run lock: EEXIST after ${MAX_ACQUIRE_ATTEMPTS} attempts`,
+			source: "run-lock",
+		};
 	} catch (err: unknown) {
 		const msg = err instanceof Error ? err.message : String(err);
 		getDebugLogger().error("run-lock", `Failed to acquire run lock: ${msg}`);
@@ -333,16 +375,46 @@ export function acquireRunLock(cwd: string, issueNum: number): Result<void> {
 	}
 }
 
-/** Release the run lock — only if we own it (PID match). Idempotent, best-effort. */
-export function releaseRunLock(cwd: string): void {
+/** Release the run lock for an issue — only if we own it (PID match). Idempotent, best-effort. */
+export function releaseRunLock(cwd: string, issueNum: number): void {
 	try {
-		const lock = readRunLock(runLockPath(cwd));
+		const lock = readRunLock(runLockPath(cwd, issueNum));
 		if (lock && lock.pid === process.pid) {
-			unlinkSync(runLockPath(cwd));
+			unlinkSync(runLockPath(cwd, issueNum));
 		}
 	} catch {
 		// Best-effort — nothing to do
 	}
+}
+
+/**
+ * True when any OTHER issue's run lock is held by a live process.
+ * Used to decide whether a completing pipeline may clear the shared
+ * footer: with two same-host pipelines, the first finisher must not
+ * clear the second run's footer data.
+ *
+ * Corrupt/unreadable lock files are treated as not live.
+ */
+export function isAnyOtherPipelineLive(cwd: string, excludeIssueNum: number): boolean {
+	try {
+		const stateDir = resolve(cwd, ".pi");
+		if (!existsSync(stateDir)) {
+			return false;
+		}
+		for (const entry of readdirSync(stateDir)) {
+			const m = RUN_LOCK_FILE_RE.exec(entry);
+			if (!m || Number(m[1]) === excludeIssueNum) {
+				continue;
+			}
+			const lock = readRunLock(join(stateDir, entry));
+			if (lock && pidAlive(lock.pid)) {
+				return true;
+			}
+		}
+	} catch {
+		// Unreadable dir — treat as no live pipeline
+	}
+	return false;
 }
 
 // ─── Cleanup Function ─────────────────────────────────────────────
@@ -351,12 +423,18 @@ export function releaseRunLock(cwd: string): void {
  * Scan for stale supervisor state checkpoint files and clean up their worktrees.
  *
  * Searches in two locations:
- * 1. The main repo's `.pi/supervisor-state.json`
- * 2. All worktree subdirectories under `worktreeBase` that contain `.pi/supervisor-state.json`
+ * 1. The main repo's `.pi/` (per-issue files + legacy bare-name)
+ * 2. All worktree subdirectories under `worktreeBase` that contain `.pi/supervisor-state*.json`
  *
  * For each stale checkpoint (age > maxAgeMs), removes the worktree and branch.
  * - Wraps each git command in try-catch so failure of one doesn't block others.
  * - Skips self-cleanup: never cleans a checkpoint whose `worktreePath` matches `currentWorktreePath`.
+ * - Liveness guard: never cleans a checkpoint whose per-issue run lock is held
+ *   by a live process — with per-issue parallelism, run B's preflight must not
+ *   prune run A's live worktree just because A's last checkpoint is >1h old.
+ *   The lock lives in the main repo `.pi/`, so it survives partial worktree
+ *   removal (the `recoverStaleWorktreeRegistration` scenario stays covered).
+ *   A dead-PID lock does not protect — the crash case still cleans.
  * - Non-blocking: if cleanup of one stale checkpoint fails, logs warning and continues to the next.
  * - Runs `git worktree prune` before `git worktree remove --force` so git admin data is synced.
  * - Includes `rm -rf` fallback for the worktree directory after git operations succeed.
@@ -387,19 +465,16 @@ export async function cleanupStalePipelineState(
 	// when the configured base is not writable (docker /workspaces overlay).
 	const baseDir = resolveWorktreeBase(cwd, worktreeBase, notify);
 
-	// Collect all supervisor-state.json files to check
+	// Collect all supervisor-state*.json files to check
 	const stateFiles: string[] = [];
 
-	// 1. Check main repo's .pi/supervisor-state.json
-	const mainStatePath = stateFilePath(cwd);
-	if (existsSync(mainStatePath)) {
-		stateFiles.push(mainStatePath);
-	}
+	// 1. Check main repo's .pi/ (per-issue + legacy bare-name)
+	stateFiles.push(...stateFilesInPiDir(resolve(cwd, ".pi")));
 
 	// 2. Scan worktree directories for state files
 	if (existsSync(baseDir)) {
 		const found = findStateFiles(baseDir);
-		// Deduplicate — mainStatePath already added
+		// Deduplicate — main state files already added
 		for (const f of found) {
 			if (!stateFiles.includes(f)) {
 				stateFiles.push(f);
@@ -408,7 +483,10 @@ export async function cleanupStalePipelineState(
 	}
 
 	if (stateFiles.length === 0) {
-		log.info("state-checkpoint", "No supervisor-state.json files found — no stale state to clean");
+		log.info(
+			"state-checkpoint",
+			"No supervisor-state*.json files found — no stale state to clean",
+		);
 		return { ok: true, value: undefined };
 	}
 
@@ -436,6 +514,18 @@ export async function cleanupStalePipelineState(
 			log.info("state-checkpoint", "Checkpoint not stale — skipping cleanup", {
 				issueNum: state.issueNum,
 				startedAt: state.startedAt,
+			});
+			continue;
+		}
+
+		// Liveness guard: a live pipeline owns this issue's worktree. Never
+		// prune it — even a >1h-old checkpoint must not let run B remove run
+		// A's live worktree. Dead-PID locks (crashed runs) still get cleaned.
+		const issueLock = readRunLock(runLockPath(cwd, state.issueNum));
+		if (issueLock && pidAlive(issueLock.pid)) {
+			log.info("state-checkpoint", "Skipping cleanup — issue has a live pipeline", {
+				issueNum: state.issueNum,
+				pid: issueLock.pid,
 			});
 			continue;
 		}

--- a/.pi/extensions/supervisor/pipeline/state-checkpoint.ts
+++ b/.pi/extensions/supervisor/pipeline/state-checkpoint.ts
@@ -430,11 +430,13 @@ export function isAnyOtherPipelineLive(cwd: string, excludeIssueNum: number): bo
  * - Wraps each git command in try-catch so failure of one doesn't block others.
  * - Skips self-cleanup: never cleans a checkpoint whose `worktreePath` matches `currentWorktreePath`.
  * - Liveness guard: never cleans a checkpoint whose per-issue run lock is held
- *   by a live process — with per-issue parallelism, run B's preflight must not
- *   prune run A's live worktree just because A's last checkpoint is >1h old.
- *   The lock lives in the main repo `.pi/`, so it survives partial worktree
- *   removal (the `recoverStaleWorktreeRegistration` scenario stays covered).
- *   A dead-PID lock does not protect — the crash case still cleans.
+ *   by a DIFFERENT live process — with per-issue parallelism, run B's preflight
+ *   must not prune run A's live worktree just because A's last checkpoint is
+ *   >1h old. Own-PID locks don't protect (acquireRunLock already wrote our pid
+ *   by the time this runs), so a same-issue rerun after a crash still prunes the
+ *   orphaned worktree. The lock lives in the main repo `.pi/`, so it survives
+ *   partial worktree removal (the `recoverStaleWorktreeRegistration` scenario
+ *   stays covered). A dead-PID lock does not protect — the crash case still cleans.
  * - Non-blocking: if cleanup of one stale checkpoint fails, logs warning and continues to the next.
  * - Runs `git worktree prune` before `git worktree remove --force` so git admin data is synced.
  * - Includes `rm -rf` fallback for the worktree directory after git operations succeed.
@@ -518,11 +520,14 @@ export async function cleanupStalePipelineState(
 			continue;
 		}
 
-		// Liveness guard: a live pipeline owns this issue's worktree. Never
-		// prune it — even a >1h-old checkpoint must not let run B remove run
-		// A's live worktree. Dead-PID locks (crashed runs) still get cleaned.
+		// Liveness guard: a DIFFERENT live process owns this issue's worktree.
+		// Never prune it — even a >1h-old checkpoint must not let run B remove
+		// run A's live worktree. Own-PID locks (acquireRunLock runs before this
+		// cleanup in the handler, so our own lock holds process.pid) do NOT
+		// protect: a same-issue rerun after a crash must still prune the
+		// orphaned worktree left by the dead run. Dead-PID locks also clean.
 		const issueLock = readRunLock(runLockPath(cwd, state.issueNum));
-		if (issueLock && pidAlive(issueLock.pid)) {
+		if (issueLock && issueLock.pid !== process.pid && pidAlive(issueLock.pid)) {
 			log.info("state-checkpoint", "Skipping cleanup — issue has a live pipeline", {
 				issueNum: state.issueNum,
 				pid: issueLock.pid,

--- a/.pi/extensions/supervisor/test/pipeline/handler-entry.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/handler-entry.test.mts
@@ -5,7 +5,7 @@
 
 import { describe, it, beforeEach, afterEach, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync, existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
@@ -220,6 +220,30 @@ describe("handler entry — top-level catch + finally", () => {
 
 		assert.equal(emitted.length, 1, "finally emits once");
 		assert.equal(emitted[0], null);
+	});
+
+	it("finally suppresses the null footer-clear when another issue's pipeline is live", async () => {
+		// Simulate a parallel same-host pipeline on a different issue holding
+		// a live lock (pid 1 = alive). Our run's finally must NOT clear the
+		// shared footer data that the other run still owns.
+		mkdirSync(join(MOCK_REPO, ".pi"), { recursive: true });
+		const foreignLock = join(MOCK_REPO, ".pi", "supervisor-run-1507.json");
+		writeFileSync(
+			foreignLock,
+			JSON.stringify({ pid: 1, issueNum: 1507, startedAt: new Date().toISOString() }),
+		);
+
+		try {
+			const { ctx } = createMockCtx();
+			const { pi, emitted } = createMockPi({ execResult: new Error("mock gh failure") });
+
+			await handleSupervisorCommand("42", ctx, pi);
+
+			assert.equal(emitted.length, 0, "no null footer-clear while another pipeline is live");
+		} finally {
+			// Restore shared MOCK_REPO state for subsequent tests
+			if (existsSync(foreignLock)) unlinkSync(foreignLock);
+		}
 	});
 });
 

--- a/.pi/extensions/supervisor/test/pipeline/handler.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/handler.test.mts
@@ -680,7 +680,7 @@ describe("handlePostPipeline() — merge/cleanup ordering (Phase 1)", () => {
 			});
 			assert.equal(stateResult.ok, true);
 
-			const statePath = join(tmpDir, ".pi", "supervisor-state.json");
+			const statePath = join(tmpDir, ".pi", "supervisor-state-42.json");
 			assert.equal(existsSync(statePath), true);
 
 			// Create ctx with tmpDir as cwd
@@ -738,7 +738,7 @@ describe("handlePostPipeline() — merge/cleanup ordering (Phase 1)", () => {
 			});
 			assert.equal(stateResult.ok, true);
 
-			const statePath = join(tmpDir, ".pi", "supervisor-state.json");
+			const statePath = join(tmpDir, ".pi", "supervisor-state-42.json");
 			assert.equal(existsSync(statePath), true);
 
 			const ctx = createMockCtx(true);
@@ -834,7 +834,7 @@ describe("handlePostPipeline() — merge/cleanup ordering (Phase 1)", () => {
 			);
 
 			// The state file should be deleted — verify by reading
-			const readResult = readCheckpointFileFromPath(join(tmpDir, ".pi", "supervisor-state.json"));
+			const readResult = readCheckpointFileFromPath(join(tmpDir, ".pi", "supervisor-state-42.json"));
 			assert.equal(readResult, null, "state file should be deleted");
 
 			rmSync(tmpDir, { recursive: true, force: true });

--- a/.pi/extensions/supervisor/test/pipeline/state-checkpoint.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/state-checkpoint.test.mts
@@ -29,6 +29,7 @@ import {
 	cleanupStalePipelineState,
 	acquireRunLock,
 	releaseRunLock,
+	isAnyOtherPipelineLive,
 	type SupervisorCheckpointState,
 	type CheckpointName,
 } from "../../pipeline/state-checkpoint.ts";
@@ -175,12 +176,12 @@ describe("writeCheckpointFile / readCheckpointFile / deleteCheckpointFile — fi
 		rmSync(tmpDir, { recursive: true, force: true });
 	});
 
-	it("writeCheckpointFile creates .pi/supervisor-state.json with correct JSON content", () => {
+	it("writeCheckpointFile creates .pi/supervisor-state-<issueNum>.json with correct JSON content", () => {
 		const state = createState();
 		const result = writeCheckpointFile(cwd, state);
 		assert.equal(result.ok, true);
 
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		assert.equal(existsSync(statePath), true);
 
 		const parsed = JSON.parse(readFileSync(statePath, "utf-8"));
@@ -197,11 +198,11 @@ describe("writeCheckpointFile / readCheckpointFile / deleteCheckpointFile — fi
 		assert.equal(result.ok, true);
 
 		// Verify no .tmp file remains after write
-		const tmpPath = join(cwd, ".pi", "supervisor-state.json.tmp");
+		const tmpPath = join(cwd, ".pi", "supervisor-state-746.json.tmp");
 		assert.equal(existsSync(tmpPath), false);
 
 		// Verify main file exists
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		assert.equal(existsSync(statePath), true);
 	});
 
@@ -226,9 +227,9 @@ describe("writeCheckpointFile / readCheckpointFile / deleteCheckpointFile — fi
 		}
 	});
 
-	it("writeCheckpointFile overwrites previous state (re-read returns new state)", () => {
-		const state1 = createState({ issueNum: 100, checkpoint: "pre-tsc" });
-		const state2 = createState({ issueNum: 200, checkpoint: "pre-lsp" });
+	it("writeCheckpointFile overwrites previous state for the same issue (re-read returns new state)", () => {
+		const state1 = createState({ issueNum: 1503, checkpoint: "pre-tsc" });
+		const state2 = createState({ issueNum: 1503, checkpoint: "pre-lsp" });
 
 		const r1 = writeCheckpointFile(cwd, state1);
 		assert.equal(r1.ok, true);
@@ -237,35 +238,63 @@ describe("writeCheckpointFile / readCheckpointFile / deleteCheckpointFile — fi
 		assert.equal(r2.ok, true);
 
 		// Re-read should return state2
-		const reread = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const reread = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-1503.json"));
 		assert.notEqual(reread, null);
-		assert.equal(reread!.issueNum, 200);
+		assert.equal(reread!.issueNum, 1503);
 		assert.equal(reread!.checkpoint, "pre-lsp");
 	});
 
-	it("deleteCheckpointFile removes .pi/supervisor-state.json — Result<void> ok", () => {
+	it("writes for two different issues coexist — second write does not clobber first (parallel isolation)", () => {
+		const state1 = createState({ issueNum: 1503, checkpoint: "pre-tsc" });
+		const state2 = createState({ issueNum: 1507, checkpoint: "pre-lsp" });
+
+		writeCheckpointFile(cwd, state1);
+		writeCheckpointFile(cwd, state2);
+
+		// Both per-issue files exist with their own content
+		const r1 = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-1503.json"));
+		const r2 = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-1507.json"));
+		assert.notEqual(r1, null);
+		assert.notEqual(r2, null);
+		assert.equal(r1!.issueNum, 1503);
+		assert.equal(r1!.checkpoint, "pre-tsc");
+		assert.equal(r2!.issueNum, 1507);
+		assert.equal(r2!.checkpoint, "pre-lsp");
+	});
+
+	it("deleteCheckpointFile removes .pi/supervisor-state-<issueNum>.json — Result<void> ok", () => {
 		const state = createState();
 		writeCheckpointFile(cwd, state);
 
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		assert.equal(existsSync(statePath), true);
 
-		const result = deleteCheckpointFile(cwd);
+		const result = deleteCheckpointFile(cwd, 746);
 		assert.equal(result.ok, true);
 		assert.equal(existsSync(statePath), false);
 	});
 
 	it("deleteCheckpointFile idempotent — returns ok when file already missing", () => {
-		const result = deleteCheckpointFile(cwd);
+		const result = deleteCheckpointFile(cwd, 746);
 		assert.equal(result.ok, true);
 	});
 
-	it("deleteCheckpointFile returns ok=false when supervisor-state.json is a directory", () => {
+	it("deleteCheckpointFile removes only the run's own issue file — other issues survive", () => {
+		writeCheckpointFile(cwd, createState({ issueNum: 1503 }));
+		writeCheckpointFile(cwd, createState({ issueNum: 1507 }));
+
+		const result = deleteCheckpointFile(cwd, 1503);
+		assert.equal(result.ok, true);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1503.json")), false);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1507.json")), true);
+	});
+
+	it("deleteCheckpointFile returns ok=false when supervisor-state-<issueNum>.json is a directory", () => {
 		// Create a directory at the state file path
-		const stateDir = join(cwd, ".pi", "supervisor-state.json");
+		const stateDir = join(cwd, ".pi", "supervisor-state-746.json");
 		mkdirSync(stateDir, { recursive: true });
 
-		const result = deleteCheckpointFile(cwd);
+		const result = deleteCheckpointFile(cwd, 746);
 		assert.equal(result.ok, false);
 		if (!result.ok) {
 			assert.equal(result.source, "state-checkpoint");
@@ -284,26 +313,13 @@ describe("writeCheckpointFile / readCheckpointFile / deleteCheckpointFile — fi
 		const writeResult = writeCheckpointFile(cwd, state);
 		assert.equal(writeResult.ok, true);
 
-		const readResult = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const readResult = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-791.json"));
 		assert.notEqual(readResult, null);
 		assert.equal(readResult!.issueNum, state.issueNum);
 		assert.equal(readResult!.checkpoint, state.checkpoint);
 		assert.equal(readResult!.worktreePath, state.worktreePath);
 		assert.equal(readResult!.worktreeBranch, state.worktreeBranch);
 		assert.equal(readResult!.startedAt, state.startedAt);
-	});
-
-	it("two writes in sequence: second overwrites first, readCheckpointFile returns second state", () => {
-		const state1 = createState({ issueNum: 1, checkpoint: "pre-tsc" });
-		const state2 = createState({ issueNum: 2, checkpoint: "pre-lsp" });
-
-		writeCheckpointFile(cwd, state1);
-		writeCheckpointFile(cwd, state2);
-
-		const readResult = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
-		assert.notEqual(readResult, null);
-		assert.equal(readResult!.issueNum, 2);
-		assert.equal(readResult!.checkpoint, "pre-lsp");
 	});
 });
 
@@ -322,28 +338,28 @@ describe("readCheckpointFile — edge cases (Phase 1)", () => {
 	});
 
 	it("readCheckpointFile returns null when file doesn't exist", () => {
-		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-746.json"));
 		assert.equal(result, null);
 	});
 
 	it("readCheckpointFile returns null with corrupted JSON (truncated)", () => {
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		writeFileSync(statePath, '{"issueNum": 746, "checkpoint": "pre-tsc",', "utf-8");
 
-		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-746.json"));
 		assert.equal(result, null);
 	});
 
 	it("readCheckpointFile returns null with JSON missing required fields", () => {
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		writeFileSync(statePath, '{"issueNum": 746}', "utf-8");
 
-		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-746.json"));
 		assert.equal(result, null);
 	});
 
 	it("readCheckpointFile returns null with invalid checkpoint name", () => {
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		writeFileSync(
 			statePath,
 			JSON.stringify({
@@ -356,7 +372,7 @@ describe("readCheckpointFile — edge cases (Phase 1)", () => {
 			"utf-8",
 		);
 
-		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-746.json"));
 		assert.equal(result, null);
 	});
 
@@ -364,7 +380,7 @@ describe("readCheckpointFile — edge cases (Phase 1)", () => {
 		const state = createState();
 		writeCheckpointFile(cwd, state);
 
-		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state.json"));
+		const result = readCheckpointFileFromPath(join(cwd, ".pi", "supervisor-state-746.json"));
 		assert.notEqual(result, null);
 		assert.equal(result!.issueNum, state.issueNum);
 		assert.equal(result!.checkpoint, state.checkpoint);
@@ -380,7 +396,7 @@ describe("readCheckpointFileFromPath — smoke tests", () => {
 	beforeEach(() => {
 		tmpDir = mkdtempSync(join(tmpdir(), "state-checkpoint-frompath-"));
 		mkdirSync(join(tmpDir, ".pi"), { recursive: true });
-		validFilePath = join(tmpDir, ".pi", "supervisor-state.json");
+		validFilePath = join(tmpDir, ".pi", "supervisor-state-746.json");
 	});
 
 	afterEach(() => {
@@ -422,7 +438,7 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 	});
 
 	it("cleanup found stale state file → cleans up worktree → returns ok", async () => {
-		// Create .pi/supervisor-state.json in main repo with stale state
+		// Create .pi/supervisor-state-746.json in main repo with stale state
 		mkdirSync(join(cwd, ".pi"), { recursive: true });
 		const staleState = createState({
 			startedAt: new Date(Date.now() - 7_200_000).toISOString(), // 2h ago → stale
@@ -463,7 +479,7 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 		assert.deepEqual(calls[3].args, ["-rf", "/tmp/stale-worktree"]);
 
 		// State file should be deleted
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		assert.equal(existsSync(statePath), false);
 	});
 
@@ -526,13 +542,13 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 		assert.equal(result.ok, true);
 		assert.equal(calls.length, 4);
 		// State file should still be deleted
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		assert.equal(existsSync(statePath), false);
 	});
 
 	it("state file parse error (corrupted JSON) → skip file, no git calls → returns ok", async () => {
 		mkdirSync(join(cwd, ".pi"), { recursive: true });
-		const statePath = join(cwd, ".pi", "supervisor-state.json");
+		const statePath = join(cwd, ".pi", "supervisor-state-746.json");
 		writeFileSync(statePath, "not-valid-json{", "utf-8");
 
 		mkdirSync(join(cwd, "../worktrees"), { recursive: true });
@@ -633,7 +649,7 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 	it("finds state file in worktree subdirectory", async () => {
 		mkdirSync(join(cwd, ".pi"), { recursive: true });
 
-		// Create a worktree directory with its own .pi/supervisor-state.json
+		// Create a worktree directory with its own .pi/supervisor-state-999.json
 		const wtDir = join(cwd, "../worktrees/some-worktree");
 		mkdirSync(join(wtDir, ".pi"), { recursive: true });
 		const wtState = createState({
@@ -642,7 +658,7 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 			worktreePath: wtDir,
 			worktreeBranch: "some-worktree",
 		});
-		const wtStatePath = join(wtDir, ".pi", "supervisor-state.json");
+		const wtStatePath = join(wtDir, ".pi", "supervisor-state-999.json");
 		writeFileSync(wtStatePath, JSON.stringify(wtState), "utf-8");
 
 		const calls: ExecCall[] = [];
@@ -665,6 +681,135 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 		assert.deepEqual(calls[1].args, ["worktree", "remove", "--force", "--force", wtDir]);
 		assert.equal(existsSync(wtStatePath), false);
 	});
+
+	it("skips a stale checkpoint whose per-issue lock has a LIVE pid (parallel pipeline guard)", async () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		// Stale (2h) checkpoint for 1503 with a live lock (pid 1 = alive, not us)
+		const staleState = createState({
+			issueNum: 1503,
+			startedAt: new Date(Date.now() - 7_200_000).toISOString(),
+			worktreePath: "/tmp/live-worktree-1503",
+			worktreeBranch: "worktree-git-issue-1503-live",
+		});
+		writeCheckpointFile(cwd, staleState);
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1503.json"),
+			JSON.stringify({ pid: 1, issueNum: 1503, startedAt: new Date().toISOString() }),
+		);
+
+		mkdirSync(join(cwd, "../worktrees"), { recursive: true });
+
+		const calls: ExecCall[] = [];
+		const pi = createMockPi([], calls);
+		const { notify } = createMockNotify();
+
+		const result = await cleanupStalePipelineState(pi, cwd, mockConfig, notify);
+
+		assert.equal(result.ok, true);
+		assert.equal(calls.length, 0, "no git calls — live pipeline owns the worktree");
+		// State file + worktree preserved
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1503.json")), true);
+	});
+
+	it("cleans a stale checkpoint whose per-issue lock has a DEAD pid (crash recovery intact)", async () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		const staleState = createState({
+			issueNum: 1503,
+			startedAt: new Date(Date.now() - 7_200_000).toISOString(),
+			worktreePath: "/tmp/crashed-worktree-1503",
+			worktreeBranch: "worktree-git-issue-1503-crashed",
+		});
+		writeCheckpointFile(cwd, staleState);
+		// Dead-PID lock — does not protect
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1503.json"),
+			JSON.stringify({ pid: 99999999, issueNum: 1503, startedAt: new Date().toISOString() }),
+		);
+
+		mkdirSync(join(cwd, "../worktrees"), { recursive: true });
+
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" }, // git worktree prune
+				{ code: 0, stdout: "", stderr: "" }, // git worktree remove --force
+				{ code: 0, stdout: "", stderr: "" }, // git branch -D
+				{ code: 0, stdout: "", stderr: "" }, // rm -rf
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+
+		const result = await cleanupStalePipelineState(pi, cwd, mockConfig, notify);
+
+		assert.equal(result.ok, true);
+		assert.equal(calls.length, 4);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1503.json")), false);
+	});
+
+	it("cleans a stale checkpoint with NO lock file present (crash removed lock, checkpoint survived)", async () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		const staleState = createState({
+			issueNum: 1503,
+			startedAt: new Date(Date.now() - 7_200_000).toISOString(),
+			worktreePath: "/tmp/orphan-worktree-1503",
+			worktreeBranch: "worktree-git-issue-1503-orphan",
+		});
+		writeCheckpointFile(cwd, staleState);
+		// No lock file at all
+
+		mkdirSync(join(cwd, "../worktrees"), { recursive: true });
+
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" },
+				{ code: 0, stdout: "", stderr: "" },
+				{ code: 0, stdout: "", stderr: "" },
+				{ code: 0, stdout: "", stderr: "" },
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+
+		const result = await cleanupStalePipelineState(pi, cwd, mockConfig, notify);
+
+		assert.equal(result.ok, true);
+		assert.equal(calls.length, 4);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1503.json")), false);
+	});
+
+	it("legacy bare-name supervisor-state.json with a live per-issue lock → skipped (guard via state.issueNum)", async () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		// Legacy bare-name file (mid-upgrade orphan) referencing issue 1503
+		const staleState = createState({
+			issueNum: 1503,
+			startedAt: new Date(Date.now() - 7_200_000).toISOString(),
+			worktreePath: "/tmp/live-worktree-1503",
+			worktreeBranch: "worktree-git-issue-1503-live",
+		});
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-state.json"),
+			JSON.stringify(staleState),
+			"utf-8",
+		);
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1503.json"),
+			JSON.stringify({ pid: 1, issueNum: 1503, startedAt: new Date().toISOString() }),
+		);
+
+		mkdirSync(join(cwd, "../worktrees"), { recursive: true });
+
+		const calls: ExecCall[] = [];
+		const pi = createMockPi([], calls);
+		const { notify } = createMockNotify();
+
+		const result = await cleanupStalePipelineState(pi, cwd, mockConfig, notify);
+
+		assert.equal(result.ok, true);
+		assert.equal(calls.length, 0);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state.json")), true);
+	});
 });
 
 // ─── Tests: acquireRunLock / releaseRunLock ──────────────────────
@@ -681,52 +826,208 @@ describe("acquireRunLock / releaseRunLock", () => {
 	it("acquires on fresh repo, then releases (own pid only)", () => {
 		const acquired = acquireRunLock(cwd, 1503);
 		assert.equal(acquired.ok, true);
-		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run.json")), true);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1503.json")), true);
 
 		// Release removes the lock
-		releaseRunLock(cwd);
-		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run.json")), false);
+		releaseRunLock(cwd, 1503);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1503.json")), false);
 	});
 
-	it("blocks when another LIVE pipeline holds the lock", () => {
+	it("acquire for issue A does not block acquire for issue B (cross-issue parallelism)", () => {
+		const acquiredA = acquireRunLock(cwd, 1503);
+		assert.equal(acquiredA.ok, true);
+		const acquiredB = acquireRunLock(cwd, 1507);
+		assert.equal(acquiredB.ok, true, "different issue must not be blocked");
+
+		// Both per-issue lock files exist side by side
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1503.json")), true);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1507.json")), true);
+	});
+
+	it("blocks when another LIVE pipeline holds the SAME issue's lock", () => {
 		const acquired = acquireRunLock(cwd, 1503);
 		assert.equal(acquired.ok, true);
-		// Second acquire — same live pid → blocked
-		const blocked = acquireRunLock(cwd, 1504);
+		// Second acquire of the same issue — same live pid → blocked
+		const blocked = acquireRunLock(cwd, 1503);
 		assert.equal(blocked.ok, false);
 		if (!blocked.ok) {
 			assert.ok(blocked.error.includes("Another supervisor pipeline is already running"));
+			assert.ok(blocked.error.includes(String(process.pid)));
+			assert.ok(blocked.error.includes("issue #1503"));
+			assert.ok(blocked.error.includes("started"));
 			assert.equal(blocked.source, "run-lock");
 		}
 	});
 
-	it("steals a stale lock whose holder PID is dead (crashed run)", () => {
-		// Write a lock claiming a dead PID
+	it("steals a stale lock whose holder PID is dead (crashed run), per issue", () => {
+		// Write a lock for 1503 claiming a dead PID
 		mkdirSync(join(cwd, ".pi"), { recursive: true });
 		writeFileSync(
-			join(cwd, ".pi", "supervisor-run.json"),
+			join(cwd, ".pi", "supervisor-run-1503.json"),
 			JSON.stringify({ pid: 99999999, issueNum: 1503, startedAt: new Date().toISOString() }),
 		);
-		const acquired = acquireRunLock(cwd, 1504);
+		const acquired = acquireRunLock(cwd, 1503);
 		assert.equal(acquired.ok, true, "stale lock should be taken over");
 		// Our pid now owns it
-		const lock = JSON.parse(readFileSync(join(cwd, ".pi", "supervisor-run.json"), "utf-8"));
+		const lock = JSON.parse(
+			readFileSync(join(cwd, ".pi", "supervisor-run-1503.json"), "utf-8"),
+		);
 		assert.equal(lock.pid, process.pid);
-		assert.equal(lock.issueNum, 1504);
+		assert.equal(lock.issueNum, 1503);
 	});
 
-	it("release does NOT delete a lock owned by another pid", () => {
+	it("stealing a stale lock does not touch another issue's LIVE lock", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		// 1507 holds a live lock (pid 1)
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1507.json"),
+			JSON.stringify({ pid: 1, issueNum: 1507, startedAt: new Date().toISOString() }),
+		);
+		// 1503 has a stale lock
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1503.json"),
+			JSON.stringify({ pid: 99999999, issueNum: 1503, startedAt: new Date().toISOString() }),
+		);
+
+		const acquired = acquireRunLock(cwd, 1503);
+		assert.equal(acquired.ok, true);
+
+		// 1507's live lock untouched
+		const lock1507 = JSON.parse(
+			readFileSync(join(cwd, ".pi", "supervisor-run-1507.json"), "utf-8"),
+		);
+		assert.equal(lock1507.pid, 1);
+		assert.equal(lock1507.issueNum, 1507);
+	});
+
+	it("release does NOT delete a lock owned by another pid (foreign lock, per issue)", () => {
 		mkdirSync(join(cwd, ".pi"), { recursive: true });
 		// pid 1 (init) is alive but not us
 		writeFileSync(
-			join(cwd, ".pi", "supervisor-run.json"),
+			join(cwd, ".pi", "supervisor-run-1503.json"),
 			JSON.stringify({ pid: 1, issueNum: 1503, startedAt: new Date().toISOString() }),
 		);
-		releaseRunLock(cwd);
+		releaseRunLock(cwd, 1503);
 		assert.equal(
-			existsSync(join(cwd, ".pi", "supervisor-run.json")),
+			existsSync(join(cwd, ".pi", "supervisor-run-1503.json")),
 			true,
 			"lock owned by another pid must survive release",
 		);
+	});
+
+	it("release deletes only the run's own issue lock — other issues survive", () => {
+		acquireRunLock(cwd, 1503);
+		acquireRunLock(cwd, 1507);
+
+		releaseRunLock(cwd, 1503);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1503.json")), false);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1507.json")), true);
+
+		// Re-acquire 1503 works while 1507 is still held
+		const reacquired = acquireRunLock(cwd, 1503);
+		assert.equal(reacquired.ok, true);
+	});
+
+	it("corrupt/unparseable lock is treated as stale — acquired", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "supervisor-run-1503.json"), "not-json{{{", "utf-8");
+
+		const acquired = acquireRunLock(cwd, 1503);
+		assert.equal(acquired.ok, true);
+		const lock = JSON.parse(
+			readFileSync(join(cwd, ".pi", "supervisor-run-1503.json"), "utf-8"),
+		);
+		assert.equal(lock.pid, process.pid);
+	});
+
+	it("acquire on repo without .pi/ creates the directory, then writes the lock", () => {
+		// No .pi dir created in beforeEach
+		const acquired = acquireRunLock(cwd, 1503);
+		assert.equal(acquired.ok, true);
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-run-1503.json")), true);
+	});
+
+	it("steal-race loop terminates within bounded retries on an unstealable path", () => {
+		// A directory at the lock path: writeLock always gets EEXIST and unlink
+		// always fails — the loop must give up after MAX_ACQUIRE_ATTEMPTS, not
+		// spin forever, and never surface a generic EEXIST from the outer catch.
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		mkdirSync(join(cwd, ".pi", "supervisor-run-1503.json"), { recursive: true });
+
+		const result = acquireRunLock(cwd, 1503);
+		assert.equal(result.ok, false);
+		if (!result.ok) {
+			assert.equal(result.source, "run-lock");
+			assert.ok(result.error.includes("attempts"), "bounded-retry error expected");
+		}
+	});
+});
+
+// ─── Tests: isAnyOtherPipelineLive ────────────────────────────────
+
+describe("isAnyOtherPipelineLive", () => {
+	let cwd: string;
+	beforeEach(() => {
+		cwd = mkdtempSync(join(tmpdir(), "other-live-"));
+	});
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+	});
+
+	it("returns false when no run lock files exist", () => {
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), false);
+	});
+
+	it("returns false when only the excluded issue's lock is live", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1503.json"),
+			JSON.stringify({ pid: process.pid, issueNum: 1503, startedAt: new Date().toISOString() }),
+		);
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), false);
+	});
+
+	it("returns true when another issue's lock is held by a live pid", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1507.json"),
+			JSON.stringify({ pid: 1, issueNum: 1507, startedAt: new Date().toISOString() }),
+		);
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), true);
+	});
+
+	it("returns false when another issue's lock is held by a dead pid", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1507.json"),
+			JSON.stringify({ pid: 99999999, issueNum: 1507, startedAt: new Date().toISOString() }),
+		);
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), false);
+	});
+
+	it("any live other-issue lock → true; all dead → false", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1501.json"),
+			JSON.stringify({ pid: 99999999, issueNum: 1501, startedAt: new Date().toISOString() }),
+		);
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1507.json"),
+			JSON.stringify({ pid: 1, issueNum: 1507, startedAt: new Date().toISOString() }),
+		);
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), true);
+
+		// Make the second one dead too → false
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1507.json"),
+			JSON.stringify({ pid: 99999999, issueNum: 1507, startedAt: new Date().toISOString() }),
+		);
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), false);
+	});
+
+	it("corrupt lock JSON in the scan is treated as dead — does not throw", () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "supervisor-run-1507.json"), "garbage{", "utf-8");
+		assert.equal(isAnyOtherPipelineLive(cwd, 1503), false);
 	});
 });

--- a/.pi/extensions/supervisor/test/pipeline/state-checkpoint.test.mts
+++ b/.pi/extensions/supervisor/test/pipeline/state-checkpoint.test.mts
@@ -747,6 +747,45 @@ describe("cleanupStalePipelineState — mock pi.exec (Phase 3)", () => {
 		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1503.json")), false);
 	});
 
+	it("cleans a stale checkpoint whose per-issue lock has OUR OWN pid (production ordering: acquireRunLock runs before cleanup)", async () => {
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		// Stale (2h) checkpoint for 1503 — a prior run crashed, leaving the
+		// checkpoint and a dead lock. The next run's acquireRunLock stole the
+		// dead lock and rewrote it with process.pid BEFORE cleanup runs, so the
+		// guard must not treat our own live PID as a protective live pipeline.
+		const staleState = createState({
+			issueNum: 1503,
+			startedAt: new Date(Date.now() - 7_200_000).toISOString(),
+			worktreePath: "/tmp/own-crashed-worktree-1503",
+			worktreeBranch: "worktree-git-issue-1503-own-crashed",
+		});
+		writeCheckpointFile(cwd, staleState);
+		writeFileSync(
+			join(cwd, ".pi", "supervisor-run-1503.json"),
+			JSON.stringify({ pid: process.pid, issueNum: 1503, startedAt: new Date().toISOString() }),
+		);
+
+		mkdirSync(join(cwd, "../worktrees"), { recursive: true });
+
+		const calls: ExecCall[] = [];
+		const pi = createMockPi(
+			[
+				{ code: 0, stdout: "", stderr: "" }, // git worktree prune
+				{ code: 0, stdout: "", stderr: "" }, // git worktree remove --force
+				{ code: 0, stdout: "", stderr: "" }, // git branch -D
+				{ code: 0, stdout: "", stderr: "" }, // rm -rf
+			],
+			calls,
+		);
+		const { notify } = createMockNotify();
+
+		const result = await cleanupStalePipelineState(pi, cwd, mockConfig, notify);
+
+		assert.equal(result.ok, true);
+		assert.equal(calls.length, 4, "own-pid lock must NOT protect — cleanup proceeds");
+		assert.equal(existsSync(join(cwd, ".pi", "supervisor-state-1503.json")), false);
+	});
+
 	it("cleans a stale checkpoint with NO lock file present (crash removed lock, checkpoint survived)", async () => {
 		mkdirSync(join(cwd, ".pi"), { recursive: true });
 		const staleState = createState({


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1526

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 5m 12s | 76.9K | 39 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 2m 16s | 37.8K | 16 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 8s | 55.2K | 21 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 9m 44s | 83.5K | 42 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 37s | 26.5K | 13 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 6m 47s | 38.2K | 17 | minimax-m3 |
| developer | ✓ SUCCESS | 1m 9s | 33.9K | 14 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 59s | 25.1K | 11 | minimax-m3 |

**Total:** 8 agents · 29m 52s · 377.1K tokens · 173 tool calls · 4 failed (2%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1526
Closes #1526

**Gate failures:**
- Dead Code Gate gate failed on run 5 — developer restarted