### PR TITLE
fix(start): resolve workspace leaf when run from init parent folder

### DIFF
--- a/cmd/cheasee-pi/repo.go
+++ b/cmd/cheasee-pi/repo.go
@@ -96,8 +96,11 @@ func pinnedCEEnv() []string {
 // findWorkspaceRoot walks up from workdir looking for cheasee-settings.json —
 // the initialized marker — and returns the workspace root (the folder
 // cheasee-pi set up) with true. Returns false when no ancestor is
-// initialized (the caller then classifies the cwd itself: empty → auto-init,
-// else refuse).
+// initialized; the caller then classifies the cwd itself (empty → auto-init,
+// else refuse). Falls back to resolveWorkspaceParent when workdir sits
+// outside the worktree but IS the cheasee-pi parent folder (the folder init
+// ran in) — the workspace leaf is then the child holding the settings
+// marker, so `cheasee-pi start`/`down` work from the parent without a cd.
 func findWorkspaceRoot(workdir string) (string, bool) {
 	dir, err := filepath.Abs(workdir)
 	if err != nil {
@@ -109,8 +112,38 @@ func findWorkspaceRoot(workdir string) (string, bool) {
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return resolveWorkspaceParent(workdir)
 		}
 		dir = parent
 	}
+}
+
+// resolveWorkspaceParent detects the cheasee-pi workspace-parent layout and
+// returns the workspace root: init runs in an EMPTY folder and leaves exactly
+// a sibling .bare plus one worktree leaf holding cheasee-settings.json — the
+// .bare sibling is the invariant, the settings-bearing leaf the workspace.
+// Runs only when no ancestor walk found a marker, so a genuine
+// non-initialized folder never resolves. Fail-closed: no .bare, no settings
+// leaf, or more than one settings leaf (user-created ambiguity) → false.
+func resolveWorkspaceParent(parent string) (string, bool) {
+	if _, err := os.Stat(filepath.Join(parent, ".bare")); err != nil {
+		return "", false
+	}
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return "", false
+	}
+	var leaf string
+	for _, e := range entries {
+		if e.Name() == ".bare" || !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(cheaseeSettingsPath(filepath.Join(parent, e.Name()))); err == nil {
+			if leaf != "" {
+				return "", false // ambiguous — refuse, user should cd
+			}
+			leaf = e.Name()
+		}
+	}
+	return filepath.Join(parent, leaf), leaf != ""
 }

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -237,27 +237,17 @@ const (
 	WorkspaceRefuse                            // non-empty, no settings → refuse
 )
 
-// resolveStartWorkspace resolves the start gate in a single pass: walks up
-// from workdir looking for cheasee-settings.json (the initialized marker) and
-// returns the workspace root when an ancestor is initialized; when no ancestor
-// is, classifies the cwd itself (empty → auto-init, else refuse). One stat
-// per ancestor level — no second pass over the cwd.
+// resolveStartWorkspace resolves the start gate: findWorkspaceRoot walks up
+// from workdir (falling back to the cheasee-pi parent layout — .bare sibling
+// + settings-bearing leaf) for the initialized marker and returns the
+// workspace root when found; when no ancestor is initialized, classifyWorkspace
+// classifies the cwd itself (empty → auto-init, else refuse).
 func resolveStartWorkspace(workdir string) (root string, state WorkspaceState, err error) {
-	dir, err := filepath.Abs(workdir)
-	if err != nil {
-		dir = workdir
+	if root, ok := findWorkspaceRoot(workdir); ok {
+		return root, WorkspaceInitialized, nil
 	}
-	for {
-		if _, err := os.Stat(cheaseeSettingsPath(dir)); err == nil {
-			return dir, WorkspaceInitialized, nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			state, err := classifyWorkspace(workdir)
-			return "", state, err
-		}
-		dir = parent
-	}
+	state, err = classifyWorkspace(workdir)
+	return "", state, err
 }
 
 // classifyWorkspace classifies a folder for the start gate: an empty folder

--- a/cmd/cheasee-pi/up_flow_test.go
+++ b/cmd/cheasee-pi/up_flow_test.go
@@ -237,6 +237,82 @@ func TestFindWorkspaceRoot_notFound(t *testing.T) {
 	}
 }
 
