### PR TITLE
fix: write default model to .pi/settings.json so pi sees it

### DIFF
--- a/cmd/cheasee-pi/provider.go
+++ b/cmd/cheasee-pi/provider.go
@@ -49,8 +49,9 @@ func DefaultModel(provider string) string {
 
 // SettingsWriter writes provider config to cheasee-settings.json (the
 // dedicated cheasee-pi settings file — single source for the default
-// provider), plus .pi/agent/settings.json, and .pi/settings.json when it
-// already exists (pi's own file; cheasee-pi init no longer scaffolds it).
+// provider), plus .pi/settings.json (pi's own file — created for initialized
+// cheasee workspaces so pi sees the selected default model), and
+// .pi/agent/settings.json.
 type SettingsWriter struct {
 	Workdir string
 }
@@ -58,7 +59,10 @@ type SettingsWriter struct {
 // WriteDefaultProvider updates workspace settings files with the given
 // default provider and model. cheasee-settings.json is the primary target
 // (single source — skipped only when absent, e.g. a legacy workspace);
-// .pi/settings.json is updated only if it exists; .pi/agent/settings.json is
+// .pi/settings.json is updated, or created when missing inside an initialized
+// cheasee-pi workspace (pi reads exactly this file for its defaults — without
+// it the selection is lost and pi falls back to its built-in per-provider
+// default, e.g. kimi-k2.6 for opencode-go); .pi/agent/settings.json is
 // always (re)created with the provider.
 func (w *SettingsWriter) WriteDefaultProvider(provider, model string) error {
 	if err := w.updateCheaseeSettings(provider, model); err != nil {
@@ -92,13 +96,22 @@ func (w *SettingsWriter) updateCheaseeSettings(provider, model string) error {
 	return settings.Save(w.Workdir)
 }
 
+// updatePISettings persists provider + model to .pi/settings.json — the one
+// settings file pi reads for defaults (project overrides the global
+// ~/.pi/agent/settings.json, and it is the only pi settings file that crosses
+// into the container bind-mount). A missing file is created when the
+// workspace is cheasee-pi-initialized (cheasee-settings.json present); outside
+// such a workspace the write stays a no-op (auth add's workspace half).
 func (w *SettingsWriter) updatePISettings(provider, model string) error {
 	settings, err := LoadSettings(w.Workdir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil // workspace not initialized, skip
+		if !os.IsNotExist(err) {
+			return err
 		}
-		return err
+		if _, cerr := os.Stat(cheaseeSettingsPath(w.Workdir)); cerr != nil {
+			return nil // not a cheasee-pi workspace, skip
+		}
+		settings = &Settings{}
 	}
 	return settings.SetDefaultProvider(provider, model).Save(w.Workdir)
 }

--- a/cmd/cheasee-pi/settings_test.go
+++ b/cmd/cheasee-pi/settings_test.go
@@ -721,16 +721,17 @@ func TestSettingsWriter_emptyModelKeepsExisting(t *testing.T) {
 }
 
 func TestSettingsWriter_missingPISettingsSkipped(t *testing.T) {
-	workdir := t.TempDir() // no cheasee-settings.json, no .pi/settings.json
+	// No cheasee-settings.json, no .pi/settings.json → not a cheasee-pi
+	// workspace: both workspace writes stay no-ops.
+	workdir := t.TempDir()
 	sw := &SettingsWriter{Workdir: workdir}
 	if err := sw.WriteDefaultProvider("openai", "gpt-4o"); err != nil {
 		t.Fatalf("missing settings files must be skipped, got %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(workdir, "cheasee-settings.json")); !os.IsNotExist(err) {
-		t.Error("missing cheasee-settings.json must not be created")
-	}
-	if _, err := os.Stat(filepath.Join(workdir, ".pi", "settings.json")); !os.IsNotExist(err) {
-		t.Error("missing .pi/settings.json must not be created")
+	for _, p := range []string{"cheasee-settings.json", ".pi/settings.json"} {
+		if _, err := os.Stat(filepath.Join(workdir, p)); !os.IsNotExist(err) {
+			t.Errorf("missing %s must not be created", p)
+		}
 	}
 }
 
@@ -775,9 +776,13 @@ func TestSettingsWriter_updatesCheaseeSettings(t *testing.T) {
 	if s.OAuth.ClientID != "client-a" {
 		t.Errorf("oauth.clientID must survive: %+v", s.OAuth)
 	}
-	// .pi/settings.json is pi's file — never created by cheasee-pi auth add.
-	if _, err := os.Stat(filepath.Join(workdir, ".pi", "settings.json")); !os.IsNotExist(err) {
-		t.Error("cheasee-pi must not create .pi/settings.json")
+	// pi's own settings file is created with the selection — pi reads the
+	// default model from exactly this file; a fresh workspace has no
+	// .pi/settings.json (pi owns it), so creation is the kimi-k2.6 regression
+	// guard.
+	data, err := os.ReadFile(filepath.Join(workdir, ".pi", "settings.json"))
+	if err != nil || !strings.Contains(string(data), "anthropic") || !strings.Contains(string(data), "claude-sonnet-4-20250514") {
+		t.Fatalf(".pi/settings.json must be created with the selection: %v", err)
 	}
 }
 


### PR DESCRIPTION
cheasee-pi persisted the user-selected default provider/model only into
cheasee-settings.json and the project-local .pi/agent/settings.json —
files pi does not read. pi reads defaults from .pi/settings.json
(project) and ~/.pi/agent/settings.json (global); the project file is
also the only pi settings file that crosses into the container
bind-mount.

Fresh workspaces had no .pi/settings.json (init deliberately does not
scaffold it), so pi never saw the selection and fell back to its
built-in per-provider default: kimi-k2.6 for opencode-go.

updatePISettings now creates .pi/settings.json with provider + model
when missing, gated on cheasee-settings.json being present (initialized
workspace) so auth add outside a cheasee workspace stays a no-op.
