### PR TITLE
fix(uninstall): sudo hint uses full binary path, docs warn against sudo

### DIFF
--- a/.pi/context/qna.jsonl
+++ b/.pi/context/qna.jsonl
@@ -75,3 +75,4 @@
 {"datetime":"2026-08-09T16:46:53.119Z","question":"Existing non-empty repo (like the cheasee-pi repo itself) — how does it get its cheasee-settings.json?","answer":"init_empty_only"}
 {"datetime":"2026-08-11T20:28:17.735Z","question":"6 old pi sessions (48–138 min old, ~781 MB total) are candidates for \"stale\". Which do I kill?","answer":"why did cheasee-pi clean not cleaned that up? fix that please"}
 {"datetime":"2026-08-11T20:40:02.447Z","question":"How should the .zed clean task be improved?","answer":"both"}
+{"datetime":"2026-08-14T18:35:45.740Z","question":"Entrypoint npm-install guard checks `[ ! -d node_modules ]`; stale empty dir (jiti cache) defeats it forever. Fix: check `node_modules/.package-lock.json` instead. Want PR (worktree + branch, main locked)?","answer":"fix_pr"}

--- a/cmd/cheasee-pi/uninstall.go
+++ b/cmd/cheasee-pi/uninstall.go
@@ -154,11 +154,11 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 		// Check if parent dir is writable — if not, suggest sudo
 		if f, err := os.Stat(binaryDir); err == nil && f.Mode().Perm()&0o222 == 0 {
 			fmt.Fprintf(os.Stderr, "  ⚠ cannot remove binary — %s is not writable by you\n", binaryDir)
-			fmt.Fprintf(os.Stderr, "    Re-run with: sudo %s uninstall\n", filepath.Base(binaryPath))
+			fmt.Fprintf(os.Stderr, "    Remove it manually: sudo rm %s\n", binaryPath)
 		} else if err := os.Remove(binaryPath); err != nil {
 			fmt.Fprintf(os.Stderr, "  ⚠ failed to remove binary at %s\n", binaryPath)
 			fmt.Fprintf(os.Stderr, "    Cause: %v\n", err)
-			fmt.Fprintf(os.Stderr, "    To remove manually: sudo rm %s\n", binaryPath)
+			fmt.Fprintf(os.Stderr, "    Remove it manually: sudo rm %s\n", binaryPath)
 		} else {
 			fmt.Fprintf(os.Stderr, "  ✓ Removed binary\n")
 		}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -287,6 +287,8 @@ For workspace-level cleanup from inside a workspace, `cheasee-pi uninstall` remo
 cheasee-pi uninstall
 ```
 
+Run it **without** `sudo` — under sudo, the config/cache paths resolve to root's account and the command would delete root's state, not yours. If the binary lives in a root-owned directory like `/usr/local/bin`, use the standalone script above instead: it elevates per-operation and never needs sudo. When the CLI itself can't remove the binary, it prints a manual `sudo rm` hint with the full path.
+
 Add `--force` to skip confirmation, `--remove-git` to also delete `.git/`.
 
 ---


### PR DESCRIPTION
## Problem

`cheasee-pi uninstall` prints this when the binary's directory is not writable:

```
⚠ cannot remove binary — /usr/local/bin is not writable by you
  Re-run with: sudo cheasee-pi uninstall
```

That hint is broken twice over:

1. `sudo` resets PATH (secure_path), so `sudo cheasee-pi uninstall` fails with
   "command not found" unless the bare binary name happens to be on root's PATH.
2. Under sudo, `HOME` and the XDG config/cache dirs resolve to root's account —
   a full `sudo ... uninstall` re-run deletes **root's** state, not the user's.

## Fix

- Both failure branches now print `sudo rm <full path>` — state removal has
  already completed at that point, so removing just the binary finishes the
  uninstall. Full path avoids the PATH lookup problem entirely.
- `docs/installation.md` CLI-command section now warns explicitly: run
  `cheasee-pi uninstall` without sudo, and use `scripts/uninstall.sh` for
  root-owned binary locations.

## Verification

- `go test ./cmd/cheasee-pi/ -count=1` passes (incl. the doc test that forbids
  `sudo cheasee-pi uninstall` in the docs).