### PR TITLE
fix(pages): scope working-directory to Jekyll build step

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ concurrency:
 
 defaults:
   run:
-    working-directory: docs
+    shell: bash
 
 jobs:
   build:
@@ -42,6 +42,7 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        working-directory: docs
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
Fix Pages deploy for v0.53 (and every docs-touching push since 5a7c8944).

Job-level `working-directory: docs` broke Checkout and `make check-no-submodules` (Makefile at repo root). Only the Jekyll step needs docs as cwd.

- Failures: Pages run 32065746079 on main v0.53 merge (and earlier)
- Release workflow itself succeeded; this is the lone v0.53 leftover