### PR TITLE
fix(clean): skip orphan scan on bash-less containers

### DIFF
--- a/cmd/cheasee-pi/orphan.go
+++ b/cmd/cheasee-pi/orphan.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -83,7 +84,12 @@ func scanOrphans(ctx context.Context, name string, maxAgeMinutes int, dryRun boo
 		name, "bash", "-c", orphanScanBash)
 	output, err := execCmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("orphan scan: %w", err)
+		// Sidecar images (e.g. the codeflow/code-server container) ship
+		// without bash — the scan script cannot run there and no pi process
+		// ever does. Aborting the whole clean over a container that has
+		// nothing to reap is worse than skipping: warn and move on.
+		fmt.Fprintf(os.Stderr, "  ⚠ orphan scan skipped for %s: %v\n", name, err)
+		return nil, nil
 	}
 
 	var killed []string

--- a/cmd/cheasee-pi/up_test.go
+++ b/cmd/cheasee-pi/up_test.go
@@ -282,7 +282,10 @@ func TestScanOrphans_countsKilled(t *testing.T) {
 	}
 }
 
-func TestScanOrphans_dockerExecFails(t *testing.T) {
+func TestScanOrphans_skipsWhenBashMissing(t *testing.T) {
+	// Sidecar containers (codeflow/code-server style images) ship without
+	// bash: docker exec fails with exit 127. The scan must not abort the
+	// whole clean over a container that never hosts pi — skip gracefully.
 	step := 0
 	stubExecCommand(t, func(_ string, _ ...string) cmdIface {
 		step++
@@ -295,14 +298,17 @@ func TestScanOrphans_dockerExecFails(t *testing.T) {
 		}
 		return &mockCmd{
 			combinedFn: func() ([]byte, error) {
-				return nil, fmt.Errorf("container stopped")
+				return []byte("exec: \"bash\": executable file not found in $PATH"), fmt.Errorf("exit status 127")
 			},
 		}
 	})
 
-	_, err := scanOrphans(context.Background(), "cheasee-pi", 0, false)
-	if err == nil {
-		t.Fatal("expected error when docker exec fails, got nil")
+	killed, err := scanOrphans(context.Background(), "cheasee-pi", 0, false)
+	if err != nil {
+		t.Fatalf("missing bash must skip, not abort: %v", err)
+	}
+	if len(killed) != 0 {
+		t.Errorf("expected 0 killed for unscannable container, got %d", len(killed))
 	}
 }
 


### PR DESCRIPTION
`cheasee-pi clean` aborts with `orphan scan: exit status 127` when any managed container lacks bash — the codeflow/code-server sidecar is one. The scan script can't run there and no pi process ever does; aborting the whole clean is worse than skipping.

- scanOrphans: exec failure → warn + skip (was: hard error)
- test: bash-less container skips gracefully

Now: `cheasee-pi clean --yes` works with the sidecar running.