### PR TITLE
fix: attach init worktree to default branch + container gh auth for private skill repos

### DIFF
--- a/.pi/context/qna.jsonl
+++ b/.pi/context/qna.jsonl
@@ -77,3 +77,4 @@
 {"datetime":"2026-08-11T20:40:02.447Z","question":"How should the .zed clean task be improved?","answer":"both"}
 {"datetime":"2026-08-14T18:35:45.740Z","question":"Entrypoint npm-install guard checks `[ ! -d node_modules ]`; stale empty dir (jiti cache) defeats it forever. Fix: check `node_modules/.package-lock.json` instead. Want PR (worktree + branch, main locked)?","answer":"fix_pr"}
 {"datetime":"2026-08-14T20:30:42.246Z","question":"Freed space: what should I run? (safe ones need no sudo)","answer":"docker_only"}
+{"datetime":"2026-08-17T19:23:12.537Z","question":"Stale /usr/local/bin/cheasee-pi (v0.52, installed today 20:47 presumably by container workflow) breaks `go test` — the uninstall dry-run test expects only one cheasee-pi on PATH. Remove it? Or keep it? (Go toolchain install itself works; fresh host build works and tests pass once stale binary gone.)","answer":"remove"}

--- a/cmd/cheasee-pi/embedded/docker/entrypoint.sh
+++ b/cmd/cheasee-pi/embedded/docker/entrypoint.sh
@@ -259,6 +259,20 @@ gosu agentuser git config --global --add url."https://github.com/".insteadOf "gi
 gosu agentuser git config --global --add url."https://github.com/".insteadOf "ssh://git@github.com/" 2>/dev/null || true
 # Use gh as credential helper for HTTPS pushes
 gosu agentuser git config --global credential.helper "!/usr/bin/gh auth git-credential" 2>/dev/null || true
+
+# The host authenticates gh via the OS keyring — and only ~/.config/gh
+# (hosts.yml/config.yml) is bind-mounted, the keyring is NOT, so a fresh
+# container starts with NO gh token and every private-repo git operation
+# (skill-repo clones above all) dies with "could not read Username".
+# cheasee-pi auth persists the GitHub token in auth.json (bind-mounted), so
+# feed it to gh once. Skip when gh already works — never clobber a token the
+# user set up interactively inside the container.
+if [ -f /home/agentuser/.config/cheasee-pi/auth.json ]; then
+    token=$(jq -r '.github_token // empty' /home/agentuser/.config/cheasee-pi/auth.json 2>/dev/null || true)
+    if [ -n "$token" ] && ! gosu agentuser gh auth status >/dev/null 2>&1; then
+        echo "$token" | gosu agentuser gh auth login --with-token 2>/dev/null || true
+    fi
+fi
 # Mark the bare repo safe for container git ops — a host-owned .bare mount
 # would otherwise trip "detected dubious ownership" (CVE-2022-24765
 # mitigation) on every git call inside the container.

--- a/cmd/cheasee-pi/helpers_test.go
+++ b/cmd/cheasee-pi/helpers_test.go
@@ -422,10 +422,18 @@ func stubInitGit(t *testing.T) *cloneCapture {
 	return c
 }
 
-// gitCloneCapture records the git clone/worktree argv from stubGitClone.
+// gitCloneCapture records the git clone/worktree argv from stubGitClone. It
+// also carries the fake `symbolic-ref HEAD` output/error the default-branch
+// probe must see (tune via symRefOut/symRefErr between stub and call).
+//
+// symRefOut defaults to "refs/heads/main\n" (the common case); set symRefErr
+// to exercise the detached-HEAD fallback.
 type gitCloneCapture struct {
 	cloneArgs    []string
 	worktreeArgs []string
+	symRefArgs   []string
+	symRefOut    string
+	symRefErr    error
 }
 
 // stubGitClone stubs the git seam for gitCloneWorktree tests: captures the
