### PR TITLE
chore: bump version to v0.54

### DIFF
--- a/cmd/cheasee-pi/cache.go
+++ b/cmd/cheasee-pi/cache.go
@@ -24,7 +24,7 @@ func CacheDir() (string, error) {
 // cliVersionKey is the cache-dir key: the CLI's own semver. Kept as a const
 // (referenced by rootCmd.Version too) so the cache path never participates in
 // a rootCmd initialization cycle.
-const cliVersionKey = "0.53"
+const cliVersionKey = "0.54"
 
 // cliVersion is the cache-dir key: the CLI's own semver.
 func cliVersion() string {

--- a/cmd/cheasee-pi/root_test.go
+++ b/cmd/cheasee-pi/root_test.go
@@ -144,7 +144,7 @@ func TestRootCmd_Version_IsValidSemver(t *testing.T) {
 }
 
 func TestRootCmd_Version_IsExpectedRelease(t *testing.T) {
-	expected := "0.53"
+	expected := "0.54"
 	if rootCmd.Version != expected {
 		t.Errorf("rootCmd.Version = %q, want %q", rootCmd.Version, expected)
 	}

--- a/docker/test/cli-install-smoke.test.mts
+++ b/docker/test/cli-install-smoke.test.mts
@@ -88,7 +88,7 @@ const POLL_INTERVAL_MS = 5_000;
  * The cache dir is version-keyed so an upgraded binary never mixes stale
  * compose/Dockerfile content with new embedded assets.
  */
-const CLI_VERSION = "0.53";
+const CLI_VERSION = "0.54";
 
 /**
  * Compute the CLI cache dir (compose/Dockerfile live there,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ nav_order: 2
 
 ```bash
 # Set version (check latest at https://github.com/SchneiderDaniel/cheasee-pi/releases)
-VERSION="0.53"
+VERSION="0.54"
 
 # Detect platform
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -43,7 +43,7 @@ curl -fsL "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v${VE
 
 ```powershell
 # PowerShell
-$version = "0.53"
+$version = "0.54"
 $arch = if ((Get-CimInstance Win32_ComputerSystem).SystemType -match "ARM") { "arm64" } else { "amd64" }
 curl -Lo cheasee-pi.zip "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v$version/cheasee-pi_${version}_windows_$arch.zip"
 tar -xf cheasee-pi.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "main",
-	"version": "0.53",
+	"version": "0.54",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "main",
-			"version": "0.53",
+			"version": "0.54",
 			"license": "MIT",
 			"dependencies": {
 				"@earendil-works/pi-ai": "^0.79.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "main",
-	"version": "0.53",
+	"version": "0.54",
 	"description": "---",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
Version bump 0.53 → 0.54 (6 files, 8 changes).

**Changed** (same shape as v0.51→v0.52 bump):
- `cmd/cheasee-pi/cache.go` — `cliVersionKey` 0.53 → 0.54
- `cmd/cheasee-pi/root_test.go` — expected version
- `docker/test/cli-install-smoke.test.mts` — `CLI_VERSION`
- `docs/installation.md` — install script VERSION lines (bash + PowerShell)
- `package.json` + `package-lock.json` — version

**Verified:**
- `go test ./cmd/cheasee-pi/...` — all pass
- `npm test` — 1308 pass, 0 fail

**Release steps after merge:** tag `v0.54` on main → push → workflow runs tests + goreleaser builds release assets.

Deliberately kept: stale-version fixtures (`0.49`/`0.50` cache dirs in uninstall tests) — they test removal of *old* versions.