### PR TITLE
fix(cli): wire upstream tracking on bare-clone worktrees

### DIFF
--- a/cmd/cheasee-pi/helpers_test.go
+++ b/cmd/cheasee-pi/helpers_test.go
@@ -432,6 +432,9 @@ type gitCloneCapture struct {
 	cloneArgs    []string
 	worktreeArgs []string
 	symRefArgs   []string
+	configArgs   []string
+	updateRefs   []string
+	upstreamArgs []string
 	symRefOut    string
 	symRefErr    error
 }
@@ -468,6 +471,20 @@ func stubGitClone(t *testing.T, cloneErr, worktreeErr error) *gitCloneCapture {
 			}
 			return &mockCmd{}
 		}
+		// Upstream wiring (wireUpstream): config fetch refspec, local
+		// update-ref of the remote-tracking ref, branch --set-upstream-to.
+		if name == "git" && slices.Contains(arg, "config") && slices.Contains(arg, "remote.origin.fetch") {
+			c.configArgs = append(append([]string(nil), name), arg...)
+			return &mockCmd{}
+		}
+		if name == "git" && slices.Contains(arg, "update-ref") {
+			c.updateRefs = append(append([]string(nil), name), arg...)
+			return &mockCmd{}
+		}
+		if name == "git" && slices.Contains(arg, "--set-upstream-to") {
+			c.upstreamArgs = append(append([]string(nil), name), arg...)
+			return &mockCmd{}
+		}
 		return saved(ctx, name, arg...)
 	})
 	return c
@@ -502,7 +519,9 @@ func gitRemoteFixture(t *testing.T, branch string) string {
 }
 
 // cloneWorktreeLayout builds the init-clone layout (bare clone + default
