### PR TITLE
fix(init): always seed ponytail in cheasee-settings skillRepos

### DIFF
--- a/cmd/cheasee-pi/init_skillrepos.go
+++ b/cmd/cheasee-pi/init_skillrepos.go
@@ -106,13 +106,13 @@ func recordSkillRepos(workdir string, specs []string) error {
 // loop; --no-input records flag specs only (no prompt). An empty/whitespace
 // input answers "done"; an invalid spec fails fast naming the accepted forms.
 func runInitSkillRepos(deps InitDeps) error {
-	canonical := make([]string, 0, len(deps.SkillRepos))
+	custom := make([]string, 0, len(deps.SkillRepos))
 	for _, spec := range deps.SkillRepos {
 		c, err := canonicalSkillRepo(spec)
 		if err != nil {
 			return err
 		}
-		canonical = append(canonical, c)
+		custom = append(custom, c)
 	}
 	if !deps.NoInput {
 		fmt.Fprintf(os.Stderr, "\n🧩 Custom Skill Repositories\n")
@@ -141,12 +141,14 @@ func runInitSkillRepos(deps InitDeps) error {
 			if err != nil {
 				return err
 			}
-			canonical = append(canonical, c)
+			custom = append(custom, c)
 			fmt.Fprintf(os.Stderr, "   ✓ Added %s — the prompt repeats; add another or answer no to finish.\n\n", c)
 		}
 	}
-	if len(canonical) == 0 {
-		return nil
-	}
-	return recordSkillRepos(deps.Workdir, canonical)
+	// Always seed the default repos (ponytail) on top of what's already
+	// recorded: the scaffold skips an existing cheasee-settings.json, so a
+	// file predating skillRepos would otherwise never get the fixed default.
+	// Custom repos merge additively after; both dedupe in recordSkillRepos.
+	specs := append(append([]string{}, defaultSkillRepos...), custom...)
+	return recordSkillRepos(deps.Workdir, specs)
 }

--- a/cmd/cheasee-pi/init_skillrepos_test.go
+++ b/cmd/cheasee-pi/init_skillrepos_test.go
@@ -152,14 +152,15 @@ func TestRunInitSkillRepos_InteractiveLoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"https://github.com/owner/repo", "git:github.com/x/y"}
-	if len(s.SkillRepos) != 2 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] {
+	want := []string{defaultSkillRepos[0], "https://github.com/owner/repo", "git:github.com/x/y"}
+	if len(s.SkillRepos) != 3 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] || s.SkillRepos[2] != want[2] {
 		t.Errorf("skillRepos = %v, want %v", s.SkillRepos, want)
 	}
 }
 
 func TestRunInitSkillRepos_EmptyInputStopsLoop(t *testing.T) {
-	// Empty/whitespace InputFn input is the silent done signal.
+	// Empty/whitespace InputFn input is the silent done signal — it stops the
+	// loop but still seeds the fixed default repo (ponytail).
 	workdir := t.TempDir()
 	testutil.WriteCheaseeSettingsFile(t, workdir, `{}`)
 	confirm, input := mockQueuePrompt(t, []bool{true}, []string{"   "})
@@ -176,8 +177,8 @@ func TestRunInitSkillRepos_EmptyInputStopsLoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(s.SkillRepos) != 0 {
-		t.Errorf("empty input must record nothing, got %v", s.SkillRepos)
+	if len(s.SkillRepos) != 1 || s.SkillRepos[0] != defaultSkillRepos[0] {
+		t.Errorf("empty input must stop the loop but seed the default repo, got %v", s.SkillRepos)
 	}
 }
 
@@ -230,9 +231,34 @@ func TestRunInitSkillRepos_PromptErrorWrapped(t *testing.T) {
 	}
 }
 