+// workspaceParentFixture builds the cheasee-pi parent layout: a parent folder
+// with a sibling .bare and one worktree leaf holding cheasee-settings.json
+// (the exact layout init leaves behind).
+func workspaceParentFixture(t *testing.T) (parent, leaf string) {
+	t.Helper()
+	parent = t.TempDir()
+	leaf = filepath.Join(parent, "main")
+	if err := os.MkdirAll(filepath.Join(parent, ".bare"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(leaf, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteCheaseeSettingsFile(t, leaf, `{}`)
+	return parent, leaf
+}
+
+func TestResolveWorkspaceParent_fromParent(t *testing.T) {
+	parent, leaf := workspaceParentFixture(t)
+	got, ok := resolveWorkspaceParent(parent)
+	if !ok || got != leaf {
+		t.Errorf("resolveWorkspaceParent(parent) = %q, %v; want %q, true", got, ok, leaf)
+	}
+}
+
+func TestResolveWorkspaceParent_noBare(t *testing.T) {
+	dir := t.TempDir()
+	leaf := filepath.Join(dir, "main")
+	if err := os.MkdirAll(leaf, 0755); err != nil {
+		t.Fatal(err)
+	}
+	testutil.WriteCheaseeSettingsFile(t, leaf, `{}`)
+	if _, ok := resolveWorkspaceParent(dir); ok {
+		t.Error("parent without .bare sibling must not resolve")
+	}
+}
+
+func TestResolveWorkspaceParent_ambiguousRefuse(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(parent, ".bare"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	for _, branch := range []string{"main", "feature"} {
+		leaf := filepath.Join(parent, branch)
+		if err := os.MkdirAll(leaf, 0755); err != nil {
+			t.Fatal(err)
+		}
+		testutil.WriteCheaseeSettingsFile(t, leaf, `{}`)
+	}
+	if _, ok := resolveWorkspaceParent(parent); ok {
+		t.Error("two settings-bearing leaves must not resolve (ambiguous)")
+	}
+}
+
+func TestFindWorkspaceRoot_fromParent(t *testing.T) {
+	parent, leaf := workspaceParentFixture(t)
+	got, ok := findWorkspaceRoot(parent)
+	if !ok || got != leaf {
+		t.Errorf("findWorkspaceRoot(parent) = %q, %v; want %q, true", got, ok, leaf)
+	}
+}
+
+func TestResolveStartWorkspace_fromParent(t *testing.T) {
+	parent, leaf := workspaceParentFixture(t)
+	root, state, err := resolveStartWorkspace(parent)
+	if err != nil {
+		t.Fatalf("resolveStartWorkspace: %v", err)
+	}
+	if state != WorkspaceInitialized {
+		t.Errorf("from parent → WorkspaceInitialized, got %v", state)
+	}
+	if root != leaf {
+		t.Errorf("from parent → root %q, want %q", root, leaf)
+	}
+}
+
 // ──────────────────────────────────────────────
 // Phase 1: start gate use cases
 // ──────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`cheasee-pi init` runs in an empty folder `<parent>`, but sets the workspace up in the leaf it clones: `<parent>/<branch>` (default `main`). `cheasee-settings.json` — the initialized marker — lives **inside the leaf**.

The post-init hint prints `cheasee-pi start` with no `cd`, so running it from `<parent>` hits a cryptic refusal:

```
Error: not initialized: "/home/dan/git/flask/blog" is not empty and has no cheasee-settings.json — run `cheasee-pi init` in an empty folder first
```

whose remedy (run init again) would itself refuse (folder not empty). The empty-folder auto-init flow (`cheasee-pi start` in an empty dir → init → stop) has the same trap on the second `start`.

## Fix

Kill the cd requirement instead of documenting it. When no ancestor holds the settings marker **and** the cwd is a cheasee-pi workspace parent (sibling `.bare` — the layout invariant init leaves behind — plus exactly one settings-bearing worktree leaf), resolve the leaf as the workspace root.

- `resolveWorkspaceParent` (repo.go): fail-closed detection — no `.bare`, no settings leaf, or **more than one** settings leaf (user-created ambiguity) → refuse as before.
- `findWorkspaceRoot` (repo.go): falls back to it, so `down` works from the parent too.
- `resolveStartWorkspace` (up.go): consolidated onto `findWorkspaceRoot` (the walk was duplicated) — `start` works from the parent.

Rest of the start flow already holds: `dockerComposeUp` derives the `.bare` sibling from the leaf path, and the exec target falls back to `/workspaces/main`.

## Verification

- New tests: `TestResolveWorkspaceParent_{fromParent,noBare,ambiguousRefuse}`, `TestFindWorkspaceRoot_fromParent`, `TestResolveStartWorkspace_fromParent`.
- `go test ./cmd/cheasee-pi/` green (one pre-existing env-dependent failure `TestUninstallScript_DryRunMatchesGoPaths` also fails on main — installed `/usr/local/bin/cheasee-pi` on the machine).