### PR TITLE
chore: bump version to v0.53

### DIFF
--- a/cmd/cheasee-pi/cache.go
+++ b/cmd/cheasee-pi/cache.go
@@ -24,7 +24,7 @@ func CacheDir() (string, error) {
 // cliVersionKey is the cache-dir key: the CLI's own semver. Kept as a const
 // (referenced by rootCmd.Version too) so the cache path never participates in
 // a rootCmd initialization cycle.
-const cliVersionKey = "0.52"
+const cliVersionKey = "0.53"
 
 // cliVersion is the cache-dir key: the CLI's own semver.
 func cliVersion() string {

--- a/cmd/cheasee-pi/root_test.go
+++ b/cmd/cheasee-pi/root_test.go
@@ -144,7 +144,7 @@ func TestRootCmd_Version_IsValidSemver(t *testing.T) {
 }
 
 func TestRootCmd_Version_IsExpectedRelease(t *testing.T) {
-	expected := "0.52"
+	expected := "0.53"
 	if rootCmd.Version != expected {
 		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, expected)
 	}

--- a/docker/test/cli-install-smoke.test.mts
+++ b/docker/test/cli-install-smoke.test.mts
@@ -88,7 +88,7 @@ const POLL_INTERVAL_MS = 5_000;
  * The cache dir is version-keyed so an upgraded binary never mixes stale
  * compose/Dockerfile content with new embedded assets.
  */
-const CLI_VERSION = "0.52";
+const CLI_VERSION = "0.53";
 
 /**
  * Compute the CLI cache dir (compose/Dockerfile live there,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ nav_order: 2
 
 ```bash
 # Set version (check latest at https://github.com/SchneiderDaniel/cheasee-pi/releases)
-VERSION="0.52"
+VERSION="0.53"
 
 # Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -43,7 +43,7 @@ curl -fsL "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v${VE
 
 ```powershell
 # PowerShell
-$version = "0.52"
+$version = "0.53"
 $arch = if ((Get-CimInstance Win32_ComputerSystem).SystemType -match "ARM") { "arm64" } else { "amd64" }
 curl -Lo cheasee-pi.zip "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v$version/cheasee-pi_${version}_windows_$arch.zip"
 tar -xf cheasee-pi.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "main",
-	"version": "0.52",
+	"version": "0.53",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "main",
-			"version": "0.52",
+			"version": "0.53",
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "^0.79.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "main",
-	"version": "0.52",
+	"version": "0.53",
 	"description": "---",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
## Summary

Release bump for v0.53 (9 commits after v0.52).

### Included fixes
- `65504512` fix(clean): skip orphan scan on containers without bash (exit-127 abort)
- `36c627cd` fix: feed auth.json GitHub token to gh so private skill repos clone
- `bb2bac30` fix: attach init worktree to the repo's default branch
- `8de3091a` fix(cli): init never launches pi; start stops after init
- `bce005ca` test: interactive init records multiple skill repos

### Changes
- Version bump `0.52 → 0.53` in: cache.go, root_test.go, cli-install-smoke.test.mts, docs/installation.md, package.json, package-lock.json

### Verification
- `go build` ✓
- `go test -run Version` ✓