### PR TITLE
feat(#1525): Docs: Add dedicated CLI reference page

### DIFF
--- a/cmd/cheasee-pi/cli_doc_test.go
+++ b/cmd/cheasee-pi/cli_doc_test.go
@@ -1,0 +1,362 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+// cliDocPath is the path to the CLI reference doc relative to this test file.
+func cliDocPath() string {
+	// Test runs from the package directory (cmd/cheasee-pi/).
+	return filepath.Join("..", "..", "docs", "cli.md")
+}
+
+func readCliDoc(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(cliDocPath())
+	if err != nil {
+		t.Fatalf("reading docs/cli.md: %v", err)
+	}
+	return string(data)
+}
+
+// readNavOrder extracts the nav_order value from a doc's Jekyll frontmatter.
+func readNavOrder(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	inFront := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			if inFront {
+				break
+			}
+			inFront = true
+			continue
+		}
+		if inFront && strings.HasPrefix(trimmed, "nav_order:") {
+			return strings.TrimSpace(strings.TrimPrefix(trimmed, "nav_order:"))
+		}
+	}
+	return ""
+}
+
+// ──────────────────────────────────────────────
+// Phase 1: Page shell & nav
+// ──────────────────────────────────────────────
+
+// TestCLIDoc_ExistsAndFrontmatter verifies docs/cli.md exists with the
+// just-the-docs frontmatter contract (layout, title, unique fractional
+// nav_order slotting between installation=2 and daily-usage=3).
+func TestCLIDoc_ExistsAndFrontmatter(t *testing.T) {
+	content := readCliDoc(t)
+	if !strings.Contains(content, "layout: default") {
+		t.Error("docs/cli.md must declare layout: default in frontmatter")
+	}
+	if !strings.Contains(content, "title: CLI Reference") {
+		t.Error("docs/cli.md must declare title: CLI Reference in frontmatter")
+	}
+	if readNavOrder(t, cliDocPath()) != "2.5" {
+		t.Error("docs/cli.md must declare nav_order: 2.5 in frontmatter")
+	}
+}
+
+// TestCLIDoc_NavOrderUnique verifies every docs/*.md has a distinct nav_order,
+// cli.md uses 2.5, and the pre-existing 1–11 values are unchanged (no
+// renumbering — the page slots into the flat nav without touching siblings).
+func TestCLIDoc_NavOrderUnique(t *testing.T) {
+	entries, err := os.ReadDir(filepath.Join("..", "..", "docs"))
+	if err != nil {
+		t.Fatalf("listing docs/: %v", err)
+	}
+
+	existing := map[string]string{
+		"index.md":            "1",
+		"installation.md":     "2",
+		"daily-usage.md":      "3",
+		"architecture.md":     "4",
+		"skills.md":           "5",
+		"prompts.md":          "6",
+		"extensions.md":       "7",
+		"github.md":           "8",
+		"security.md":         "9",
+		"sbom.md":             "10",
+		"acknowledgements.md": "11",
+	}
+
+	seen := make(map[string]string)
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".md") {
+			continue
+		}
+		path := filepath.Join("..", "..", "docs", e.Name())
+		order := readNavOrder(t, path)
+		if order == "" {
+			continue // README.md (included via index.md) has no nav_order
+		}
+		if want, ok := existing[e.Name()]; ok && order != want {
+			t.Errorf("docs/%s nav_order changed from %q to %q — renumbering is not allowed", e.Name(), want, order)
+		}
+		if prev, dup := seen[order]; dup {
+			t.Errorf("nav_order collision: docs/%s and docs/%s both use %q", prev, e.Name(), order)
+		}
+		seen[order] = e.Name()
+	}
+	if seen["2.5"] != "cli.md" {
+		t.Errorf("nav_order 2.5 must belong to cli.md, got %q", seen["2.5"])
+	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 2: Command surface sync
+// ──────────────────────────────────────────────
+
+// TestCLIDoc_AllTopLevelCommands verifies every top-level command registered
+// on rootCmd (excluding Cobra built-ins) is documented in cli.md.
+func TestCLIDoc_AllTopLevelCommands(t *testing.T) {
+	content := readCliDoc(t)
+	for _, c := range rootCmd.Commands() {
+		if builtInCmds[c.Name()] {
+			continue
+		}
+		if !strings.Contains(content, c.Name()) {
+			t.Errorf("docs/cli.md should document top-level command %q", c.Name())
+		}
+	}
+}
+
+// TestCLIDoc_AliasesDocumented verifies the documented aliases: no-args
+// invocation = start, start alias up, down alias stop.
+func TestCLIDoc_AliasesDocumented(t *testing.T) {
+	content := readCliDoc(t)
+	if !strings.Contains(content, "(no args)") {
+		t.Error("docs/cli.md should state that `cheasee-pi` with no args runs start")
+	}
+	if !strings.Contains(content, "`up`") {
+		t.Error("docs/cli.md should document the `up` alias for start")
+	}
+	if !strings.Contains(content, "`stop`") {
+		t.Error("docs/cli.md should document the `stop` alias for down")
+	}
+}
+
+// TestCLIDoc_AllInitFlags verifies every registered init flag appears in
+// cli.md with its one-line meaning (mandated 8 + code-truth --reauth and
+// --skill-repo).
+func TestCLIDoc_AllInitFlags(t *testing.T) {
+	content := readCliDoc(t)
+	initCmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if !strings.Contains(content, "--"+f.Name) {
+			t.Errorf("docs/cli.md should document init flag --%s", f.Name)
+		}
+	})
+}
+
+// TestCLIDoc_StartAndAuthFlags verifies the auth subcommands and start flags
+// are documented.
+func TestCLIDoc_StartAndAuthFlags(t *testing.T) {
+	content := readCliDoc(t)
+	for _, sub := range []string{"auth add", "auth remove", "auth list", "auth envvars"} {
+		if !strings.Contains(content, sub) {
+			t.Errorf("docs/cli.md should document `cheasee-pi %s`", sub)
+		}
+	}
+	for _, flag := range []string{"--build", "--api-key", "--no-docker-check", "--dry-run", "--name", "--workdir"} {
+		if !strings.Contains(content, flag) {
+			t.Errorf("docs/cli.md should document start flag %s", flag)
+		}
+	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 3: Checks / behavioral claims
+// ──────────────────────────────────────────────
+
+// TestCLIDoc_DockerGate verifies the Docker gate (binary + docker info +
+// Engine ≥ 24.0.0, 5 s timeout) and the --no-docker-check skip are stated.
+func TestCLIDoc_DockerGate(t *testing.T) {
+	content := readCliDoc(t)
+	if !strings.Contains(content, "24.0.0") {
+		t.Error("docs/cli.md should state the Docker Engine ≥ 24.0.0 requirement")
+	}
+	if !strings.Contains(content, "5 s") {
+		t.Error("docs/cli.md should state the 5 s docker check timeout")
+	}
+	if !strings.Contains(content, "--no-docker-check") {
+		t.Error("docs/cli.md should state that --no-docker-check skips the Docker check")
+	}
+}
+
+// TestCLIDoc_InitGates verifies the init preconditions: empty-folder gate,
+// cheasee-settings.json as initialized marker, non-empty refusal, 5-minute
+// timeout, --no-input requiring --repo-url, --no-github legacy path, and
+// start auto-init in the same invocation.
+func TestCLIDoc_InitGates(t *testing.T) {
+	content := readCliDoc(t)
+	checks := []struct {
+		want, msg string
+	}{
+		{"empty folder", "empty-folder requirement"},
+		{"non-empty folders are refused", "refusal of non-empty folders"},
+		{"initialized", "cheasee-settings.json as initialized marker"},
+		{"5-minute", "5-minute init/OAuth timeout"},
+		{"--no-input` requires `--repo-url", "--no-input requires --repo-url"},
+		{"--no-github", "--no-github legacy path"},
+		{"same invocation", "start auto-init continuation"},
+	}
+	for _, c := range checks {
+		if !strings.Contains(content, c.want) {
+			t.Errorf("docs/cli.md should state: %s", c.msg)
+		}
+	}
+	if !strings.Contains(content, "cheasee-settings.json") {
+		t.Error("docs/cli.md should reference cheasee-settings.json")
+	}
+}
+
+// TestCLIDoc_CleanSemantics verifies clean's cross-workspace blast radius
+// and its scoping flags.
+func TestCLIDoc_CleanSemantics(t *testing.T) {
+	content := readCliDoc(t)
+	for _, s := range []string{"ALL managed containers", "force-remove", "--name", "--dry-run", "--yes", "--older-than"} {
+		if !strings.Contains(content, s) {
+			t.Errorf("docs/cli.md should state clean's %q semantics", s)
+		}
+	}
+}
+
+// TestCLIDoc_DownSemantics verifies down targets only the current
+// workspace's compose project, no-ops when nothing matches, and excludes
+// legacy pre-derivation containers (clean removes those).
+func TestCLIDoc_DownSemantics(t *testing.T) {
+	content := readCliDoc(t)
+	for _, s := range []string{"current workspace", "No-ops", "`cheasee-pi clean` removes those"} {
+		if !strings.Contains(content, s) {
+			t.Errorf("docs/cli.md should state down's %q semantics", s)
+		}
+	}
+}
+
+// TestCLIDoc_BuildApply verifies the cached-build apply step is documented.
+func TestCLIDoc_BuildApply(t *testing.T) {
+	content := readCliDoc(t)
+	if !strings.Contains(content, "start --build") {
+		t.Error("docs/cli.md should state applying a build via `cheasee-pi start --build`")
+	}
+	if !strings.Contains(content, "`cheasee-pi down` + `cheasee-pi start`") {
+		t.Error("docs/cli.md should state the down + start apply path")
+	}
+}
+
+// TestCLIDoc_AuthRemoveDefaults verifies auth remove leaves the workspace
+// default untouched and switching requires auth add.
+func TestCLIDoc_AuthRemoveDefaults(t *testing.T) {
+	content := readCliDoc(t)
+	for _, s := range []string{"defaultProvider", "defaultModel", "`cheasee-pi auth add <other>`"} {
+		if !strings.Contains(content, s) {
+			t.Errorf("docs/cli.md should state that auth remove leaves %q", s)
+		}
+	}
+}
+
+// TestCLIDoc_ContainerNaming verifies the per-repo container name and the
+// sibling .bare mount are documented.
+func TestCLIDoc_ContainerNaming(t *testing.T) {
+	content := readCliDoc(t)
+	if !strings.Contains(content, "cheasee-pi-<repo-slug>") {
+		t.Error("docs/cli.md should state the per-repo container name cheasee-pi-<repo-slug>")
+	}
+	if !strings.Contains(content, "/workspaces/.bare") {
+		t.Error("docs/cli.md should state the sibling .bare mount at /workspaces/.bare")
+	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 4: Inputs, visualization, links
+// ──────────────────────────────────────────────
+
+// TestCLIDoc_ProviderEnvVarsMatchCode verifies every env var name the CLI
+// probes (provider vars + passthrough) appears in cli.md, and that
+// CODEFLOW_PORT documents the resolution order.
+func TestCLIDoc_ProviderEnvVarsMatchCode(t *testing.T) {
+	content := readCliDoc(t)
+	for _, name := range AllEnvVarNames() {
+		if !strings.Contains(content, name) {
+			t.Errorf("docs/cli.md should document env var %s", name)
+		}
+	}
+	if !strings.Contains(content, "CODEFLOW_PORT") {
+		t.Error("docs/cli.md should document CODEFLOW_PORT")
+	}
+	if !strings.Contains(content, "codeflowPort") {
+		t.Error("docs/cli.md should document the docker.codeflowPort settings source")
+	}
+}
+
+// TestCLIDoc_FilesReadWritten verifies the documented files: auth.json (0600),
+// cheasee-settings.json, version-keyed cache dir, and .pi/.
+func TestCLIDoc_FilesReadWritten(t *testing.T) {
+	content := readCliDoc(t)
+	for _, s := range []string{"auth.json", "0600", "cheasee-settings.json", "UserCacheDir", ".pi/"} {
+		if !strings.Contains(content, s) {
+			t.Errorf("docs/cli.md should document %s", s)
+		}
+	}
+}
+
+// TestCLIDoc_Visualization verifies at least one markdown table gives the
+// at-a-glance command surface.
+func TestCLIDoc_Visualization(t *testing.T) {
+	content := readCliDoc(t)
+	if !strings.Contains(content, "|") {
+		t.Error("docs/cli.md should contain at least one |-delimited markdown table")
+	}
+	if !strings.Contains(content, "At a glance") {
+		t.Error("docs/cli.md should have an at-a-glance command overview")
+	}
+}
+
+// TestCLIDoc_LinksToDepth verifies the one-directional links: cli.md links
+// to installation.md and daily-usage.md, and both link back to cli.md.
+func TestCLIDoc_LinksToDepth(t *testing.T) {
+	content := readCliDoc(t)
+	for _, link := range []string{"installation.md", "daily-usage.md"} {
+		if !strings.Contains(content, link) {
+			t.Errorf("docs/cli.md should link to %s", link)
+		}
+	}
+	readDoc := func(path string) string {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		return string(data)
+	}
+	for _, path := range []string{
+		filepath.Join("..", "..", "docs", "installation.md"),
+		filepath.Join("..", "..", "docs", "daily-usage.md"),
+	} {
+		if !strings.Contains(readDoc(path), "cli.md") {
+			t.Errorf("%s should link to cli.md", filepath.Base(path))
+		}
+	}
+}
+
+// TestCLIDoc_NoTutorialDuplication verifies cli.md stays a reference page:
+// no install one-liner (curl / VERSION= snippet) and no troubleshooting
+// section — those live in installation.md / daily-usage.md.
+func TestCLIDoc_NoTutorialDuplication(t *testing.T) {
+	content := readCliDoc(t)
+	for _, banned := range []string{"curl", "VERSION=", "Troubleshooting"} {
+		if strings.Contains(content, banned) {
+			t.Errorf("docs/cli.md must not contain %q (tutorial detail belongs in installation.md / daily-usage.md)", banned)
+		}
+	}
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,190 @@
+---
+layout: default
+title: CLI Reference
+nav_order: 2.5
+---
+
+# CLI Reference
+
+`cheasee-pi` is the Docker-based launcher for the pi coding agent. It sets up
+a workspace, launches pi inside a container with provider keys injected, and
+manages the container lifecycle. This page is the command reference — every
+command's **does**, **checks**, and **inputs** at a glance. For step-by-step
+setup and daily walkthroughs, see [Installation](installation.md) and
+[Daily Usage](daily-usage.md).
+
+## At a glance
+
+| Command | Does | Key inputs |
+|---|---|---|
+| `cheasee-pi` (no args) | Launch pi in the container — alias of `start` | workspace, API keys |
+| `cheasee-pi start` (alias `up`) | Launch pi inside the container with provider keys injected | workspace, `--build` to rebuild first |
+| `cheasee-pi init` | Set up workspace: bare clone + main worktree + `cheasee-settings.json` | empty folder, repo URL |
+| `cheasee-pi auth add \| remove \| list \| envvars` | Manage provider API keys | provider, key |
+| `cheasee-pi build` (full: `rebuild`) | Rebuild the Docker image | workspace settings |
+| `cheasee-pi down` (alias `stop`) | Stop and remove the container for this workspace | — |
+| `cheasee-pi clean` | Kill orphaned pi sessions, remove all containers, prune Docker garbage | confirmation |
+| `cheasee-pi uninstall` | Remove config + extracted files | confirmation |
+
+`cheasee-pi --version` prints the CLI version. `cheasee-pi --help` lists every
+subcommand.
+
+## Lifecycle
+
+| Step | Command | What happens |
+|---|---|---|
+| 1 | `cheasee-pi init` | empty-folder workspace setup (clone, scaffold, auth) |
+| 2 | `cheasee-pi auth add <provider>` | store API key, set default provider |
+| 3 | `cheasee-pi start` | build image on first run, launch pi |
+| 4 | (work) | interactive pi session inside the container |
+| 5 | `cheasee-pi down` | stop and remove this workspace's container |
+| 6 | `cheasee-pi clean` | sweep every container + orphan sessions, prune |
+
+An empty folder can skip step 1: `cheasee-pi start` auto-inits it and
+continues into start in the same invocation.
+
+## `cheasee-pi` (no args) / `start`
+
+Launch an interactive pi session inside the container. The root command run
+without a subcommand executes the same handler as `start`.
+
+| | |
+|---|---|
+| **Does** | Mounts the workspace at `/workspaces/main` and its sibling bare clone at `/workspaces/.bare`, starts the container (`docker compose up` if not running), injects provider keys from `~/.config/cheasee-pi/auth.json` as environment variables, launches pi, and prints the CodeFlow URL (`http://localhost:<port>/?repo=local/workspace&run=1`) once the container is healthy. |
+| **Checks** | Workspace gate: empty folder → runs `init` first and continues into start in the same invocation; `cheasee-settings.json` present → run; non-empty folder without it → refused. Docker gate (binary present + `docker info` responds + Engine ≥ 24.0.0, 5 s timeout) unless `--no-docker-check`. |
+| **Inputs** | Flags: `--workdir`, `--name`, `--build`, `--no-docker-check`, `--api-key` (session-only, not saved), `--dry-run` (print injected env vars, then exit). Reads `auth.json` + `cheasee-settings.json`; writes the version-keyed compose/Dockerfile cache. |
+
+## `cheasee-pi init`
+
+Set up a cheasee-pi workspace from scratch: bare clone to `<parent>/.bare`,
+main worktree in the folder, and the dedicated `cheasee-settings.json`
+scaffolded (gitignored, machine-local). GitHub OAuth (device flow) is the
+primary authentication; `--no-github` falls back to the legacy API-key-only
+path (no clone, no repo URL).
+
+| | |
+|---|---|
+| **Does** | Bare-clones the project repo, adds the main worktree, scaffolds `cheasee-settings.json` (never overwrites an existing one), authenticates GitHub, records custom skill repos, saves auth config, and sets up the provider API key. Prints `cheasee-pi start` as the next step (or continues into start automatically when triggered by `start`). |
+| **Checks** | Docker gate unless `--no-docker-check`. Empty-folder probe: non-empty folders are refused (`.DS_Store` tolerated). `cheasee-settings.json` presence marks the workspace initialized — init refuses it unless `--reauth` (which re-runs only the GitHub + API-key authentications). Single invocation capped at a 5-minute timeout (device-flow OAuth polling dominates). `--no-input` requires `--repo-url`. |
+| **Inputs** | Repo URL (`--repo-url` or interactive prompt), GitHub OAuth device flow, API key (`--api-key` or prompt), provider name. Files written: `cheasee-settings.json`, `~/.config/cheasee-pi/auth.json`, `.pi/` agent settings, sibling `.bare` clone + main worktree. |
+
+### init flags
+
+| Flag | Meaning |
+|---|---|
+| `--workdir <dir>` | Working directory (default: current directory) |
+| `--no-github` | Legacy API-key-only path — skip the clone and GitHub OAuth entirely |
+| `--client-id <id>` | GitHub OAuth app client ID (default: cheasee-pi's app) |
+| `--provider <name>` | Provider name for the API key (default: opencode-go) |
+| `--no-input` | Skip all interactive prompts (`--repo-url` then required) |
+| `--api-key <key>` | API key, skips the interactive prompt |
+| `--no-docker-check` | Skip the Docker Engine check |
+| `--repo-url <url>` | Project repository URL for the clone (`owner/repo` or GitHub URL) |
+| `--reauth` | Redo GitHub + pi API-key authentications on an initialized workspace |
+| `--skill-repo <spec>` | Custom skill repository installed into the container (repeatable) |
+
+## `cheasee-pi auth`
+
+Manage provider API keys. Keys live in `~/.config/cheasee-pi/auth.json`
+(0600, atomic writes) and the last-added provider becomes the default in the
+workspace settings.
+
+| Subcommand | Does | Inputs / checks |
+|---|---|---|
+| `auth add [provider]` | Add or update a provider API key; sets it as the default provider (and model) in the workspace settings | provider name or interactive picker; `--workdir`, `--no-input` (skip model selection). Saves to `auth.json` + `cheasee-settings.json` + `.pi/agent/settings.json` |
+| `auth remove <provider>` | Delete the key from `auth.json` | exact provider name; `--workdir`. Leaves `defaultProvider`/`defaultModel` in `cheasee-settings.json` untouched — switch the default with `cheasee-pi auth add <other>` |
+| `auth list` | List configured providers (masked keys) + the workspace default | `--workdir` |
+| `auth envvars` | Print the canonical provider→env var mapping (shell format by default) | `--format shell\|json`; emits no key values |
+
+## `cheasee-pi build` / `rebuild`
+
+Rebuild the Docker image without starting the container. `build` reuses the
+Docker layer cache; `rebuild` is a full no-cache rebuild plus prune
+(`build --no-cache` is a compatibility alias for a full rebuild).
+
+| | |
+|---|---|
+| **Does** | Rebuilds the image from the compose/Dockerfile in the version-keyed cache dir; passes `CHEASEEPI_MEMORY` from `cheasee-settings.json` as a build arg. |
+| **Checks** | Runs from a git repo (settings + git identity come from it). Docker gate unless `--no-docker-check`. Compose validates every volume spec, so the workspace path must resolve. |
+| **Inputs** | Flags: `--workdir`, `--no-docker-check`, `--no-cache`. Reads `cheasee-settings.json` (`docker.memory`). |
+| **Note** | A cached build does not apply the new image to a running container — apply with `cheasee-pi start --build` or `cheasee-pi down` + `cheasee-pi start`. |
+
+## `cheasee-pi down`
+
+Stop and remove the Docker container for the current workspace via
+`docker compose down` (alias `stop`).
+
+| | |
+|---|---|
+| **Does** | Removes the compose project derived from this workspace's repo — sibling workspaces' containers keep running. |
+| **Checks** | No-ops when no container matches the workspace's project. Legacy pre-derivation containers (project `cheasee-pi`) are deliberately not targeted — `cheasee-pi clean` removes those. |
+| **Inputs** | None (no flags). |
+
+## `cheasee-pi clean`
+
+Kill orphaned/stale pi sessions and remove all cheasee-pi containers.
+
+| | |
+|---|---|
+| **Does** | Enumerates ALL managed containers on the host (every repo, running or stopped), force-removes each, kills orphaned pi processes inside them, and prunes dangling images + build cache. |
+| **Checks** | Lists the matches and asks for confirmation before killing anything (`--yes` skips, `--dry-run` previews). Default scope is every cheasee-pi container on the host — `--name` scopes to a single container. |
+| **Inputs** | Flags: `--name <container>` (scope), `--older-than <minutes>` (orphan age reap; `0` disables), `--dry-run`, `--yes`. |
+
+## `cheasee-pi uninstall`
+
+Remove cheasee-pi configuration and CLI-managed assets.
+
+| | |
+|---|---|
+| **Does** | Removes the version-keyed cache dir (compose/Dockerfile), the workspace `.pi/`, `~/.config/cheasee-pi/auth.json`, the running binary, and `.git/` when `--remove-git` is set. |
+| **Checks** | Shows a summary and asks for confirmation (`--force` skips). Skips binary removal when running from a Go build cache; warns when the binary's directory is not writable. |
+| **Inputs** | Flags: `--workdir`, `--force`, `--remove-git`. |
+
+## Environment variables
+
+Provider keys are read from `~/.config/cheasee-pi/auth.json`, not the
+environment — the mapping below is what the CLI injects into the container.
+`cheasee-pi auth envvars` is the canonical live source.
+
+| Provider | Env var |
+|---|---|
+| opencode-go (alias: opencode) | `OPENCODE_API_KEY` |
+| openai | `OPENAI_API_KEY` |
+| anthropic (alias: claude) | `ANTHROPIC_API_KEY` |
+| deepseek | `DEEPSEEK_API_KEY` |
+| gemini (alias: google) | `GEMINI_API_KEY` |
+| groq | `GROQ_API_KEY` |
+| mistral | `MISTRAL_API_KEY` |
+| openrouter | `OPENROUTER_API_KEY` |
+| xai | `XAI_API_KEY` |
+| fireworks | `FIREWORKS_API_KEY` |
+| together | `TOGETHER_API_KEY` |
+| cerebras | `CEREBRAS_API_KEY` |
+
+Passthrough from the host environment (when set):
+
+- `GH_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`
+
+Other variables the CLI reads:
+
+| Variable | Meaning |
+|---|---|
+| `CODEFLOW_PORT` | Host port for the CodeFlow sidecar. Resolution order: `docker.codeflowPort` in `cheasee-settings.json` → env `CODEFLOW_PORT` → derived `8470 + fnv32(repo-slug) % 1024`, probed next-free |
+| `CHEASEEPI_MEMORY` | Build arg passed by `build`/`rebuild` from `docker.memory` in `cheasee-settings.json` |
+| `XDG_CACHE_HOME` (Unix) / `LocalAppData` (Windows) | Base for the CLI cache dir via `os.UserCacheDir` |
+
+## Files and artifacts
+
+| Path | Role |
+|---|---|
+| `~/.config/cheasee-pi/auth.json` | Provider API keys + GitHub token/user (0600, atomic writes) |
+| `<workspace>/cheasee-settings.json` | Initialized marker; `defaultProvider`/`defaultModel`, docker settings, skill repos (tab-indented, never overwritten by init) |
+| `<UserCacheDir>/cheasee-pi/<version>` | CLI-managed cache: `docker-compose.yml`, `Dockerfile` (extracted on demand) |
+| `<workspace>/.pi/` | pi agent config (settings, agent settings) |
+| `<parent>/.bare` | Sibling bare clone, mounted at `/workspaces/.bare` in the container |
+| container `cheasee-pi-<repo-slug>` | Per-repo Docker container (workspace mounts at `/workspaces/main`) |
+
+## Where to go deeper
+
+- [Installation](installation.md) — prerequisites, install, first setup, uninstall
+- [Daily Usage](daily-usage.md) — start/stop flows, CodeFlow, parallel workspaces, troubleshooting

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -18,6 +18,8 @@ nav_order: 3
 
 ## Prerequisites
 
+> Command-level reference (flags, checks, inputs): [CLI Reference](cli.md).
+
 Before running pi via Docker, ensure the following are in place:
 
 - **Docker Engine** running with Compose V2 (verified by `docker compose version`)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,6 +59,9 @@ cheasee-pi --version
 
 ## Setup
 
+> Full command reference — what every command does, checks, and needs as input:
+> [CLI Reference](cli.md).
+
 ```bash
 cheasee-pi init
 ```


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1525

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 12m 4s | 68.5K | 40 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 19s | 22.7K | 11 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 2m 7s | 52.3K | 19 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 4m 0s | 67.4K | 35 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 51s | 60.2K | 64 | minimax-m3 |

**Total:** 5 runs · 22m 22s · 271.0K tokens · 169 tool calls · 6 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1525
Closes #1525