@@ -434,7 +442,7 @@ type gitCloneCapture struct {
 // commands fall through to the real seam.
 func stubGitClone(t *testing.T, cloneErr, worktreeErr error) *gitCloneCapture {
 	t.Helper()
-	c := &gitCloneCapture{}
+	c := &gitCloneCapture{symRefOut: "refs/heads/main\n"}
 	saved := runCommandContext
 	stubRunCommandContext(t, func(ctx context.Context, name string, arg ...string) runner {
 		if name == "git" && slices.Contains(arg, "clone") {
@@ -448,6 +456,10 @@ func stubGitClone(t *testing.T, cloneErr, worktreeErr error) *gitCloneCapture {
 				return &mockCmd{combinedFn: func() ([]byte, error) { return []byte("fatal: remote error"), cloneErr }}
 			}
 			return &mockCmd{}
+		}
+		if name == "git" && slices.Contains(arg, "symbolic-ref") {
+			c.symRefArgs = append(append([]string(nil), name), arg...)
+			return &mockCmd{combinedFn: func() ([]byte, error) { return []byte(c.symRefOut), c.symRefErr }}
 		}
 		if name == "git" && slices.Contains(arg, "worktree") {
 			c.worktreeArgs = append(append([]string(nil), name), arg...)
@@ -489,12 +501,17 @@ func gitRemoteFixture(t *testing.T, branch string) string {
 	return src
 }
 
-// cloneWorktreeLayout builds the init-clone layout (bare clone +
-// worktree add --detach, no branch) exactly as gitCloneWorktree does.
+// cloneWorktreeLayout builds the init-clone layout (bare clone + default
+// branch probe + worktree add <branch>) exactly as gitCloneWorktree does.
 func cloneWorktreeLayout(t *testing.T, src, parent, workdir string) string {
 	t.Helper()
 	bareDir := filepath.Join(parent, ".bare")
 	runGit(t, "clone", "--bare", "-q", src, bareDir)
-	runGit(t, "--git-dir", bareDir, "worktree", "add", "--detach", workdir)
+	out, err := exec.Command("git", "--git-dir", bareDir, "symbolic-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		t.Fatalf("symbolic-ref HEAD: %v\n%s", err, out)
+	}
+	branch := strings.TrimPrefix(strings.TrimSpace(string(out)), "refs/heads/")
+	runGit(t, "--git-dir", bareDir, "worktree", "add", workdir, branch)
 	return bareDir
 }

--- a/cmd/cheasee-pi/init_clone.go
+++ b/cmd/cheasee-pi/init_clone.go
@@ -43,7 +43,7 @@ func canonicalRepoURL(repoURL string) (string, error) {
 }
 
 // gitCloneWorktree bare-clones the user's project repo to <parent>/.bare and
-// adds the main worktree (checked out at the bare HEAD, detached) into
+// adds the main worktree (checked out on the repo's default branch) into
 // workdir — the exact layout worktree-fix.sh expects inside the container
 // (/workspaces/main + /workspaces/.bare as sibling mounts).
 //
@@ -55,11 +55,14 @@ func canonicalRepoURL(repoURL string) (string, error) {
 //
 // The bare clone is full (no --depth/--single-branch): a later
 // `worktree add` of non-default branches must stay possible from the same
-// .bare. `worktree add --detach` takes NO branch argument — bare clones
-// leave no refs/remotes/origin/HEAD symbolic ref, so the old
-// symbolic-ref-based default-branch detection silently fell back to "main"
-// and hard-failed on master-default repos; no-branch add checks out the bare
-// HEAD on both.
+// .bare. Bare clones carry the default branch directly as refs/heads/<name>
+// (no refs/remotes/origin/HEAD symbolic ref), so the default branch is read
+// from the bare HEAD itself via symbolic-ref; the worktree is then attached
+// to it. This keeps the workspace on a named branch (no "detached HEAD"
+// footer state for pi) and works for every default-branch name (main,
+// master, …). A bare HEAD that cannot be resolved to a branch name (exotic
+// detached-edge case) falls back to the old `worktree add --detach` bare
+// HEAD checkout.
 func gitCloneWorktree(ctx context.Context, repoURL, workdir string) error {
 	cloneURL, err := canonicalRepoURL(repoURL)
 	if err != nil {
@@ -111,16 +114,37 @@ func gitCloneWorktree(ctx context.Context, repoURL, workdir string) error {
 	default:
 	}
 
-	wtCmd := runCommandContext(ctx, "git",
-		"--git-dir", bareDir,
-		"worktree", "add", "--detach", workdir,
-	)
+	wtArgs := []string{"--git-dir", bareDir, "worktree", "add"}
+	if branch := gitDefaultBranch(ctx, bareDir); branch != "" {
+		wtArgs = append(wtArgs, workdir, branch)
+	} else {
+		wtArgs = append(wtArgs, "--detach", workdir)
+	}
+	wtCmd := runCommandContext(ctx, "git", wtArgs...)
 	if out, err := wtCmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("worktree add failed: %w\n%s", err, redactToken(string(out)))
 	}
 
 	fmt.Fprintf(os.Stderr, "  ✓ Cloned (bare + worktree) to %s\n", workdir)
 	return nil
+}
+
+// gitDefaultBranch resolves the bare repo's default branch name from its
+// HEAD symbolic ref (refs/heads/<name>). Bare clones keep branches directly
+// under refs/heads and carry no refs/remotes/origin/HEAD, so HEAD is the
+// single source of truth. Returns "" when HEAD is detached or missing — the
+// caller then falls back to a detached worktree add (bare HEAD checkout).
+func gitDefaultBranch(ctx context.Context, bareDir string) string {
+	out, err := runCommandContext(ctx, "git", "--git-dir", bareDir, "symbolic-ref", "HEAD").CombinedOutput()
+	if err != nil {
+		return ""
+	}
+	ref := strings.TrimSpace(string(out)) // e.g. refs/heads/main
+	const headsPrefix = "refs/heads/"
+	if !strings.HasPrefix(ref, headsPrefix) {
+		return ""
+	}
+	return strings.TrimPrefix(ref, headsPrefix)
 }
 
 // removeInitResidue best-effort cleans a half-initialized workspace after a

--- a/cmd/cheasee-pi/init_clone_test.go
+++ b/cmd/cheasee-pi/init_clone_test.go
@@ -145,10 +145,55 @@ func TestGitCloneWorktree_exactArgv(t *testing.T) {
 			t.Errorf("clone argv must not contain %s (full bare clone), got %v", banned, c.cloneArgs)
 		}
 	}
-	// worktree add --detach with NO branch argument (bare HEAD checkout).
-	wantWT := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "worktree", "add", "--detach", workdir}
+	// default-branch probe: symbolic-ref HEAD on the bare repo.
+	wantSym := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "symbolic-ref", "HEAD"}
+	if !slices.Equal(c.symRefArgs, wantSym) {
+		t.Errorf("symbolic-ref argv = %v, want %v", c.symRefArgs, wantSym)
+	}
+	// worktree add attached to the repo's default branch (not detached).
+	wantWT := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "worktree", "add", workdir, "main"}
 	if !slices.Equal(c.worktreeArgs, wantWT) {
 		t.Errorf("worktree argv = %v, want %v", c.worktreeArgs, wantWT)
+	}
+}
+
+func TestGitCloneWorktree_masterDefaultAttached(t *testing.T) {
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := stubGitClone(t, nil, nil)
+	c.symRefOut = "refs/heads/master\n"
+	if err := gitCloneWorktree(context.Background(), "https://github.com/owner/repo", workdir); err != nil {
+		t.Fatalf("gitCloneWorktree: %v", err)
+	}
+	wantWT := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "worktree", "add", workdir, "master"}
+	if !slices.Equal(c.worktreeArgs, wantWT) {
+		t.Errorf("master-default worktree argv = %v, want %v", c.worktreeArgs, wantWT)
+	}
+}
+
+func TestGitCloneWorktree_detachedHeadFallback(t *testing.T) {
+	// Exotic edge: the bare HEAD cannot be resolved to a branch name — the
+	// clone degrades to the old detached bare-HEAD checkout instead of
+	// failing the workspace init.
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := stubGitClone(t, nil, nil)
+	c.symRefOut = ""
+	c.symRefErr = errors.New("fatal: ref HEAD is not a symbolic ref")
+	if err := gitCloneWorktree(context.Background(), "https://github.com/owner/repo", workdir); err != nil {
+		t.Fatalf("gitCloneWorktree: %v", err)
+	}
+	wantWT := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "worktree", "add", "--detach", workdir}
+	if !slices.Equal(c.worktreeArgs, wantWT) {
+		t.Errorf("fallback worktree argv = %v, want %v", c.worktreeArgs, wantWT)
 	}
 }
 
