### PR TITLE
fix(docker): guard workspace npm install on .package-lock.json, not node_modules dir

### DIFF
--- a/cmd/cheasee-pi/embedded/docker/entrypoint.sh
+++ b/cmd/cheasee-pi/embedded/docker/entrypoint.sh
@@ -299,7 +299,11 @@ install_skill_repos
 # The workspace is a bind-mount from the host; node_modules is local to the
 # container and must be installed at runtime. Skip if already present so
 # subsequent container starts are fast.
-if [ ! -d /workspaces/main/node_modules ]; then
+# Guard on npm's install marker (.package-lock.json), NOT on the node_modules
+# dir: a stale dir containing only .cache/jiti (created by pi's extension
+# loader) would otherwise skip the install forever and every extension that
+# imports a third-party package fails to load.
+if [ ! -f /workspaces/main/node_modules/.package-lock.json ]; then
     echo "Installing workspace npm dependencies…"
     gosu agentuser bash -c 'cd /workspaces/main && npm install --no-audit --no-fund' \
         || echo "Warning: npm install failed (non-fatal — pi may still work depending on which extensions are loaded)"

--- a/docker/test/cli-install-smoke.test.mts
+++ b/docker/test/cli-install-smoke.test.mts
@@ -414,6 +414,15 @@ describe("CLI install smoke", { timeout: 600_000 }, () => {
 			cleaned.includes("SessionID") || cleaned.includes("Docker Engine"),
 			`expected pi output, got (cleaned, last 2000 chars):\n${cleaned.slice(-2000)}`,
 		);
+
+		// Extensions must load cleanly — a boot that only *survives* (pi treats
+		// extension load failure as non-fatal and keeps running) but shows
+		// "Failed to load extension" is a broken image. The stale-dir npm
+		// guard bug (#1561) produced exactly this: pi boots, extensions fail.
+		assert.ok(
+			!cleaned.includes("Failed to load extension"),
+			`extension load failed at pi boot (cleaned, last 2000 chars):\n${cleaned.slice(-2000)}`,
+		);
 	});
 
 	// ── Checkpoint 9: cheasee-pi down removes container ────────────


### PR DESCRIPTION
A stale node_modules containing only .cache/jiti (created by pi's
extension loader on a first boot where install failed or was skipped)
defeats the dir-exists guard and skips the runtime npm install
forever — every extension importing zod/proper-lockfile/typescript/
shell-quote fails to load. npm writes .package-lock.json last on a
successful install, so guard on that instead.
