### PR TITLE
fix(cli): init never launches pi; start stops after init

### DIFF
--- a/cmd/cheasee-pi/cli_doc_test.go
+++ b/cmd/cheasee-pi/cli_doc_test.go
@@ -196,8 +196,8 @@ func TestCLIDoc_DockerGate(t *testing.T) {
 
 // TestCLIDoc_InitGates verifies the init preconditions: empty-folder gate,
 // cheasee-settings.json as initialized marker, non-empty refusal, 5-minute
-// timeout, --no-input requiring --repo-url, --no-github legacy path, and
-// start auto-init in the same invocation.
+// timeout, --no-input requiring --repo-url, --no-github legacy path, and the
+// init-stops-then-start handoff.
 func TestCLIDoc_InitGates(t *testing.T) {
 	content := readCliDoc(t)
 	checks := []struct {
@@ -209,7 +209,7 @@ func TestCLIDoc_InitGates(t *testing.T) {
 		{"5-minute", "5-minute init/OAuth timeout"},
 		{"--no-input` requires `--repo-url", "--no-input requires --repo-url"},
 		{"--no-github", "--no-github legacy path"},
-		{"same invocation", "start auto-init continuation"},
+		{"re-run `start` to launch pi", "init-stops-then-start handoff"},
 	}
 	for _, c := range checks {
 		if !strings.Contains(content, c.want) {

--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -14,10 +14,10 @@ import (
 )
 
 // newInitDeps builds the shared InitDeps used by both `cheasee-pi init`
-// (runInitE) and start-triggered init (runUpE's empty-folder branch), so the
-// two entry points run byte-identical flows. Package-var seam (newRepository
-// pattern): tests replace it to drive either entry point with stubbed
-// OAuth/prompt boundaries instead of a real device flow or TTY.
+// (runInitE) and the empty-folder branch of runUpE, so the two entry points
+// run byte-identical flows. Package-var seam (newRepository pattern): tests
+// replace it to drive either entry point with stubbed OAuth/prompt boundaries
+// instead of a real device flow or TTY.
 var newInitDeps = func(workdir string) InitDeps {
 	return InitDeps{
 		Ports:         InitPorts{Auth: NewAuthenticator(initClientID)},
@@ -40,9 +40,9 @@ var newInitDeps = func(workdir string) InitDeps {
 const nextStepHint = "cheasee-pi start"
 
 // initTimeout bounds a single init invocation — device-flow OAuth polling
-// dominates the window. Shared by standalone init (runInitE) and start-
-// triggered init (runUpE's empty-folder branch) so both cap the auth window
-// identically instead of polling until the ~900 s device-code expiry.
+// dominates the window. Shared by `cheasee-pi init` (runInitE) and the
+// empty-folder branch of runUpE so both cap the auth window identically
+// instead of polling until the ~900 s device-code expiry.
 const initTimeout = 5 * time.Minute
 
 var (
@@ -69,7 +69,8 @@ type InitPorts struct {
 // InitDeps bundles all dependencies, flags, and callbacks for runInit.
 // Provider/ClientID/RepoURL carry the flag-derived init inputs so the
 // shared factory (newInitDeps) fully encapsulates them — no package-global
-// reads inside the flow (start-triggered init and runInitE run identically).
+// reads inside the flow (the runUpE empty-folder branch and runInitE run
+// identically).
 type InitDeps struct {
 	Ports            InitPorts
 	APIKey           string
@@ -88,13 +89,8 @@ type InitDeps struct {
 	// `pi install -l -a` before pi execs.
 	SkillRepos []string
 	Workdir    string
-	// InStartFlow marks init as triggered by `cheasee-pi start`'s empty-folder
-	// branch: the completion message drops the standalone "Next step:
-	// cheasee-pi start" hint because start continues automatically. Zero value
-	// (false) = standalone init, backward compatible.
-	InStartFlow bool
-	ConfirmFn   func(string) (bool, error)
-	InputFn     func(title, placeholder string) (string, error)
+	ConfirmFn  func(string) (bool, error)
+	InputFn    func(title, placeholder string) (string, error)
 }
 
 // Validate checks that all required dependencies for the active path are non-nil.
@@ -347,15 +343,11 @@ func runInit(ctx context.Context, deps InitDeps) error {
 		return postCloneErr
 	}
 
-	// Completion message. Standalone `cheasee-pi init` points at the next
-	// step; start-triggered init (InStartFlow) continues into start
-	// automatically, so no second-invocation hint is printed.
-	if deps.InStartFlow {
-		fmt.Fprintf(os.Stderr, "\n✅ Init complete.\n")
-	} else {
-		fmt.Fprintf(os.Stderr, "\n✅ Init complete! Next step:\n")
-		fmt.Fprintf(os.Stderr, "   %s\n", nextStepHint)
-	}
+	// Init never launches pi — init sets the workspace up and hands off to
+	// `cheasee-pi start` (the runUpE empty-folder branch returns after init;
+	// a second invocation then starts the container).
+	fmt.Fprintf(os.Stderr, "\n✅ Init complete! Next step:\n")
+	fmt.Fprintf(os.Stderr, "   %s\n", nextStepHint)
 	return nil
 }
 

--- a/cmd/cheasee-pi/init_scaffold_test.go
+++ b/cmd/cheasee-pi/init_scaffold_test.go
@@ -268,29 +268,3 @@ func TestInit_SuccessMessage(t *testing.T) {
 	}
 }
 
-func TestInit_SuccessMessageInStartFlow(t *testing.T) {
-	// Start-triggered init (InStartFlow) prints "✅ Init complete" WITHOUT the
-	// standalone "Next step: cheasee-pi start" hint — start continues into
-	// the launch automatically.
-	testutil.SetGitConfig(t, testGitIdentityConfig)
-	stubDockerCheck(t, nil, "24.0.9", nil)
-	testutil.RedirectConfigHome(t)
-
-	output := testutil.CaptureStderr(t, func() {
-		err := runInit(context.Background(), initDeps(t, func(d *InitDeps) {
-			d.NoGitHub = true
-			d.APIKey = FakeAPIKey
-			d.InStartFlow = true
-		}))
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-
-	if !strings.Contains(output, "✅ Init complete") {
-		t.Error("success message must contain the checkmark and 'Init complete'")
-	}
-	if strings.Contains(output, "Next step:") || strings.Contains(output, "cheasee-pi start") {
-		t.Errorf("start-triggered init must not print the second-invocation hint, got: %q", output)
-	}
-}

--- a/cmd/cheasee-pi/installation_doc_test.go
+++ b/cmd/cheasee-pi/installation_doc_test.go
@@ -113,21 +113,21 @@ func TestInstallationDoc_GoCliPathVersion(t *testing.T) {
 	}
 }
 
-// TestInstallationDoc_OneShotFirstRun verifies the empty-folder gate bullet
-// describes the single-invocation flow (init + start in one run) — the
-// two-step "run start again" handoff is gone.
-func TestInstallationDoc_OneShotFirstRun(t *testing.T) {
+// TestInstallationDoc_TwoStepFirstRun verifies the empty-folder gate bullet
+// describes the two-step flow: init runs and STOPS (init never launches pi),
+// and the user re-runs start to launch.
+func TestInstallationDoc_TwoStepFirstRun(t *testing.T) {
 	data, err := os.ReadFile(docPath())
 	if err != nil {
 		t.Fatalf("reading docs/installation.md: %v", err)
 	}
 	content := string(data)
 
-	if strings.Contains(content, "then you run `start` again") {
-		t.Error("installation.md must not describe a two-step first run (run start again)")
+	if strings.Contains(content, "same invocation") {
+		t.Error("installation.md must not describe a one-shot continuation (init + start fused)")
 	}
-	if !strings.Contains(content, "same invocation") {
-		t.Error("installation.md should describe the one-shot continuation (init + start in the same invocation)")
+	if !strings.Contains(content, "run `cheasee-pi start` again") {
+		t.Error("installation.md should describe the two-step handoff (run start again after init)")
 	}
 }
 
@@ -151,9 +151,9 @@ func TestInstallationDoc_SkillRepoStep(t *testing.T) {
 	}
 }
 
-// TestDailyUsageDoc_OneShotFirstRun verifies daily-usage.md describes the
-// single-invocation auto-init continuation instead of a two-step handoff.
-func TestDailyUsageDoc_OneShotFirstRun(t *testing.T) {
+// TestDailyUsageDoc_TwoStepFirstRun verifies daily-usage.md describes the
+// two-step handoff: init auto-runs and stops, then the user re-runs start.
+func TestDailyUsageDoc_TwoStepFirstRun(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "daily-usage.md"))
 	if err != nil {
 		t.Fatalf("reading docs/daily-usage.md: %v", err)
@@ -163,8 +163,11 @@ func TestDailyUsageDoc_OneShotFirstRun(t *testing.T) {
 	if strings.Contains(content, "auto-inits first.") {
 		t.Error("daily-usage.md must not describe auto-init as a standalone step (no continuation)")
 	}
-	if !strings.Contains(content, "same invocation") {
-		t.Error("daily-usage.md should describe the single-invocation auto-init continuation")
+	if strings.Contains(content, "same invocation") {
+		t.Error("daily-usage.md must not describe a one-shot continuation")
+	}
+	if !strings.Contains(content, "run `cheasee-pi start` again") {
+		t.Error("daily-usage.md should describe the two-step handoff (run start again after init)")
 	}
 }
 

--- a/cmd/cheasee-pi/root.go
+++ b/cmd/cheasee-pi/root.go
@@ -12,7 +12,10 @@ Its init command sets up an empty folder (bare clone + main worktree +
 cheasee-settings.json); 'cheasee-pi start' mounts the workspace into the
 container and launches pi.
 
-Without a subcommand, launches pi inside the Docker container (same as 'up').`,
+Without a subcommand, 'cheasee-pi' checks the folder: empty → runs
+'cheasee-pi init' (which stops — run start again to launch pi);
+cheasee-settings.json present → launches pi inside the Docker container
+(same as 'up'); non-empty without it → error (run init in an empty folder).`,
 	Version:           cliVersionKey,
 	DisableAutoGenTag: true,
 	RunE:              runUpE,

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -35,10 +35,9 @@ bind-mounted at /workspaces/main and its sibling bare repo at
 CLI-managed cache dir; the dedicated cheasee-settings.json (gitignored,
 machine-local) is the initialized marker.
 
-Empty folder → runs cheasee-pi init first (bare clone + main worktree +
-cheasee-settings.json), then continues into start in the same invocation.
-Non-empty folder without cheasee-settings.json is refused — run 'cheasee-pi
-init' in an empty folder.
+Empty folder → runs cheasee-pi init and stops (init never launches pi);
+run 'cheasee-pi start' again to launch. Non-empty folder without
+cheasee-settings.json is refused — run 'cheasee-pi init' in an empty folder.
 
 The image clones the cheasee-pi repo at build time (Dockerfile ARG
 CHEASEE_REF) for its .pi resources. Reads provider API keys from
@@ -82,65 +81,30 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve workdir: %w", err)
 	}
 
-	// Phase 1: workspace gate — empty folder → auto-init; cheasee-settings.json
+	// Phase 1: workspace gate — empty folder → auto-init and stop; cheasee-settings.json
 	// present → run; anything else → refuse. Runs before any docker/git call so
 	// a non-initialized cwd is refused fast (and dry-run touches nothing).
 	root, state, err := resolveStartWorkspace(workdir)
 	if err != nil {
 		return err
 	}
-	// firstRun marks the one-shot path: init ran in this invocation, so the
-	// pre-exec confirmation announces the workspace setup (init's own
-	// completion message drops the standalone next-step hint via InStartFlow).
-	firstRun := false
 	if state == WorkspaceEmpty {
 		if upDryRun {
-			fmt.Fprintf(os.Stderr, "  ℹ %s is empty — would run `cheasee-pi init` (bare clone + main worktree + cheasee-settings.json), then `cheasee-pi start` — init and start in one invocation.\n", workdir)
+			fmt.Fprintf(os.Stderr, "  ℹ %s is empty — would run `cheasee-pi init` (bare clone + main worktree + cheasee-settings.json), then stop. Run `cheasee-pi start` again to launch pi.\n", workdir)
 			return nil
 		}
-		fmt.Fprintf(os.Stderr, "  ℹ %s is empty — running `cheasee-pi init` first...\n", workdir)
-		// Init is time-bounded (device-flow OAuth polling dominates the window);
-		// the continuation after it stays unbounded — image build + npm install
-		// legitimately exceed 5 minutes.
+		fmt.Fprintf(os.Stderr, "  ℹ %s is empty — running `cheasee-pi init`...\n", workdir)
+		// Init is time-bounded (device-flow OAuth polling dominates the window).
 		initCtx, cancel := context.WithTimeout(ctx, initTimeout)
-		deps := newInitDeps(workdir)
-		deps.InStartFlow = true
-		initErr := runInit(initCtx, deps)
+		initErr := runInit(initCtx, newInitDeps(workdir))
 		cancel()
 		if initErr != nil {
 			return fmt.Errorf("auto-init failed: %w", initErr)
 		}
-		firstRun = true
-
-		// Re-resolve the workspace state: the continuation needs the resolved
-		// root for container name / compose mounts (the empty state resolved
-		// root=""), and the re-classification fails closed when init left no
-		// settings marker — a worktree without cheasee-settings.json is a
-		// folder both init and start refuse.
-		root, state, err = resolveStartWorkspace(workdir)
-		if err != nil {
-			return err
-		}
-		// Init lays the worktree at <workdir>/<branch>, so the settings marker
-		// lives one level DOWN from the init folder — resolveStartWorkspace only
-		// walks up. Recover the leaf from the child folders.
-		if state != WorkspaceInitialized {
-			if entries, readErr := os.ReadDir(workdir); readErr == nil {
-				for _, e := range entries {
-					if !e.IsDir() {
-						continue
-					}
-					cand := filepath.Join(workdir, e.Name())
-					if _, statErr := os.Stat(cheaseeSettingsPath(cand)); statErr == nil {
-						root, state = cand, WorkspaceInitialized
-						break
-					}
-				}
-			}
-		}
-		if state != WorkspaceInitialized {
-			return fmt.Errorf("auto-init left %q non-empty without cheasee-settings.json — remove the worktree/.bare residue and re-run `cheasee-pi start` in an empty folder", workdir)
-		}
+		// Init never launches pi: stop here and let the next invocation start.
+		// If init left the folder non-empty without a settings marker, the next
+		// `cheasee-pi start` refuses via WorkspaceRefuse (fail-closed).
+		return nil
 	}
 	if state == WorkspaceRefuse {
 		return fmt.Errorf("not initialized: %q is not empty and has no cheasee-settings.json — run `cheasee-pi init` in an empty folder first", workdir)
@@ -252,12 +216,7 @@ func runUpE(cmd *cobra.Command, _ []string) error {
 		fmt.Fprintf(os.Stderr, "  ✓ Killed %d orphaned pi process(es)\n", len(killed))
 	}
 
-	// Phase 8: exec pi — the one-shot confirmation must print BEFORE the
-	// blocking exec (a post-exec message would only appear when the session
-	// ends).
-	if firstRun {
-		fmt.Fprintf(os.Stderr, "  ✓ Workspace set up — starting pi...\n")
-	}
+	// Phase 8: exec pi.
 	execErr := execPIContainer(upName, envMap, target)
 
 	// The docker exec client just exited (user quit or disconnected). Reap the

--- a/cmd/cheasee-pi/up_flow_test.go
+++ b/cmd/cheasee-pi/up_flow_test.go
@@ -155,9 +155,9 @@ func mkWorkspace(t *testing.T, settingsContent string) (parent, root string) {
 	return parent, root
 }
 
-// stubAutoInitDeps replaces the shared newInitDeps factory so start-triggered
-// init runs with the stubbed OAuth/prompt boundaries (the same seam runInitE
-// tests use) instead of a real device flow or TTY.
+// stubAutoInitDeps replaces the shared newInitDeps factory so the empty-
+// folder auto-init path runs with the stubbed OAuth/prompt boundaries (the
+// same seam runInitE tests use) instead of a real device flow or TTY.
 func stubAutoInitDeps(t *testing.T) {
 	t.Helper()
 	saved := newInitDeps
@@ -286,8 +286,8 @@ func TestRunUpE_dryRunOnEmptyFolder(t *testing.T) {
 	if !strings.Contains(stderr, "would run `cheasee-pi init`") {
 		t.Errorf("dry-run on empty must announce the would-be init, got: %q", stderr)
 	}
-	if !strings.Contains(stderr, "one invocation") {
-		t.Errorf("dry-run on empty must describe the one-shot continuation, got: %q", stderr)
+	if !strings.Contains(stderr, "again to launch pi") {
+		t.Errorf("dry-run on empty must point at re-running start, got: %q", stderr)
 	}
 	if _, err := os.Stat(filepath.Join(workdir, "cheasee-settings.json")); !os.IsNotExist(err) {
 		t.Errorf("dry-run must not scaffold cheasee-settings.json: %v", err)
@@ -325,7 +325,10 @@ func TestRunUpE_dryRunOnInitialized(t *testing.T) {
 	}
 }
 
-func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
+func TestRunUpE_autoInitStopsAfterInit(t *testing.T) {
+	// Empty folder → runUpE runs init and STOPS (init never launches pi): no
+	// compose, no docker exec. The next-step hint tells the user to re-run
+	// start — the initialized-workspace start path is covered separately.
 	parent := t.TempDir()
 	workdir := filepath.Join(parent, "ws")
 	if err := os.MkdirAll(workdir, 0755); err != nil {
@@ -335,20 +338,13 @@ func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
 	testutil.RedirectConfigHome(t)
 	testutil.SetGitConfig(t, testGitIdentityConfig)
 	// Stub order matters: stubUpFlow installs the execCommand/runCommandContext
-	// seams the continuation needs and must sit before stubInitGit so init's
-	// clone chains to stubUpFlow's docker/version handlers.
+	// seams and must sit before stubInitGit so init's clone chains to
+	// stubUpFlow's docker/version handlers.
 	stubDockerCheck(t, nil, "24.0.9", nil)
 	c := stubUpFlow(t, workdir, false)
 	stubInitGit(t)
 	stubAutoInitDeps(t)
 	exec := stubExecPIContainer(t)
-	// Ordering pin: the one-shot confirmation must print BEFORE the blocking
-	// exec (a post-exec message would only appear when the session ends).
-	savedExec := execPIContainer
-	execPIContainer = func(name string, env map[string]string, target string) error {
-		fmt.Fprintf(os.Stderr, "EXEC-INVOKED\n")
-		return savedExec(name, env, target)
-	}
 
 	stderr := testutil.CaptureStderr(t, func() {
 		if err := runUpE(&cobra.Command{}, nil); err != nil {
@@ -356,23 +352,16 @@ func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
 		}
 	})
 
-	if !strings.Contains(stderr, "running `cheasee-pi init` first") {
+	if !strings.Contains(stderr, "running `cheasee-pi init`") {
 		t.Errorf("empty folder must announce auto-init, got: %q", stderr)
 	}
 	if !strings.Contains(stderr, "Cloned (bare + worktree)") {
 		t.Errorf("user should see the clone notice during auto-init, got: %q", stderr)
 	}
-	if strings.Contains(stderr, "run `cheasee-pi start` again") {
-		t.Errorf("one-shot start must not hand off to a second start, got: %q", stderr)
-	}
-	if strings.Contains(stderr, "Next step:") {
-		t.Errorf("start-triggered init must not print the standalone next-step hint, got: %q", stderr)
-	}
-	if !strings.Contains(stderr, "starting pi") {
-		t.Errorf("one-shot start must confirm pi is starting, got: %q", stderr)
-	}
-	if i, j := strings.Index(stderr, "starting pi"), strings.Index(stderr, "EXEC-INVOKED"); i < 0 || j < 0 || i > j {
-		t.Errorf("'starting pi' confirmation must precede the exec invocation, stderr: %q", stderr)
+	// Init never launches pi: the standalone next-step hint is printed and the
+	// invocation ends — no compose, no exec.
+	if !strings.Contains(stderr, "Next step:") || !strings.Contains(stderr, "cheasee-pi start") {
+		t.Errorf("auto-init must hand off to a second `cheasee-pi start`, got: %q", stderr)
 	}
 	// Init artifacts: worktree checked out at the branch-named leaf, its
 	// sibling .bare, settings inside the leaf.
@@ -388,29 +377,11 @@ func TestRunUpE_autoInitEmptyFolder(t *testing.T) {
 	if !authJSONExists(t) {
 		t.Error("auto-init must save auth.json")
 	}
-
-	// Continuation: compose build + up from the cache dir with the two sibling
-	// mounts, then exec into the derived container.
-	if len(c.composeArgs) != 2 {
-		t.Errorf("one-shot start must build + up via compose, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
+	if len(c.composeArgs) != 0 {
+		t.Errorf("auto-init must stop after init — compose must not run, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
 	}
-	cacheDir, err := CacheDir()
-	if err != nil {
-		t.Fatal(err)
-	}
-	composeFile := filepath.Join(cacheDir, "docker-compose.yml")
-	if len(c.composeArgs) == 2 && (!slices.Contains(c.composeArgs[0], composeFile) || !slices.Contains(c.composeArgs[1], "up")) {
-		t.Errorf("compose must build + up from the cache dir, got %v", c.composeArgs)
-	}
-	if exec.name != containerName(filepath.Join(workdir, "main")) || exec.target != "/workspaces/main" {
-		t.Errorf("exec must target -w /workspaces/main in container %q, got name=%q target=%q", containerName(filepath.Join(workdir, "main")), exec.name, exec.target)
-	}
-	upEnv := c.composeCmds[1].env
-	if !slices.Contains(upEnv, "WORKSPACE_HOST_PATH="+filepath.Join(workdir, "main")) {
-		t.Errorf("up env must carry WORKSPACE_HOST_PATH=%s, got %v", filepath.Join(workdir, "main"), upEnv)
-	}
-	if !slices.Contains(upEnv, "WORKSPACE_BARE_PATH="+filepath.Join(workdir, ".bare")) {
-		t.Errorf("up env must carry WORKSPACE_BARE_PATH=%s, got %v", filepath.Join(workdir, ".bare"), upEnv)
+	if exec.name != "" || exec.target != "" {
+		t.Errorf("auto-init must not exec pi, got name=%q target=%q", exec.name, exec.target)
 	}
 }
 
@@ -459,11 +430,12 @@ func TestRunUpE_autoInitMatchesRunInit(t *testing.T) {
 	}
 }
 
-func TestRunUpE_autoInitMissingMarkerFailsClosed(t *testing.T) {
+func TestRunUpE_autoInitWithoutMarkerThenNextRunRefuses(t *testing.T) {
 	// init returns nil but leaves no settings marker (ConfirmFn deletes
-	// cheasee-settings.json during the API-key phase and declines) → the
-	// post-init re-resolution re-classifies the folder as non-initialized and
-	// start fails closed naming the residue; no compose, no exec.
+	// cheasee-settings.json during the API-key phase and declines): the empty-
+	// folder branch stops after init (it no longer re-resolves the workspace),
+	// so the residue lingers — the NEXT start classifies the folder as
+	// non-initialized and refuses. No compose, no exec.
 	parent := t.TempDir()
 	workdir := filepath.Join(parent, "ws")
 	if err := os.MkdirAll(workdir, 0755); err != nil {
@@ -475,7 +447,7 @@ func TestRunUpE_autoInitMissingMarkerFailsClosed(t *testing.T) {
 	stubDockerCheck(t, nil, "24.0.9", nil)
 	c := stubUpFlow(t, workdir, false)
 	stubInitGit(t)
-	stubExecPIContainer(t)
+	exec := stubExecPIContainer(t)
 	saved := newInitDeps
 	newInitDeps = func(wd string) InitDeps {
 		deps := initDepsWithRepoURL(t, wd)
@@ -493,15 +465,27 @@ func TestRunUpE_autoInitMissingMarkerFailsClosed(t *testing.T) {
 	}
 	t.Cleanup(func() { newInitDeps = saved })
 
-	err := runUpE(&cobra.Command{}, nil)
-	if err == nil || !strings.Contains(err.Error(), "worktree/.bare residue") {
-		t.Fatalf("expected fail-closed error naming the residue, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "cheasee-pi start") {
-		t.Errorf("refusal should point at re-running start in an empty folder, got %v", err)
+	// First start: empty folder → init runs, then stops. No compose/exec even
+	// though the marker is gone (init reported success).
+	if err := runUpE(&cobra.Command{}, nil); err != nil {
+		t.Fatalf("first runUpE: %v", err)
 	}
 	if len(c.composeArgs) != 0 {
-		t.Errorf("missing marker must never reach compose, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
+		t.Errorf("post-init stop must never reach compose, got %d invocations: %v", len(c.composeArgs), c.composeArgs)
+	}
+	if exec.name != "" {
+		t.Errorf("post-init stop must never exec pi, got name=%q", exec.name)
+	}
+
+	// Second start: non-empty (worktree + .bare residue) without the settings
+	// marker → refused with the empty-folder hint, message includes the error
+	// the user asked for ('run in an empty folder').
+	err := runUpE(&cobra.Command{}, nil)
+	if err == nil || !strings.Contains(err.Error(), "not initialized") {
+		t.Fatalf("second runUpE must refuse the non-initialized residue, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "cheasee-pi init") || !strings.Contains(err.Error(), "empty folder") {
+		t.Errorf("refusal should point at init in an empty folder, got %v", err)
 	}
 }
 
@@ -555,51 +539,6 @@ func TestRunUpE_autoInitFailureSurfaces(t *testing.T) {
 	}
 }
 
-func TestRunUpE_autoInitContinuationDockerRecheck(t *testing.T) {
-	// runInit's docker check (call 1) passes; the continuation's re-check
-	// (call 2) fails → error surfaces post-init, no compose. The re-check is
-	// a UX gate after a long OAuth stall, not a correctness requirement.
-	parent := t.TempDir()
-	workdir := filepath.Join(parent, "ws")
-	if err := os.MkdirAll(workdir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	setUpRunMode(t, workdir, false)
-	testutil.RedirectConfigHome(t)
-	testutil.SetGitConfig(t, testGitIdentityConfig)
-	stubInitGit(t)
-	stubAutoInitDeps(t)
-	stubExecPIContainer(t)
-
-	var infoCalls int
-	saved := runCommandContext
-	stubRunCommandContext(t, func(ctx context.Context, name string, arg ...string) runner {
-		if name == "docker" && len(arg) > 0 && arg[0] == "info" {
-			infoCalls++
-			if infoCalls > 1 {
-				return &mockCmd{runFn: func() error { return fmt.Errorf("Cannot connect to the Docker daemon") }}
-			}
-			return &mockCmd{}
-		}
-		if name == "docker" && len(arg) > 0 && arg[0] == "version" {
-			return &mockCmd{outputFn: func() ([]byte, error) { return []byte("24.0.9"), nil }}
-		}
-		return saved(ctx, name, arg...)
-	})
-	stubLookPath(t, func(_ string) (string, error) { return "/usr/bin/docker", nil })
-	stubExecCommand(t, func(_ string, arg ...string) cmdIface {
-		return &mockCmd{}
-	})
-
-	err := runUpE(&cobra.Command{}, nil)
-	if err == nil || !strings.Contains(err.Error(), "not running") {
-		t.Fatalf("expected continuation docker-check failure, got %v", err)
-	}
-	if infoCalls != 2 {
-		t.Errorf("docker check must run twice on the one-shot path (init + continuation), got %d", infoCalls)
-	}
-}
-
 func TestRunUpE_autoInitPreCancelledFailsFast(t *testing.T) {
 	// A pre-cancelled parent ctx propagates into the 5-min initTimeout child
 	// ctx → auto-init fails fast with the ctx error; no compose, no exec.
@@ -633,7 +572,7 @@ func TestRunUpE_autoInitPreCancelledFailsFast(t *testing.T) {
 
 func TestRunUpE_autoInitDsStoreOnlyFolder(t *testing.T) {
 	// A Finder-touched folder (.DS_Store only) classifies as empty and takes
-	// the same one-shot path.
+	// the same init-then-stop path: init runs, no compose, no exec.
 	parent := t.TempDir()
 	workdir := filepath.Join(parent, "ws")
 	if err := os.MkdirAll(workdir, 0755); err != nil {
@@ -654,11 +593,11 @@ func TestRunUpE_autoInitDsStoreOnlyFolder(t *testing.T) {
 	if err := runUpE(&cobra.Command{}, nil); err != nil {
 		t.Fatalf("runUpE: %v", err)
 	}
-	if len(c.composeArgs) != 2 {
-		t.Errorf(".DS_Store-only folder must take the one-shot path (build + up), got %d: %v", len(c.composeArgs), c.composeArgs)
+	if len(c.composeArgs) != 0 {
+		t.Errorf(".DS_Store-only folder must stop after init — no compose, got %d: %v", len(c.composeArgs), c.composeArgs)
 	}
-	if exec.name != containerName(filepath.Join(workdir, "main")) {
-		t.Errorf(".DS_Store-only one-shot must exec into %q, got %q", containerName(filepath.Join(workdir, "main")), exec.name)
+	if exec.name != "" {
+		t.Errorf(".DS_Store-only folder must not exec pi, got name=%q", exec.name)
 	}
 }
 
@@ -685,8 +624,8 @@ func TestRunUpE_fullFlowRunsContainer(t *testing.T) {
 	if strings.Contains(stderr, "Created .pi/settings.json") {
 		t.Errorf("start must not announce a .pi/settings.json scaffold, got: %q", stderr)
 	}
-	// Regression: the one-shot confirmation is auto-init-only — an initialized
-	// workspace start must not print it.
+	// Regression: the 'starting pi' confirmation was the one-shot auto-init's
+	// message — an initialized-workspace start must never print it.
 	if strings.Contains(stderr, "starting pi") {
 		t.Errorf("initialized-workspace start must not print the first-run confirmation, got: %q", stderr)
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Or manually from the [latest release](https://github.com/SchneiderDaniel/cheasee
 cheasee-pi init           # empty-folder setup: repo URL, auth, bare clone + worktree,
                           # scaffold gitignored cheasee-settings.json
 cheasee-pi init --reauth  # initialized workspace: redo GitHub OAuth + pi API-key auth
-cheasee-pi start          # empty folder → auto-init; workspace → start pi (default)
+cheasee-pi start          # empty folder → init (stops); workspace → start pi (default)
 cheasee-pi down           # stop and remove current workspace's container
 cheasee-pi clean          # remove all cheasee-pi containers (all repos) + prune garbage
 cheasee-pi build          # rebuild container image (Dockerfile/entrypoint changes)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,8 +122,8 @@ The repo root is bind-mounted at `/workspaces/main`. Host UID/GID are mapped to 
 - **Empty folder** → auto-runs `cheasee-pi init` (repo-URL prompt → bare clone
   to `<parent>/.bare` → worktree attach on the repo's default branch (bare
   HEAD via `symbolic-ref`) → `cheasee-settings.json`),
-  then falls through into the normal start phases in the same invocation
-  (docker check → compose up → exec pi).
+  then stops — init never launches pi; a second `cheasee-pi start` runs the
+  normal start phases (docker check → compose up → exec pi).
 - **`cheasee-settings.json` present** → initialized; runs normally.
 - **Non-empty folder without settings** → refused (“not initialized; run
   `cheasee-pi init` in an empty folder”).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -40,8 +40,8 @@ subcommand.
 | 5 | `cheasee-pi down` | stop and remove this workspace's container |
 | 6 | `cheasee-pi clean` | sweep every container + orphan sessions, prune |
 
-An empty folder can skip step 1: `cheasee-pi start` auto-inits it and
-continues into start in the same invocation.
+An empty folder can skip step 1: `cheasee-pi start` auto-runs init and
+stops (init never launches pi); run `cheasee-pi start` again to launch.
 
 ## `cheasee-pi` (no args) / `start`
 
@@ -51,7 +51,7 @@ without a subcommand executes the same handler as `start`.
 | | |
 |---|---|
 | **Does** | Mounts the workspace at `/workspaces/main` and its sibling bare clone at `/workspaces/.bare`, starts the container (`docker compose up` if not running), injects provider keys from `~/.config/cheasee-pi/auth.json` as environment variables, launches pi, and prints the CodeFlow URL (`http://localhost:<port>/?repo=local/workspace&run=1`) once the container is healthy. |
-| **Checks** | Workspace gate: empty folder → runs `init` first and continues into start in the same invocation; `cheasee-settings.json` present → run; non-empty folder without it → refused. Docker gate (binary present + `docker info` responds + Engine ≥ 24.0.0, 5 s timeout) unless `--no-docker-check`. |
+| **Checks** | Workspace gate: empty folder → runs `init` and stops (re-run `start` to launch pi); `cheasee-settings.json` present → run; non-empty folder without it → refused with an empty-folder hint. Docker gate (binary present + `docker info` responds + Engine ≥ 24.0.0, 5 s timeout) unless `--no-docker-check`. |
 | **Inputs** | Flags: `--workdir`, `--name`, `--build`, `--no-docker-check`, `--api-key` (session-only, not saved), `--dry-run` (print injected env vars, then exit). Reads `auth.json` + `cheasee-settings.json`; writes the version-keyed compose/Dockerfile cache. |
 
 ## `cheasee-pi init`
@@ -65,7 +65,7 @@ path (no clone, no repo URL).
 
 | | |
 |---|---|
-| **Does** | Bare-clones the project repo, adds the main worktree in a branch-named subfolder of the workspace (`<workdir>/main` unless a different branch is stated), scaffolds `cheasee-settings.json` in the worktree leaf (never overwrites an existing one), authenticates GitHub, records custom skill repos, saves auth config, and sets up the provider API key. Prints `cheasee-pi start` as the next step (or continues into start automatically when triggered by `start`). |
+| **Does** | Bare-clones the project repo, adds the main worktree in a branch-named subfolder of the workspace (`<workdir>/main` unless a different branch is stated), scaffolds `cheasee-settings.json` in the worktree leaf (never overwrites an existing one), authenticates GitHub, records custom skill repos, saves auth config, and sets up the provider API key. Prints `cheasee-pi start` as the next step — init never launches pi (the second `start` invocation does). |
 | **Checks** | Docker gate unless `--no-docker-check`. Empty-folder probe: non-empty folders are refused (`.DS_Store` tolerated). `cheasee-settings.json` presence marks the workspace initialized — init refuses it unless `--reauth` (which re-runs only the GitHub + API-key authentications). Single invocation capped at a 5-minute timeout (device-flow OAuth polling dominates). `--no-input` requires `--repo-url`. |
 | **Inputs** | Repo URL (`--repo-url` or interactive prompt), branch naming the worktree folder (interactive prompt, default `main`), GitHub OAuth device flow, API key (`--api-key` or prompt), provider name. Files written: `cheasee-settings.json` in the worktree leaf, `~/.config/cheasee-pi/auth.json`, `.pi/` agent settings, sibling `.bare` clone + worktree leaf. |
 

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -28,10 +28,10 @@ Before running pi via Docker, ensure the following are in place:
 - **First-time build complete** — the Docker image must be built at least once. See [Start](#start-the-container) below.
 - **A cheasee-pi workspace** — run `cheasee-pi init` in an empty folder to set
   one up (bare clone + main worktree + `cheasee-settings.json`), or just run
-  `cheasee-pi start` in an empty folder — it auto-inits first and continues
-  into start in the same invocation. Re-authenticate later (revoked GitHub
-  token, rotated API keys) with `cheasee-pi init --reauth` in the workspace —
-  it redoes the GitHub OAuth and pi API-key authentications.
+  `cheasee-pi start` in an empty folder — it auto-runs init and stops (init
+  never launches pi); run `cheasee-pi start` again to start pi. Re-authenticate
+  later (revoked GitHub token, rotated API keys) with `cheasee-pi init --reauth`
+  in the workspace — it redoes the GitHub OAuth and pi API-key authentications.
 
 The container mounts `~/.config/gh/` read-write, so host GitHub authentication works
 automatically inside the container.
@@ -151,9 +151,10 @@ cheasee-pi
 ```
 
 `cheasee-pi` (no subcommand, alias `start`) gates on the workspace: empty
-folder → auto-runs `cheasee-pi init` and continues into start in the same
-invocation; `cheasee-settings.json` present → runs; non-empty folder without
-settings → refused with a hint to run init. It then starts the container if
+folder → auto-runs `cheasee-pi init` and stops (init never launches pi —
+run `cheasee-pi start` again to start); `cheasee-settings.json` present →
+runs; non-empty folder without settings → refused with a hint to run init in
+an empty folder. On an initialized workspace it starts the container if
 needed, reads `~/.config/cheasee-pi/auth.json`,
 injects API keys as env vars, and launches pi with your repo mounted at
 `/workspaces/main`.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -128,8 +128,8 @@ cheasee-pi start
 `cheasee-pi` (alias `start`) gates on the workspace state:
 
 - **Empty folder** → auto-runs `cheasee-pi init` (repo URL prompt, bare clone
-  + main worktree, `cheasee-settings.json`), then continues into `start` in
-  the same invocation — one command sets the workspace up and starts pi
+  + main worktree, `cheasee-settings.json`), then stops — init never launches
+  pi; run `cheasee-pi start` again to start
 - **`cheasee-settings.json` present** → initialized workspace; runs normally
 - **Non-empty folder without `cheasee-settings.json`** → refused with
   “not initialized; run `cheasee-pi init` in an empty folder”


### PR DESCRIPTION
## What

Bare `cheasee-pi` / `cheasee-pi start` in an **empty folder** used to run `init` and then continue into the pi launch in the same invocation. Now **init always stops** — it never launches pi:

- **empty folder** → runs `cheasee-pi init` and exits; init prints the next-step hint (`cheasee-pi start`)
- **`cheasee-settings.json` present** → runs start (unchanged)
- **non-empty folder without settings** → refused with the run-init-in-an-empty-folder error (unchanged)

Two-step flow: `cheasee-pi` in an empty folder inits and stops; run `cheasee-pi` again to launch pi.

## Why

Requested behavior: `cheasee-pi init` should not end by starting pi, and the bare command should dispatch on the workspace state — empty → init, initialized → start, non-empty-without-settings → error.

## Changes

- `cmd/cheasee-pi/up.go` — empty-folder branch runs init then returns; removed the continuation (post-init re-resolution, `firstRun`, "Workspace set up — starting pi…" confirmation)
- `cmd/cheasee-pi/init.go` — removed `InStartFlow`; completion always prints "Next step: cheasee-pi start"
- `cmd/cheasee-pi/root.go` — help text describes the dispatcher
- Tests — retargeted `TestRunUpE_autoInitStopsAfterInit`, `TestRunUpE_autoInitWithoutMarkerThenNextRunRefuses`, `.DS_Store` variant; removed `TestRunUpE_autoInitContinuationDockerRecheck` and `TestInit_SuccessMessageInStartFlow`
- Docs — README, docs/cli.md, docs/daily-usage.md, docs/installation.md, docs/architecture.md + doc-consistency tests

## Verification

`go build`, `go vet`, `go test ./cmd/cheasee-pi/` all pass.