@@ -356,8 +401,9 @@ func TestGitCloneWorktree_worktreeAddFailureWrapped(t *testing.T) {
 // Real-git adapter/e2e tests (acceptance: verified by execution)
 // ──────────────────────────────────────────────
 // These exercise the exact CLI sequence gitCloneWorktree builds — bare clone
-// + `worktree add --detach` with NO branch argument — against the real git
-// binary on temp repos, plus the worktree-fix.sh container path rewrite.
+// + default-branch probe + `worktree add <branch>` (attached, not detached)
+// — against the real git binary on temp repos, plus the worktree-fix.sh
+// container path rewrite.
 
 func TestGitCloneWorktree_realGitMainDefault(t *testing.T) {
 	src := gitRemoteFixture(t, "main")
@@ -366,7 +412,15 @@ func TestGitCloneWorktree_realGitMainDefault(t *testing.T) {
 
 	bareDir := cloneWorktreeLayout(t, src, parent, workdir)
 
-	// HEAD checked out (detached) — no branch arg picked the bare HEAD.
+	// Attached to the named default branch, not a detached HEAD — the pi
+	// footer shows the branch ("detached [main]" stays away).
+	out, err := exec.Command("git", "-C", workdir, "branch", "--show-current").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "main" {
+		t.Errorf("worktree must be attached to branch 'main', got %q", strings.TrimSpace(string(out)))
+	}
 	data, err := os.ReadFile(filepath.Join(workdir, "README.md"))
 	if err != nil {
 		t.Fatalf("worktree must check out HEAD: %v", err)
@@ -383,7 +437,7 @@ func TestGitCloneWorktree_realGitMainDefault(t *testing.T) {
 		t.Errorf(".git must reference .bare/worktrees/main, got: %q", gitFile)
 	}
 	// git worktree list is valid.
-	out, err := exec.Command("git", "--git-dir", bareDir, "worktree", "list").CombinedOutput()
+	out, err = exec.Command("git", "--git-dir", bareDir, "worktree", "list").CombinedOutput()
 	if err != nil {
 		t.Fatalf("git worktree list: %v\n%s", err, out)
 	}
@@ -393,21 +447,36 @@ func TestGitCloneWorktree_realGitMainDefault(t *testing.T) {
 }
 
 func TestGitCloneWorktree_realGitMasterDefault(t *testing.T) {
-	// Regression pin for the old symbolic-ref pitfall: a master-default repo
-	// must not hard-fail with "invalid reference: main" — no-branch
-	// `worktree add --detach` checks out the bare HEAD on both defaults.
 	src := gitRemoteFixture(t, "master")
 	parent := t.TempDir()
 	workdir := filepath.Join(parent, "main")
 
-	cloneWorktreeLayout(t, src, parent, workdir)
+	bareDir := cloneWorktreeLayout(t, src, parent, workdir)
 
+	// Attached to 'master'; the old symbolic-ref pitfall (hard-fail
+	// "invalid reference: main") is gone because the branch name comes from
+	// the bare HEAD, never an assumption.
+	out, err := exec.Command("git", "-C", workdir, "branch", "--show-current").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "master" {
+		t.Errorf("master-default worktree must be attached to 'master', got %q", strings.TrimSpace(string(out)))
+	}
 	data, err := os.ReadFile(filepath.Join(workdir, "README.md"))
 	if err != nil {
 		t.Fatalf("master-default worktree must check out HEAD: %v", err)
 	}
 	if string(data) != "fixture\n" {
 		t.Errorf("master-default worktree content mismatch: %q", data)
+	}
+	// git worktree list is valid on the master-default layout too.
+	out, err = exec.Command("git", "--git-dir", bareDir, "worktree", "list").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git worktree list: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), workdir) {
+		t.Errorf("worktree list must contain the worktree %s:\n%s", workdir, out)
 	}
 }
 
@@ -503,7 +572,7 @@ func TestGitCloneWorktree_e2eWorktreeFix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("git worktree list after fix: %v\n%s", err, out)
 	}
-	if !strings.Contains(string(out), "(detached HEAD)") || !strings.Contains(string(out), "locked") {
+	if !strings.Contains(string(out), "main") || !strings.Contains(string(out), "locked") {
 		t.Errorf("worktree list must show the fixed, locked worktree:\n%s", out)
 	}
 	// git status --porcelain shows no untracked cheasee-settings.json (the

--- a/cmd/cheasee-pi/init_split_test.go
+++ b/cmd/cheasee-pi/init_split_test.go
@@ -44,6 +44,7 @@ var wantInitDecls = map[string]string{
 	"const:initModeFull,initModeReauth": "init.go",
 
 	"func:gitCloneWorktree":  "init_clone.go",
+	"func:gitDefaultBranch":  "init_clone.go",
 	"func:canonicalRepoURL":  "init_clone.go",
 	"func:removeInitResidue": "init_clone.go",
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,8 @@ The repo root is bind-mounted at `/workspaces/main`. Host UID/GID are mapped to 
 `cheasee-pi start` gates on the workspace state instead of “is a git repo”:
 
 - **Empty folder** → auto-runs `cheasee-pi init` (repo-URL prompt → bare clone
-  to `<parent>/.bare` + `worktree add --detach` → `cheasee-settings.json`),
+  to `<parent>/.bare` → worktree attach on the repo's default branch (bare
+  HEAD via `symbolic-ref`) → `cheasee-settings.json`),
   then falls through into the normal start phases in the same invocation
   (docker check → compose up → exec pi).
 - **`cheasee-settings.json` present** → initialized; runs normally.


### PR DESCRIPTION
## Summary

Fixes two bugs that broke fresh workspaces out of the box (found while
initializing a new project):

### 1. Init left the worktree on a detached HEAD
`gitCloneWorktree` bare-cloned and ran `worktree add --detach`, so every
new workspace started on a detached HEAD — the pi footer showed
`detached [main]` and branch-aware tooling saw no branch.

Bare clones carry the default branch directly under `refs/heads/` (there
is no `refs/remotes/origin/HEAD` symbolic ref), so the default branch is
now resolved from the bare repo's own HEAD (`symbolic-ref HEAD`) and the
worktree is **attached** to it. Works for any default-branch name (`main`,
`master`, …) — the branch name never comes from an assumption. A bare HEAD
that cannot be resolved (exotic detached edge) falls back to the old
`--detach` behavior.

- `cmd/cheasee-pi/init_clone.go` — new `gitDefaultBranch` helper, worktree
  add attaches the default branch
- tests: stub argv assertions (main + master + detached fallback), real-git
  e2e tests assert `branch --show-current`, `cloneWorktreeLayout` helper
  mirrors the new sequence
- `docs/architecture.md` — workspace-layout note updated

### 2. Private skill repos failed to clone in a fresh container
The host authenticates gh via the **OS keyring**; only `~/.config/gh`
(`hosts.yml`/`config.yml`) is bind-mounted into the container — the keyring
is not. A fresh container therefore had no gh token and `pi install -l -a`
of a **private** skill repo died with:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

`cheasee-pi auth` persists the GitHub token in `auth.json`, which *is*
bind-mounted. The entrypoint now feeds it to gh once via
`gh auth login --with-token` — skipped when gh already authenticates, so a
token the user set up interactively inside the container is never clobbered.

- `cmd/cheasee-pi/embedded/docker/entrypoint.sh`

## Verification
- `go build ./cmd/cheasee-pi/` ✓
- `go vet ./cmd/cheasee-pi/` ✓
- `go test ./cmd/cheasee-pi/ -count=1` ✓
- Manually verified the full flow on a real workspace: detached-HEAD fix
  applied via `git switch main` (the exact state the new init sequence
  produces), gh token feeding applied manually inside the running
  container — private skill repo installed, branch shows correctly in the
  pi footer.