### PR TITLE
chore: bump version to v0.51

### DIFF
--- a/cmd/cheasee-pi/cache.go
+++ b/cmd/cheasee-pi/cache.go
@@ -24,7 +24,7 @@ func CacheDir() (string, error) {
 // cliVersionKey is the cache-dir key: the CLI's own semver. Kept as a const
 // (referenced by rootCmd.Version too) so the cache path never participates in
 // a rootCmd initialization cycle.
-const cliVersionKey = "0.50"
+const cliVersionKey = "0.51"
 
 // cliVersion is the cache-dir key: the CLI's own semver.
 func cliVersion() string {

--- a/cmd/cheasee-pi/installation_doc_test.go
+++ b/cmd/cheasee-pi/installation_doc_test.go
@@ -170,9 +170,9 @@ func TestDailyUsageDoc_OneShotFirstRun(t *testing.T) {
 
 // TestInstallationDoc_UninstallScriptReference verifies the Uninstall section
 // presents the standalone scripts/uninstall.sh one-liner as the primary path
-// (issue #1510) while retaining the `cheasee-pi uninstall` subcommand for
-// workspace-level cleanup — and drops the misleading `sudo` prefix (under
-// sudo, os.UserCacheDir/UserConfigDir resolve to /root).
+// (issue #1510) while retaining the `cheasee-pi uninstall` subcommand — and
+// drops the misleading `sudo` prefix (under sudo, os.UserCacheDir/
+// UserConfigDir resolve to /root).
 func TestInstallationDoc_UninstallScriptReference(t *testing.T) {
 	data, err := os.ReadFile(docPath())
 	if err != nil {

--- a/cmd/cheasee-pi/root_test.go
+++ b/cmd/cheasee-pi/root_test.go
@@ -144,7 +144,7 @@ func TestRootCmd_Version_IsValidSemver(t *testing.T) {
 }
 
 func TestRootCmd_Version_IsExpectedRelease(t *testing.T) {
-	expected := "0.50"
+	expected := "0.51"
 	if rootCmd.Version != expected {
 		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, expected)
 	}

--- a/cmd/cheasee-pi/uninstall.go
+++ b/cmd/cheasee-pi/uninstall.go
@@ -9,11 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	uninstallWorkdir  string
-	uninstallForce    bool
-	uninstallRemoveGit bool
-)
+var uninstallForce bool
 
 var uninstallCmd = &cobra.Command{
 	Use:   "uninstall",
@@ -22,11 +18,10 @@ var uninstallCmd = &cobra.Command{
 
 The uninstall command removes:
   1. Cache dir (compose/Dockerfile under the user cache dir)
-  2. .pi/ directory (agent configuration, contexts, themes)
-  3. Auth config (~/.config/cheasee-pi/auth.json)
-  4. cheasee-pi binary (the running executable)
-  5. .git/ directory (if --remove-git is set)
+  2. Auth config (~/.config/cheasee-pi/auth.json)
+  3. cheasee-pi binary (the running executable)
 
+Workspace files (.pi/, .git/, source checkouts) are never touched.
 Use --force to skip the confirmation prompt.`,
 	DisableAutoGenTag: true,
 	RunE:              runUninstallE,
@@ -34,21 +29,10 @@ Use --force to skip the confirmation prompt.`,
 
 func init() {
 	rootCmd.AddCommand(uninstallCmd)
-	uninstallCmd.Flags().StringVar(&uninstallWorkdir, "workdir", "", "Working directory (default: current directory)")
 	uninstallCmd.Flags().BoolVar(&uninstallForce, "force", false, "Skip confirmation prompt")
-	uninstallCmd.Flags().BoolVar(&uninstallRemoveGit, "remove-git", false, "Also remove .git directory")
 }
 
 func runUninstallE(cmd *cobra.Command, _ []string) error {
-	workdir := uninstallWorkdir
-	if workdir == "" {
-		var err error
-		workdir, err = os.Getwd()
-		if err != nil {
-			return fmt.Errorf("get working directory: %w", err)
-		}
-	}
-
 	identify := func(path string) string {
 		if _, err := os.Stat(path); err == nil {
 			return "will remove"
@@ -58,8 +42,6 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 
 	// CLI-managed assets live in the version-keyed cache dir, never the repo.
 	cacheDir, _ := CacheDir()
-	piDir := filepath.Join(workdir, ".pi")
-	gitDir := filepath.Join(workdir, ".git")
 
 	// Detect binary path — skip if running from Go build cache
 	binaryPath, _ := os.Executable()
@@ -78,13 +60,6 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 	fmt.Fprintf(os.Stderr, "The following will be removed:\n")
 	if cacheDir != "" {
 		fmt.Fprintf(os.Stderr, "  %s        — %s\n", cacheDir, identify(cacheDir))
-	}
-	fmt.Fprintf(os.Stderr, "  %s/.pi/      — %s\n", filepath.Base(workdir), identify(piDir))
-	fmt.Fprintf(os.Stderr, "  %s/.git/     — %s", filepath.Base(workdir), identify(gitDir))
-	if uninstallRemoveGit {
-		fmt.Fprintf(os.Stderr, " (--remove-git)\n")
-	} else {
-		fmt.Fprintf(os.Stderr, " (use --remove-git to include)\n")
 	}
 
 	// Auth config
@@ -118,22 +93,6 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 			fmt.Fprintf(os.Stderr, "  ⚠ failed to remove cache dir: %v\n", err)
 		} else {
 			fmt.Fprintf(os.Stderr, "  ✓ Removed cache dir\n")
-		}
-	}
-
-	// Remove .pi/
-	if err := os.RemoveAll(piDir); err != nil {
-		fmt.Fprintf(os.Stderr, "  ⚠ failed to remove .pi/: %v\n", err)
-	} else {
-		fmt.Fprintf(os.Stderr, "  ✓ Removed .pi/\n")
-	}
-
-	// Remove .git/ (only if --remove-git)
-	if uninstallRemoveGit {
-		if err := os.RemoveAll(gitDir); err != nil {
-			fmt.Fprintf(os.Stderr, "  ⚠ failed to remove .git/: %v\n", err)
-		} else {
-			fmt.Fprintf(os.Stderr, "  ✓ Removed .git/\n")
 		}
 	}
 

--- a/cmd/cheasee-pi/uninstall_script_test.go
+++ b/cmd/cheasee-pi/uninstall_script_test.go
@@ -16,8 +16,8 @@ func uninstallScriptPath() string {
 
 // TestUninstallScript_DryRunMatchesGoPaths pins the standalone uninstall
 // script's --dry-run deletion list to the Go-computed paths it must mirror
-// (cache parent, auth config, workdir .pi/, binary). The script removes the
-// whole <cache>/cheasee-pi/ parent while Go removes only the current version
+// (cache parent, auth config, binary). The script removes the whole
+// <cache>/cheasee-pi/ parent while Go removes only the current version
 // key — this intentional divergence is what the test locks in.
 func TestUninstallScript_DryRunMatchesGoPaths(t *testing.T) {
 	script := uninstallScriptPath()
@@ -30,15 +30,14 @@ func TestUninstallScript_DryRunMatchesGoPaths(t *testing.T) {
 	cacheBase := filepath.Join(tmp, "cache")
 	configBase := filepath.Join(tmp, "config")
 	binDir := filepath.Join(tmp, "bin")
-	workdir := filepath.Join(tmp, "ws")
-	for _, d := range []string{home, cacheBase, configBase, binDir, workdir} {
+	for _, d := range []string{home, cacheBase, configBase, binDir} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", d, err)
 		}
 	}
 
 	// Install-state fixture: cache parent with two version keys, auth.json,
-	// a .pi/ in the workdir, and a dummy binary on PATH.
+	// and a dummy binary on PATH. (Workspace .pi/.git must never appear.)
 	cacheParent := filepath.Join(cacheBase, "cheasee-pi")
 	for _, v := range []string{"0.49", "0.50"} {
 		if err := os.MkdirAll(filepath.Join(cacheParent, v), 0o755); err != nil {
@@ -52,10 +51,6 @@ func TestUninstallScript_DryRunMatchesGoPaths(t *testing.T) {
 	if err := os.WriteFile(authPath, []byte("{}\n"), 0o600); err != nil {
 		t.Fatalf("write %s: %v", authPath, err)
 	}
-	piDir := filepath.Join(workdir, ".pi")
-	if err := os.MkdirAll(piDir, 0o755); err != nil {
-		t.Fatalf("mkdir %s: %v", piDir, err)
-	}
 	binary := filepath.Join(binDir, "cheasee-pi")
 	if err := os.WriteFile(binary, []byte("#!/bin/sh\n"), 0o755); err != nil {
 		t.Fatalf("write %s: %v", binary, err)
@@ -66,7 +61,7 @@ func TestUninstallScript_DryRunMatchesGoPaths(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", configBase)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	cmd := exec.Command("bash", script, "--dry-run", "--force", "--workdir", workdir)
+	cmd := exec.Command("bash", script, "--dry-run", "--force")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("uninstall.sh --dry-run failed: %v\n%s", err, out)
@@ -83,7 +78,6 @@ func TestUninstallScript_DryRunMatchesGoPaths(t *testing.T) {
 	want := map[string]bool{
 		filepath.Dir(mustCacheDir(t)): true, // whole cache parent (all version keys)
 		authPath:                      true,
-		piDir:                         true,
 		binary:                        true,
 	}
 	if len(got) != len(want) {
@@ -95,7 +89,7 @@ func TestUninstallScript_DryRunMatchesGoPaths(t *testing.T) {
 		}
 	}
 	// Dry run must not delete anything.
-	for _, p := range []string{filepath.Join(cacheParent, "0.49"), authPath, piDir, binary} {
+	for _, p := range []string{filepath.Join(cacheParent, "0.49"), authPath, binary} {
 		if _, err := os.Stat(p); err != nil {
 			t.Errorf("dry-run deleted %s: %v", p, err)
 		}

--- a/docker/test/cli-install-smoke.test.mts
+++ b/docker/test/cli-install-smoke.test.mts
@@ -88,7 +88,7 @@ const POLL_INTERVAL_MS = 5_000;
  * The cache dir is version-keyed so an upgraded binary never mixes stale
  * compose/Dockerfile content with new embedded assets.
  */
-const CLI_VERSION = "0.50";
+const CLI_VERSION = "0.51";
 
 /**
  * Compute the CLI cache dir (compose/Dockerfile live there,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,9 +136,9 @@ Remove cheasee-pi configuration and CLI-managed assets.
 
 | | |
 |---|---|
-| **Does** | Removes the version-keyed cache dir (compose/Dockerfile), the workspace `.pi/`, `~/.config/cheasee-pi/auth.json`, the running binary, and `.git/` when `--remove-git` is set. |
+| **Does** | Removes the version-keyed cache dir (compose/Dockerfile), `~/.config/cheasee-pi/auth.json`, and the running binary. Workspace files (`.pi/`, `.git/`, source checkouts) are never touched. |
 | **Checks** | Shows a summary and asks for confirmation (`--force` skips). Skips binary removal when running from a Go build cache; warns when the binary's directory is not writable. |
-| **Inputs** | Flags: `--workdir`, `--force`, `--remove-git`. |
+| **Inputs** | Flags: `--force`. |
 
 ## Environment variables
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ nav_order: 2
 
 ```bash
 # Set version (check latest at https://github.com/SchneiderDaniel/cheasee-pi/releases)
-VERSION="0.50"
+VERSION="0.51"
 
 # Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -43,7 +43,7 @@ curl -fsL "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v${VE
 
 ```powershell
 # PowerShell
-$version = "0.50"
+$version = "0.51"
 $arch = if ((Get-CimInstance Win32_ComputerSystem).SystemType -match "ARM") { "arm64" } else { "amd64" }
 curl -Lo cheasee-pi.zip "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v$version/cheasee-pi_${version}_windows_$arch.zip"
 tar -xf cheasee-pi.zip

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -277,17 +277,17 @@ docker exec -it \
 curl -fsL https://raw.githubusercontent.com/SchneiderDaniel/cheasee-pi/main/scripts/uninstall.sh | bash
 ```
 
-Add `--force` to skip the confirmation prompt, `--dry-run` to preview what would be removed. The script removes the binary (from `/usr/local/bin`, `~/.local/bin`, or your PATH), the whole CLI cache dir, the auth config (`cheasee-pi/auth.json` under your user config dir), and the `.pi/` directory in the current folder (`--remove-git` also deletes `.git/`). It works even if the binary is already gone, and never needs `sudo` (root-owned files like `/usr/local/bin` are elevated per-operation).
+Add `--force` to skip the confirmation prompt, `--dry-run` to preview what would be removed. The script removes the binary (from `/usr/local/bin`, `~/.local/bin`, or your PATH), the whole CLI cache dir, and the auth config (`cheasee-pi/auth.json` under your user config dir). Workspace files (`.pi/`, `.git/`, source checkouts) are never touched. It works even if the binary is already gone, and never needs `sudo` (root-owned files like `/usr/local/bin` are elevated per-operation).
 
 ### CLI command
 
-For workspace-level cleanup from inside a workspace, `cheasee-pi uninstall` removes the cache dir, auth config, `.pi/`, and the running binary:
+`cheasee-pi uninstall` removes the cache dir, auth config, and the running binary:
 
 ```bash
 cheasee-pi uninstall
 ```
 
-Add `--force` to skip confirmation, `--remove-git` to also delete `.git/`.
+Add `--force` to skip confirmation.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "main",
-	"version": "0.50",
+	"version": "0.51",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "main",
-			"version": "0.50",
+			"version": "0.51",
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "^0.79.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "main",
-	"version": "0.50",
+	"version": "0.51",
 	"description": "---",
 	"main": "index.js",
 	"scripts": {

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,35 +5,27 @@
 #      symlink-resolved, go-build/tmp paths skipped)
 #   2. the whole cache parent <UserCacheDir>/cheasee-pi/ (all version keys)
 #   3. the auth config <UserConfigDir>/cheasee-pi/auth.json
-#   4. .pi/ (and .git/ with --remove-git) under --workdir (default: cwd)
+#
+# Workspace files (.pi/, .git/, source checkouts) are never touched.
 #
 # Usage:
 #   curl -fsL https://raw.githubusercontent.com/SchneiderDaniel/cheasee-pi/main/scripts/uninstall.sh | bash
-#   bash scripts/uninstall.sh [--force] [--dry-run] [--workdir DIR] [--remove-git]
+#   bash scripts/uninstall.sh [--force] [--dry-run]
 #
 # Flags (meaningful when run from a file — under `curl | bash` stdin is the
 # script stream, so the confirmation prompt is skipped automatically):
 #   --force       skip the confirmation prompt
 #   --dry-run     print the deletion list and exit without deleting
-#   --workdir DIR scope .pi/ (and .git/ with --remove-git) cleanup to DIR
-#   --remove-git  also remove .git/ under --workdir
 #   env NONINTERACTIVE=1 skips the prompt (same as --force)
 set -euo pipefail
 
 FORCE=0
 DRY_RUN=0
-REMOVE_GIT=0
-WORKDIR=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --force) FORCE=1 ;;
     --dry-run) DRY_RUN=1 ;;
-    --remove-git) REMOVE_GIT=1 ;;
-    --workdir)
-      WORKDIR="${2:-}"
-      shift
-      ;;
     *)
       echo "Unknown option: $1" >&2
       exit 1
@@ -41,8 +33,6 @@ while [ "$#" -gt 0 ]; do
   esac
   shift
 done
-
-WORKDIR="${WORKDIR:-$(pwd)}"
 
 # Running as root via sudo: sudoers env_reset sets HOME=/root, so resolve the
 # invoking user's home — root's own cache/config must never be the target.
@@ -151,14 +141,6 @@ config_base="$(user_config_dir)"
 if [ -n "$config_base" ]; then
   auth_path="$config_base/cheasee-pi/auth.json"
   if [ -e "$auth_path" ]; then file_targets+=("$auth_path"); fi
-fi
-
-pi_dir="$WORKDIR/.pi"
-if [ -e "$pi_dir" ]; then tree_targets+=("$pi_dir"); fi
-
-if [ "$REMOVE_GIT" -eq 1 ]; then
-  git_dir="$WORKDIR/.git"
-  if [ -e "$git_dir" ]; then tree_targets+=("$git_dir"); fi
 fi
 
 collect_binaries

--- a/test/uninstall-script.test.sh
+++ b/test/uninstall-script.test.sh
@@ -40,11 +40,10 @@ new_dir() {
 
 # build_fixture <sandbox> — creates a fake full install state and exports
 # fresh HOME/XDG_*/PATH pointing into the sandbox (in the calling shell; do
-# not wrap in command substitution). Sets FIXTURE_WORKDIR for the caller.
+# not wrap in command substitution).
 build_fixture() {
   local sandbox="$1"
-  FIXTURE_WORKDIR="$sandbox/workdir"
-  mkdir -p "$FIXTURE_WORKDIR" "$sandbox/home" "$sandbox/cache" "$sandbox/config" "$sandbox/bin"
+  mkdir -p "$sandbox/home" "$sandbox/cache" "$sandbox/config" "$sandbox/bin"
   export HOME="$sandbox/home"
   export XDG_CACHE_HOME="$sandbox/cache"
   export XDG_CONFIG_HOME="$sandbox/config"
@@ -54,9 +53,6 @@ build_fixture() {
   # auth config
   mkdir -p "$XDG_CONFIG_HOME/cheasee-pi"
   printf '{}\n' > "$XDG_CONFIG_HOME/cheasee-pi/auth.json"
-  # workspace artifacts
-  mkdir -p "$FIXTURE_WORKDIR/.pi" "$FIXTURE_WORKDIR/.git"
-  printf '{}\n' > "$FIXTURE_WORKDIR/cheasee-settings.json"
   # binary on PATH (outside the two install dirs → command -v hit)
   printf '#!/bin/sh\necho fake\n' > "$sandbox/bin/cheasee-pi"
   chmod +x "$sandbox/bin/cheasee-pi"
@@ -79,16 +75,18 @@ t_force() {
   local sandbox workdir
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
+  workdir="$sandbox/workdir"
+  mkdir -p "$workdir/.pi" "$workdir/.git"
+  printf '{}\n' > "$workdir/cheasee-settings.json"
   local out
-  out="$(bash "$SCRIPT" --force --workdir "$workdir" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   local rc=$?
   if [ "$rc" -eq 0 ]; then pass "--force happy path exits 0"; else fail "--force happy path exits 0 (got $rc): $out"; fi
   assert_gone "$XDG_CACHE_HOME/cheasee-pi" "whole cache parent removed (both version keys)"
   assert_gone "$XDG_CONFIG_HOME/cheasee-pi/auth.json" "auth.json removed"
-  assert_gone "$workdir/.pi" ".pi/ removed"
   assert_gone "$sandbox/bin/cheasee-pi" "binary removed"
-  assert_present "$workdir/.git" ".git/ retained (no --remove-git)"
+  assert_present "$workdir/.pi" ".pi/ retained (workspace never touched)"
+  assert_present "$workdir/.git" ".git/ retained (workspace never touched)"
   assert_present "$workdir/cheasee-settings.json" "cheasee-settings.json retained"
 }
 t_force
@@ -98,13 +96,12 @@ t_dry_run() {
   local sandbox workdir out
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
-  out="$(bash "$SCRIPT" --dry-run --force --workdir "$workdir" 2>&1)"
+  out="$(bash "$SCRIPT" --dry-run --force 2>&1)"
   local rc=$?
   if [ "$rc" -eq 0 ]; then pass "--dry-run exits 0"; else fail "--dry-run exits 0 (got $rc)"; fi
   local cache_parent="$XDG_CACHE_HOME/cheasee-pi"
   local auth_path="$XDG_CONFIG_HOME/cheasee-pi/auth.json"
-  for target in "$cache_parent" "$auth_path" "$workdir/.pi" "$sandbox/bin/cheasee-pi"; do
+  for target in "$cache_parent" "$auth_path" "$sandbox/bin/cheasee-pi"; do
     if printf '%s\n' "$out" | grep -Fq "  will remove $target"; then
       pass "--dry-run lists $target"
     else
@@ -113,24 +110,21 @@ t_dry_run() {
   done
   assert_present "$cache_parent/0.49" "--dry-run deletes nothing (cache)"
   assert_present "$auth_path" "--dry-run deletes nothing (auth.json)"
-  assert_present "$workdir/.pi" "--dry-run deletes nothing (.pi/)"
   assert_present "$sandbox/bin/cheasee-pi" "--dry-run deletes nothing (binary)"
 }
 t_dry_run
 
 # --- TTY-gate regression (piped stdin = script stream) ----------------------
 t_piped_stdin() {
-  local sandbox workdir
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   local out rc
   set +e
-  out="$(cd "$workdir" && cat "$SCRIPT" | bash 2>&1)"
+  out="$(cat "$SCRIPT" | bash 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "cat script | bash completes without hang (exit 0)"; else fail "cat script | bash (got $rc)"; fi
-  assert_gone "$workdir/.pi" "piped run removes state (prompt skipped, no stdin consumed)"
   assert_gone "$XDG_CACHE_HOME/cheasee-pi" "piped run removes cache parent"
 }
 t_piped_stdin
@@ -142,12 +136,11 @@ t_prompt() {
     return 0
   fi
   # 'n' on a pty → cancelled, nothing deleted
-  local sandbox workdir out rc
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   set +e
-  out="$(printf 'n\n' | script -qec "bash \"$SCRIPT\" --workdir \"$workdir\"" /dev/null 2>&1)"
+  out="$(printf 'n\n' | script -qec "bash \"$SCRIPT\"" /dev/null 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "prompt 'n' exits 0"; else fail "prompt 'n' exits 0 (got $rc)"; fi
@@ -156,37 +149,34 @@ t_prompt() {
   else
     fail "prompt 'n' prints 'Uninstall cancelled.'"
   fi
-  assert_present "$workdir/.pi" "prompt 'n' deletes nothing (.pi/)"
   assert_present "$XDG_CACHE_HOME/cheasee-pi" "prompt 'n' deletes nothing (cache)"
 
   # NONINTERACTIVE=1 on a pty → prompt skipped, deletion proceeds
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   set +e
-  out="$(printf 'n\n' | NONINTERACTIVE=1 script -qec "bash \"$SCRIPT\" --workdir \"$workdir\"" /dev/null 2>&1)"
+  out="$(printf 'n\n' | NONINTERACTIVE=1 script -qec "bash \"$SCRIPT\"" /dev/null 2>&1)"
   rc=$?
   set -e
-  if [ "$rc" -eq 0 ] && [ ! -e "$workdir/.pi" ]; then
+  if [ "$rc" -eq 0 ] && [ ! -e "$XDG_CACHE_HOME/cheasee-pi" ]; then
     pass "NONINTERACTIVE=1 skips the prompt (deletes despite 'n' on stdin)"
   else
-    fail "NONINTERACTIVE=1 skips the prompt (rc=$rc, .pi exists: $([ -e "$workdir/.pi" ] && echo yes || echo no))"
+    fail "NONINTERACTIVE=1 skips the prompt (rc=$rc, cache exists: $([ -e "$XDG_CACHE_HOME/cheasee-pi" ] && echo yes || echo no))"
   fi
 }
 t_prompt
 
 # --- partial failure --------------------------------------------------------
 t_partial_failure() {
-  local sandbox workdir out rc
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   # Make auth.json a non-empty dir → rm -f (file semantics) must fail
   rm "$XDG_CONFIG_HOME/cheasee-pi/auth.json"
   mkdir "$XDG_CONFIG_HOME/cheasee-pi/auth.json"
   touch "$XDG_CONFIG_HOME/cheasee-pi/auth.json/blocker"
   set +e
-  out="$(bash "$SCRIPT" --force --workdir "$workdir" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -ne 0 ]; then pass "partial failure exits non-zero (got $rc)"; else fail "partial failure exits non-zero (got 0)"; fi
@@ -197,7 +187,6 @@ t_partial_failure() {
   fi
   assert_present "$XDG_CONFIG_HOME/cheasee-pi/auth.json" "failed target left in place"
   assert_gone "$XDG_CACHE_HOME/cheasee-pi" "other targets still removed (cache)"
-  assert_gone "$workdir/.pi" "other targets still removed (.pi/)"
   assert_gone "$sandbox/bin/cheasee-pi" "other targets still removed (binary)"
 }
 t_partial_failure
@@ -210,7 +199,7 @@ t_nothing_installed() {
   export PATH="$sandbox/bin:$ORIG_PATH"
   mkdir -p "$HOME" "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$sandbox/bin"
   set +e
-  out="$(bash "$SCRIPT" --force --workdir "$sandbox" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "nothing installed exits 0"; else fail "nothing installed exits 0 (got $rc)"; fi
@@ -222,7 +211,7 @@ t_nothing_installed() {
 
   # set -u hardening: no unbound-variable errors with env vars stripped
   set +e
-  out="$(env -u HOME -u XDG_CACHE_HOME -u XDG_CONFIG_HOME bash "$SCRIPT" --dry-run --force --workdir "$sandbox" 2>&1)"
+  out="$(env -u HOME -u XDG_CACHE_HOME -u XDG_CONFIG_HOME bash "$SCRIPT" --dry-run --force 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "env -u HOME ... runs clean (exit 0)"; else fail "env -u HOME ... (got $rc): $out"; fi
@@ -237,16 +226,15 @@ t_nothing_installed
 # --- binary detection: symlinks, command -v, go-build/tmp skip, dedup -------
 t_binary_detection() {
   # symlinked binary: real file resolved and removed (link too)
-  local sandbox workdir out rc
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   mkdir -p "$sandbox/real-bin"
   printf '#!/bin/sh\n' > "$sandbox/real-bin/cheasee-pi"
   chmod +x "$sandbox/real-bin/cheasee-pi"
   ln -sf "$sandbox/real-bin/cheasee-pi" "$sandbox/bin/cheasee-pi"
   set +e
-  out="$(bash "$SCRIPT" --force --workdir "$workdir" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
   assert_gone "$sandbox/real-bin/cheasee-pi" "symlinked binary resolved and real file removed"
@@ -257,13 +245,12 @@ t_binary_detection() {
   for go_path in "$HOME/go-build" "$HOME/tmp/go"; do
     sandbox="$(new_dir)"
     build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
     rm "$sandbox/bin/cheasee-pi"
     mkdir -p "$go_path"
     printf '#!/bin/sh\n' > "$go_path/cheasee-pi"
     chmod +x "$go_path/cheasee-pi"
     set +e
-    out="$(PATH="$go_path:$ORIG_PATH" bash "$SCRIPT" --dry-run --force --workdir "$workdir" 2>&1)"
+    out="$(PATH="$go_path:$ORIG_PATH" bash "$SCRIPT" --dry-run --force 2>&1)"
     rc=$?
     set -e
     if printf '%s\n' "$out" | grep -Fq "will remove $go_path/cheasee-pi"; then
@@ -277,13 +264,12 @@ t_binary_detection() {
   # duplicate candidates deduped to one list entry
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   rm "$sandbox/bin/cheasee-pi"
   mkdir -p "$HOME/.local/bin"
   printf '#!/bin/sh\n' > "$HOME/.local/bin/cheasee-pi"
   chmod +x "$HOME/.local/bin/cheasee-pi"
   set +e
-  out="$(PATH="$HOME/.local/bin:$ORIG_PATH" bash "$SCRIPT" --dry-run --force --workdir "$workdir" 2>&1)"
+  out="$(PATH="$HOME/.local/bin:$ORIG_PATH" bash "$SCRIPT" --dry-run --force 2>&1)"
   rc=$?
   set -e
   local count
@@ -296,45 +282,33 @@ t_binary_detection() {
 }
 t_binary_detection
 
-# --- --workdir scoping / --remove-git ---------------------------------------
-t_workdir() {
-  local sandbox workdir other out rc
+# --- workspace files are never touched --------------------------------------
+t_workspace_untouched() {
+  # Running from inside a workspace must leave .pi/ and .git/ alone.
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
-  other="$sandbox/other"
-  mkdir -p "$other/.pi"
-  # default cwd: .pi/ in cwd removed, other workspace untouched
+  mkdir -p "$sandbox/ws/.pi" "$sandbox/ws/.git"
   set +e
-  out="$(cd "$workdir" && bash "$SCRIPT" --force 2>&1)"
+  out="$(cd "$sandbox/ws" && bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
-  assert_gone "$workdir/.pi" "--workdir defaults to cwd (.pi/ in cwd removed)"
-  assert_present "$other/.pi" "other workspace .pi/ untouched"
-  assert_present "$workdir/.git" ".git/ retained without --remove-git"
-
-  # --remove-git adds .git/
-  set +e
-  out="$(bash "$SCRIPT" --force --remove-git --workdir "$workdir" 2>&1)"
-  rc=$?
-  set -e
-  assert_gone "$workdir/.git" "--remove-git removes .git/"
-
-  # explicit --workdir scopes .pi/ cleanup there
-  mkdir -p "$other/.pi"
-  set +e
-  out="$(bash "$SCRIPT" --force --workdir "$other" 2>&1)"
-  rc=$?
-  set -e
-  assert_gone "$other/.pi" "--workdir <dir> scopes .pi/ cleanup to <dir>"
+  if [ "$rc" -eq 0 ]; then pass "run from workspace exits 0"; else fail "run from workspace exits 0 (got $rc): $out"; fi
+  assert_present "$sandbox/ws/.pi" "workspace .pi/ untouched"
+  assert_present "$sandbox/ws/.git" "workspace .git/ untouched"
+  if printf '%s\n' "$out" | grep -Fq ".pi"; then
+    fail "deletion list never mentions .pi/"
+  else
+    pass "deletion list never mentions .pi/"
+  fi
 }
-t_workdir
+t_workspace_untouched
 
 # --- paths with spaces + XDG fallback ---------------------------------------
 t_spaces() {
   local sandbox out rc
   sandbox="$(new_dir)/sandbox with spaces"
-  mkdir -p "$sandbox/home dir" "$sandbox/cache dir/cheasee-pi/0.50" "$sandbox/config dir/cheasee-pi" "$sandbox/ws dir/.pi" "$sandbox/bin dir"
+  mkdir -p "$sandbox/home dir" "$sandbox/cache dir/cheasee-pi/0.50" "$sandbox/config dir/cheasee-pi" "$sandbox/bin dir"
   export HOME="$sandbox/home dir"
   export XDG_CACHE_HOME="$sandbox/cache dir"
   export XDG_CONFIG_HOME="$sandbox/config dir"
@@ -343,13 +317,12 @@ t_spaces() {
   printf '#!/bin/sh\n' > "$sandbox/bin dir/cheasee-pi"
   chmod +x "$sandbox/bin dir/cheasee-pi"
   set +e
-  out="$(bash "$SCRIPT" --force --workdir "$sandbox/ws dir" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "paths with spaces handled (exit 0)"; else fail "paths with spaces handled (got $rc): $out"; fi
   assert_gone "$XDG_CACHE_HOME/cheasee-pi" "spaced cache parent removed"
   assert_gone "$XDG_CONFIG_HOME/cheasee-pi/auth.json" "spaced auth.json removed"
-  assert_gone "$sandbox/ws dir/.pi" "spaced .pi/ removed"
   assert_gone "$sandbox/bin dir/cheasee-pi" "spaced binary removed"
 
   # XDG vars unset → $HOME/.cache and $HOME/.config fallback
@@ -359,7 +332,7 @@ t_spaces() {
   mkdir -p "$HOME/.cache/cheasee-pi/0.50" "$HOME/.config/cheasee-pi"
   printf '{}\n' > "$HOME/.config/cheasee-pi/auth.json"
   set +e
-  out="$(bash "$SCRIPT" --force --workdir "$sandbox" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
   assert_gone "$HOME/.cache/cheasee-pi" "XDG unset → \$HOME/.cache fallback used"
@@ -369,13 +342,12 @@ t_spaces
 
 # --- idempotency ------------------------------------------------------------
 t_idempotent() {
-  local sandbox workdir out rc
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
-  bash "$SCRIPT" --force --workdir "$workdir" >/dev/null 2>&1
+  bash "$SCRIPT" --force >/dev/null 2>&1
   set +e
-  out="$(bash "$SCRIPT" --force --workdir "$workdir" 2>&1)"
+  out="$(bash "$SCRIPT" --force 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "second run exits 0"; else fail "second run exits 0 (got $rc)"; fi
@@ -389,12 +361,11 @@ t_idempotent
 
 # --- user journey: the documented one-liner delivery shape ------------------
 t_user_journey() {
-  local sandbox workdir out rc
+  local sandbox out rc
   sandbox="$(new_dir)"
   build_fixture "$sandbox"
-  workdir="$FIXTURE_WORKDIR"
   set +e
-  out="$(cd "$workdir" && cat "$SCRIPT" | bash 2>&1)"
+  out="$(cat "$SCRIPT" | bash 2>&1)"
   rc=$?
   set -e
   if [ "$rc" -eq 0 ]; then pass "user journey: cat scripts/uninstall.sh | bash exits 0"; else fail "user journey exit 0 (got $rc)"; fi
@@ -405,7 +376,6 @@ t_user_journey() {
       fail "user journey: shows '$needle'"
     fi
   done
-  assert_gone "$workdir/.pi" "user journey: host fully clean (.pi/)"
   assert_gone "$XDG_CACHE_HOME/cheasee-pi" "user journey: host fully clean (cache)"
   assert_gone "$XDG_CONFIG_HOME/cheasee-pi/auth.json" "user journey: host fully clean (auth.json)"
   assert_gone "$sandbox/bin/cheasee-pi" "user journey: host fully clean (binary)"


### PR DESCRIPTION
## What

Version bump 0.50 → 0.51, same 6 files touched as the v0.50 bump (plus cache.go instead of root.go — rootCmd.Version now reads `cliVersionKey` const — and package-lock.json + docker smoke test pin):

- `cmd/cheasee-pi/cache.go` — cliVersionKey const
- `cmd/cheasee-pi/root_test.go` — expected release version
- `docs/installation.md` — Linux/macOS + Windows version vars
- `package.json` / `package-lock.json`
- `docker/test/cli-install-smoke.test.mts` — CLI_VERSION pin (must match cliVersionKey)

Left untouched deliberately: `test/uninstall-script.test.sh` + `uninstall_script_test.go` stale-version fixtures (0.49/0.50 cache dirs) — they test removal of *old* versions, staying realistic.

## After merge

Tag `v0.51` on the merge commit + push → release.yml runs tests + goreleaser builds artifacts → release body updated (style of v0.50).