-// branch probe + worktree add <branch>) exactly as gitCloneWorktree does.
+// branch probe + worktree add <branch>) exactly as gitCloneWorktree does,
+// including the wireUpstream remote-tracking setup (refspec, tracking ref,
+// upstream binding).
 func cloneWorktreeLayout(t *testing.T, src, parent, workdir string) string {
 	t.Helper()
 	bareDir := filepath.Join(parent, ".bare")
@@ -513,5 +532,9 @@ func cloneWorktreeLayout(t *testing.T, src, parent, workdir string) string {
 	}
 	branch := strings.TrimPrefix(strings.TrimSpace(string(out)), "refs/heads/")
 	runGit(t, "--git-dir", bareDir, "worktree", "add", workdir, branch)
+	// Mirror wireUpstream so the layout tracks origin like the real init.
+	runGit(t, "--git-dir", bareDir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+	runGit(t, "--git-dir", bareDir, "update-ref", "refs/remotes/origin/"+branch, branch)
+	runGit(t, "--git-dir", bareDir, "branch", "--set-upstream-to", "origin/"+branch, branch)
 	return bareDir
 }

--- a/cmd/cheasee-pi/init_clone.go
+++ b/cmd/cheasee-pi/init_clone.go
@@ -63,6 +63,13 @@ func canonicalRepoURL(repoURL string) (string, error) {
 // master, …). A bare HEAD that cannot be resolved to a branch name (exotic
 // detached-edge case) falls back to the old `worktree add --detach` bare
 // HEAD checkout.
+//
+// A bare clone carries no remote-tracking setup: `remote.origin.fetch` is
+// unset and the default branch has no upstream, so the worktree branch
+// would silently diverge from origin (editors like Zed then show no
+// ahead/behind, their pull targets nothing, and a push is rejected
+// non-fast-forward). wireUpstream restores the normal-clone tracking so the
+// workspace behaves like a regular checkout from the start.
 func gitCloneWorktree(ctx context.Context, repoURL, workdir string) error {
 	cloneURL, err := canonicalRepoURL(repoURL)
 	if err != nil {
@@ -114,8 +121,9 @@ func gitCloneWorktree(ctx context.Context, repoURL, workdir string) error {
 	default:
 	}
 
+	branch := gitDefaultBranch(ctx, bareDir)
 	wtArgs := []string{"--git-dir", bareDir, "worktree", "add"}
-	if branch := gitDefaultBranch(ctx, bareDir); branch != "" {
+	if branch != "" {
 		wtArgs = append(wtArgs, workdir, branch)
 	} else {
 		wtArgs = append(wtArgs, "--detach", workdir)
@@ -125,7 +133,39 @@ func gitCloneWorktree(ctx context.Context, repoURL, workdir string) error {
 		return fmt.Errorf("worktree add failed: %w\n%s", err, redactToken(string(out)))
 	}
 
+	// Named-branch worktree: give it a remote-tracking ref and an upstream
+	// (stored in the shared .bare config, visible to every worktree). A bare
+	// clone ships without remote.origin.fetch and without a tracking ref, so
+	// without this the branch diverges from origin in silence. Purely local
+	// operations — the objects already came down with the full bare clone.
+	if branch != "" {
+		if err := wireUpstream(ctx, bareDir, branch); err != nil {
+			return err
+		}
+	}
+
 	fmt.Fprintf(os.Stderr, "  ✓ Cloned (bare + worktree) to %s\n", workdir)
+	return nil
+}
+
+// wireUpstream adds the remote-tracking setup a bare clone omits: the
+// remote.origin.fetch refspec (so later `git fetch` in any worktree resolves
+// all branches), the default branch's remote-tracking ref, and the upstream
+// binding branch.<name>.remote/merge. All three write into the shared .bare
+// config, so every worktree on the repo sees the tracking. All local, no
+// network round trip.
+func wireUpstream(ctx context.Context, bareDir, branch string) error {
+	trackingRef := "refs/remotes/origin/" + branch
+	cmds := [][]string{
+		{"--git-dir", bareDir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"},
+		{"--git-dir", bareDir, "update-ref", trackingRef, branch},
+		{"--git-dir", bareDir, "branch", "--set-upstream-to", "origin/" + branch, branch},
+	}
+	for _, args := range cmds {
+		if out, err := runCommandContext(ctx, "git", args...).CombinedOutput(); err != nil {
+			return fmt.Errorf("set upstream tracking for %s: %w\n%s", branch, err, redactToken(string(out)))
+		}
+	}
 	return nil
 }
 

--- a/cmd/cheasee-pi/init_clone_test.go
+++ b/cmd/cheasee-pi/init_clone_test.go
@@ -155,6 +155,20 @@ func TestGitCloneWorktree_exactArgv(t *testing.T) {
 	if !slices.Equal(c.worktreeArgs, wantWT) {
 		t.Errorf("worktree argv = %v, want %v", c.worktreeArgs, wantWT)
 	}
+	// Upstream wiring (wireUpstream) so the default branch tracks origin
+	// instead of silently diverging (editor pull/push must have a target).
+	wantCfg := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"}
+	if !slices.Equal(c.configArgs, wantCfg) {
+		t.Errorf("config argparse = %v, want %v", c.configArgs, wantCfg)
+	}
+	wantUR := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "update-ref", "refs/remotes/origin/main", "main"}
+	if !slices.Equal(c.updateRefs, wantUR) {
+		t.Errorf("update-ref argv = %v, want %v", c.updateRefs, wantUR)
+	}
+	wantUS := []string{"git", "--git-dir", filepath.Join(parent, ".bare"), "branch", "--set-upstream-to", "origin/main", "main"}
+	if !slices.Equal(c.upstreamArgs, wantUS) {
+		t.Errorf("set-upstream argv = %v, want %v", c.upstreamArgs, wantUS)
+	}
 }
 
 func TestGitCloneWorktree_masterDefaultAttached(t *testing.T) {
@@ -477,6 +491,32 @@ func TestGitCloneWorktree_realGitMasterDefault(t *testing.T) {
 	}
 	if !strings.Contains(string(out), workdir) {
 		t.Errorf("worktree list must contain the worktree %s:\n%s", workdir, out)
+	}
+}
+
+func TestGitCloneWorktree_realGitTracksOrigin(t *testing.T) {
+	// Acceptance: after the CLI layout, the default-branch worktree tracks
+	// origin (upstream resolves, status shows ahead/behind) — a bare clone
+	// gives none of that on its own, which previously left editor pull/push
+	// targetless and let the branch diverge in silence.
+	src := gitRemoteFixture(t, "main")
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "main")
+	cloneWorktreeLayout(t, src, parent, workdir)
+
+	out, err := exec.Command("git", "-C", workdir, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}").CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse @{u}: %v\n%s", err, out)
+	}
+	if strings.TrimSpace(string(out)) != "origin/main" {
+		t.Errorf("worktree must track origin/main, got %q", strings.TrimSpace(string(out)))
+	}
+	out, err = exec.Command("git", "-C", workdir, "status", "-sb").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git status: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "...origin/main") {
+		t.Errorf("status must show the tracking relationship, got: %q", strings.TrimSpace(string(out)))
 	}
 }
 

--- a/cmd/cheasee-pi/init_split_test.go
+++ b/cmd/cheasee-pi/init_split_test.go
@@ -47,6 +47,7 @@ var wantInitDecls = map[string]string{
 	"func:gitDefaultBranch":  "init_clone.go",
 	"func:canonicalRepoURL":  "init_clone.go",
 	"func:removeInitResidue": "init_clone.go",
+	"func:wireUpstream":     "init_clone.go",
 
 	"func:runInitAuth":    "init_auth.go",
 	"func:runInitAPIKeys": "init_auth.go",


### PR DESCRIPTION
Fixes the fresh-setup push failure: bare-clone+worktree-add leaves no upstream tracking, so the workspace branch diverges from origin silently and pushes are rejected non-fast-forward.

Adds wireUpstream after worktree add (3 local ops in shared .bare config): set remote.origin.fetch refspec, update-ref the default branch's remote-tracking ref, bind upstream. Editors (Zed) get a pull target and status shows ahead/behind.

Tests: extended stubGitClone + cloneWorktreeLayout; new TestGitCloneWorktree_realGitTracksOrigin asserts @{u}=origin/main and status shows tracking. go vet clean.