### PR TITLE
fix(docker): retry osv-scanner download

### DIFF
--- a/cmd/cheasee-pi/embedded/docker/Dockerfile
+++ b/cmd/cheasee-pi/embedded/docker/Dockerfile
@@ -195,7 +195,12 @@ RUN case "$(dpkg --print-architecture)" in \
             osv_asset="osv-scanner_linux_arm64" ;; \
         *) echo "Unsupported arch: $(dpkg --print-architecture)" >&2; exit 1 ;; \
     esac && \
-    curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/${osv_asset}" -o "/usr/local/bin/osv-scanner" && \
+    for i in 1 2 3; do \
+      curl -fsSL "https://github.com/google/osv-scanner/releases/download/v${OSV_SCANNER_VERSION}/${osv_asset}" -o "/usr/local/bin/osv-scanner" \
+        && break; \
+      echo "[attempt $i] osv-scanner download failed, retrying in 5s…"; \
+      sleep 5; \
+    done && \
     chmod +x /usr/local/bin/osv-scanner && \
     osv-scanner --version
 


### PR DESCRIPTION
Step 15 (`curl` of osv-scanner binary from GitHub releases) exits 92 (HTTP/2 PROTOCOL_ERROR) intermittently — a transient network flake with no retry, unlike the patchright chromium install loop. One hiccup kills the whole build regardless of repo contents.

Wrap the download in the same 3-attempt loop. `chmod +x` and `osv-scanner --version` after it keep a total download failure fatal.

Quick sanity: retry semantics verified visually; full behavior needs a build, which I can't run here. Merge before any rebuild for full confidence.