-func TestRunInitSkillRepos_NoInputNoFlagsNoop(t *testing.T) {
-	// --no-input without --skill-repo: phase skipped entirely, no skillRepos
-	// key emitted.
+func TestRunInitSkillRepos_SeedsDefaultAlongsideExistingCustom(t *testing.T) {
+	// Regression: an existing cheasee-settings.json whose skillRepos holds a
+	// custom repo (private-pi) but not the fixed default (ponytail) must gain
+	// ponytail — the scaffold skipped writing, so the default was lost.
+	workdir := t.TempDir()
+	testutil.WriteCheaseeSettingsFile(t, workdir, `{"skillRepos":["https://github.com/SchneiderDaniel/private-pi.git"]}`)
+	deps := initDeps(t, func(d *InitDeps) { d.Workdir = workdir }) // NoInput defaults true
+	if err := runInitSkillRepos(deps); err != nil {
+		t.Fatalf("seed default: %v", err)
+	}
+	s, err := LoadCheaseeSettings(workdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"https://github.com/SchneiderDaniel/private-pi.git",
+		defaultSkillRepos[0],
+	}
+	got := s.SkillRepos
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("skillRepos = %v, want %v", got, want)
+	}
+}
+
+func TestRunInitSkillRepos_NoInputNoFlagsSeedsDefault(t *testing.T) {
+	// --no-input without --skill-repo: no custom repos, but the fixed default
+	// (ponytail) is still ensured — a pre-existing cheasee-settings.json that
+	// predates skillRepos must gain it.
 	workdir := t.TempDir()
 	testutil.WriteCheaseeSettingsFile(t, workdir, `{}`)
 	deps := initDeps(t, func(d *InitDeps) { d.Workdir = workdir }) // NoInput defaults true
@@ -243,12 +269,8 @@ func TestRunInitSkillRepos_NoInputNoFlagsNoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(s.SkillRepos) != 0 {
-		t.Errorf("no-input without flags must record nothing, got %v", s.SkillRepos)
-	}
-	raw := testutil.ReadCheaseeSettingsRaw(t, workdir)
-	if _, ok := raw["skillRepos"]; ok {
-		t.Error("no-input without flags must not emit a skillRepos key")
+	if len(s.SkillRepos) != 1 || s.SkillRepos[0] != defaultSkillRepos[0] {
+		t.Errorf("no-input without flags must seed the default repo, got %v", s.SkillRepos)
 	}
 }
 
@@ -267,8 +289,8 @@ func TestRunInitSkillRepos_NoInputFlagsRecorded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"https://github.com/owner/repo", "git:github.com/x/y"}
-	if len(s.SkillRepos) != 2 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] {
+	want := []string{defaultSkillRepos[0], "https://github.com/owner/repo", "git:github.com/x/y"}
+	if len(s.SkillRepos) != 3 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] || s.SkillRepos[2] != want[2] {
 		t.Errorf("skillRepos = %v, want %v", s.SkillRepos, want)
 	}
 }
@@ -293,9 +315,9 @@ func TestRunInitSkillRepos_FlagsPreseedDeduped(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"https://github.com/owner/repo"}
-	if len(s.SkillRepos) != 1 || s.SkillRepos[0] != want[0] {
-		t.Errorf("skillRepos = %v, want %v (flag+prompt dupes collapsed)", s.SkillRepos, want)
+	want := []string{defaultSkillRepos[0], "https://github.com/owner/repo"}
+	if len(s.SkillRepos) != 2 || s.SkillRepos[0] != want[0] || s.SkillRepos[1] != want[1] {
+		t.Errorf("skillRepos = %v, want %v (default + flag/prompt dupes collapsed)", s.SkillRepos, want)
 	}
 }
 


### PR DESCRIPTION
## Problem

`cheasee-pi` aborts at startup with:

```
Error: Failed to load extension ".../ponytail/index.js": Cannot find module
'.../DietrichGebert/ponytail/hooks/ponytail-config.js'
```

## Root cause

`runInitSkillRepos` seeded the fixed default repo (ponytail) only via the
settings scaffold template. `Scaffold` **never overwrites** an existing
`cheasee-settings.json`, so a file that predates the `skillRepos` field
never gained ponytail — only user-supplied custom repos (e.g. private-pi,
added via `--skill-repo`) were merged by `recordSkillRepos`.

Since the ponytail extension hard-requires its upstream clone in
`.pi/git/github.com/DietrichGebert/ponytail`, the missing repo breaks
container startup.

## Fix

`runInitSkillRepos` now seeds `defaultSkillRepos` (ponytail)
unconditionally, on top of any already-recorded repos. Custom repos still
merge additively after; `recordSkillRepos` dedupes, so a fresh scaffold
stays byte-identical (no-op when ponytail already present).

Tests updated to the new contract (default always present) plus a
regression test: an existing `skillRepos` holding only a custom repo
(private-pi) now gains ponytail.

## Verification

- `go build ./...` passes
- skill-repo/init unit tests pass, `go vet` clean

(note: `TestUninstallScript_DryRunMatchesGoPaths` fails pre-existing on
main in this environment — unrelated, path/env dependent)