### PR TITLE
feat(init): install ponytail as default skill repo

### DIFF
--- a/cmd/cheasee-pi/init_scaffold.go
+++ b/cmd/cheasee-pi/init_scaffold.go
@@ -71,15 +71,19 @@ func runInitScaffold(
 	}
 
 	vals := TemplateSettingsValues{
-		Provider:       deps.Provider,
-		DefaultModel:   DefaultModel(deps.Provider),
-		GitName:        gitName,
-		GitEmail:       gitEmail,
-		Memory:         "2G",
-		CPUs:           "2.0",
-		ClientID:       deps.ClientID,
-		RepositoryURL:  repoURL,
-		GitHubUser:     githubUser,
+		Provider:      deps.Provider,
+		DefaultModel:  DefaultModel(deps.Provider),
+		GitName:       gitName,
+		GitEmail:      gitEmail,
+		Memory:        "2G",
+		CPUs:          "2.0",
+		ClientID:      deps.ClientID,
+		RepositoryURL: repoURL,
+		GitHubUser:    githubUser,
+		// Every init records the default pi repos (ponytail) so the container
+		// entrypoint installs them uniformly; user-added custom repos are
+		// merged additively afterwards via recordSkillRepos.
+		SkillRepos: defaultSkillRepos,
 	}
 
 	if err := NewCheaseeSettingsScaffold().Scaffold(ctx, deps.Workdir, vals); err != nil {

--- a/cmd/cheasee-pi/init_skillrepos.go
+++ b/cmd/cheasee-pi/init_skillrepos.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+// defaultSkillRepos are canonical external pi git repos cheasee-pi installs
+// into every container by default, seeded into cheasee-settings.json skillRepos
+// at init and installed by the entrypoint through the same `pi install -l -a`
+// mechanism as user-added custom repos — one uniform install path for all
+// external pi packages (ponytail among them). Canonical form, stored verbatim.
+var defaultSkillRepos = []string{"https://github.com/DietrichGebert/ponytail"}
+
 // canonicalSkillRepo validates and normalizes a custom skill repository spec
 // to the canonical form the entrypoint passes to `pi install -l -a` verbatim
 // (clones land in the bind-mounted .pi/git/ and pi owns the settings

--- a/cmd/cheasee-pi/init_split_test.go
+++ b/cmd/cheasee-pi/init_split_test.go
@@ -61,6 +61,7 @@ var wantInitDecls = map[string]string{
 	"func:runInitSkillRepos":  "init_skillrepos.go",
 	"func:canonicalSkillRepo": "init_skillrepos.go",
 	"func:recordSkillRepos":   "init_skillrepos.go",
+	"var:defaultSkillRepos":   "init_skillrepos.go",
 
 	"func:promptConfirm":     "init_prompt.go",
 	"func:promptGitIdentity": "init_prompt.go",

--- a/cmd/cheasee-pi/init_usecase_test.go
+++ b/cmd/cheasee-pi/init_usecase_test.go
@@ -507,9 +507,9 @@ func TestInitUseCase_SkillReposInteractiveMultiAdd(t *testing.T) {
 }
 
 func TestInitUseCase_NoSkillReposScaffoldByteIdentical(t *testing.T) {
-	// Full flow without skill repos: the skill-repo phase records nothing and
-	// performs no Save — cheasee-settings.json stays byte-identical to the
-	// scaffold template output.
+	// Full flow without user skill repos: the skill-repo phase records nothing
+	// and performs no Save — cheasee-settings.json stays byte-identical to the
+	// scaffold template output, which now carries the default repos (ponytail).
 	testutil.RedirectConfigHome(t)
 	testutil.SetGitConfig(t, testGitIdentityConfig)
 	stubDockerCheck(t, nil, "24.0.9", nil)
@@ -528,13 +528,13 @@ func TestInitUseCase_NoSkillReposScaffoldByteIdentical(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if strings.Contains(string(got), "skillRepos") {
-		t.Errorf("no skill repos → no skillRepos key, got: %s", got)
+	if !strings.Contains(string(got), "DietrichGebert/ponytail") {
+		t.Errorf("scaffold must carry the default ponytail repo, got: %s", got)
 	}
 
 	// Baseline: the embedded template rendered with the exact values
 	// runInitScaffold used (identity from SetGitConfig, defaults, canonical
-	// repo URL, resolved GitHub user).
+	// repo URL, resolved GitHub user, default skill repos).
 	baseline := t.TempDir()
 	if err := NewCheaseeSettingsScaffold().Scaffold(context.Background(), baseline, TemplateSettingsValues{
 		Provider:      deps.Provider,
@@ -546,6 +546,7 @@ func TestInitUseCase_NoSkillReposScaffoldByteIdentical(t *testing.T) {
 		ClientID:      deps.ClientID,
 		RepositoryURL: "https://github.com/owner/repo.git",
 		GitHubUser:    MockGitHubUser,
+		SkillRepos:    defaultSkillRepos,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -588,8 +589,11 @@ func TestInitUseCase_NoInputSkillRepoFlagsNoPrompts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"https://github.com/owner/repo"}
-	if len(s.SkillRepos) != 1 || s.SkillRepos[0] != want[0] {
+	want := []string{
+		defaultSkillRepos[0],
+		"https://github.com/owner/repo",
+	}
+	if len(s.SkillRepos) != 2 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] {
 		t.Errorf("skillRepos = %v, want %v", s.SkillRepos, want)
 	}
 }
@@ -615,8 +619,11 @@ func TestInitUseCase_NoGitHubRecordsSkillRepos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"https://github.com/owner/repo"}
-	if len(s.SkillRepos) != 1 || s.SkillRepos[0] != want[0] {
+	want := []string{
+		defaultSkillRepos[0],
+		"https://github.com/owner/repo",
+	}
+	if len(s.SkillRepos) != 2 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] {
 		t.Errorf("skillRepos = %v, want %v", s.SkillRepos, want)
 	}
 }


### PR DESCRIPTION
## Summary

Running cheasee-pi **on the cheasee-pi repo** (dogfooding) failed at pi startup:

```
Error: Cannot find module '/workspaces/main/.pi/git/github.com/DietrichGebert/ponytail/hooks/ponytail-config.js'
```

**Root cause:** the tracked `.pi/extensions/ponytail/index.js` `require()`s package hooks from `.pi/git/…`, which is **gitignored** — an untracked, per-checkout clone created only by `pi install`. The dogfood checkout mounted into the container never had ponytail installed, so the `require` failed. Normal repos never hit this because their `.pi/` doesn't carry the ponytail extension.

**Fix:** seed `DietrichGebert/ponytail` into `cheasee-settings.json` `skillRepos` at init scaffold time. The container entrypoint already installs every entry via `pi install -l -a`, so ponytail now flows through the **same uniform mechanism as user-added custom repos** — no dogfood special-case.

## Changes
- `init_skillrepos.go`: add `defaultSkillRepos = ["https://github.com/DietrichGebert/ponytail"]`
- `init_scaffold.go`: scaffold seeds `SkillRepos: defaultSkillRepos` so every fresh init records the default repo
- `recordSkillRepos` unchanged (already additive + deduped) — user custom repos merge alongside defaults
- `init_split_test.go`: added `var:defaultSkillRepos` to the init split inventory
- `init_usecase_test.go`: updated 3 tests that asserted the old no-defaults contract

## After re-init
`cheasee-pi init` → `cheasee-settings.json` contains `"skillRepos": ["https://github.com/DietrichGebert/ponytail"]` → fresh container build → entrypoint installs it → dogfood works.

## Note
Ponytail now installs into **every** cheasee-pi container by default (the requested uniform behavior). Manual removal per workspace is still possible (scaffold is init-only, not reconciled at `start`).