### PR TITLE
fix: request 'project' scope in OAuth device flow

### DIFF
--- a/cmd/cheasee-pi/init_auth.go
+++ b/cmd/cheasee-pi/init_auth.go
@@ -21,7 +21,7 @@ func runInitAuth(ctx context.Context, authenticator Authenticator) (token, user 
 	fmt.Fprintf(os.Stderr, "   ⚠ SECURITY: Only enter the code at https://github.com/login/device\n")
 	fmt.Fprintf(os.Stderr, "   Do NOT search for this URL — type it directly.\n\n")
 
-	code, err := authenticator.RequestCode(ctx, []string{"repo", "read:org"})
+	code, err := authenticator.RequestCode(ctx, []string{"repo", "read:org", "project"})
 	if err != nil {
 		return "", "", fmt.Errorf("device code request failed: %w", err)
 	}

--- a/cmd/cheasee-pi/init_auth_test.go
+++ b/cmd/cheasee-pi/init_auth_test.go
@@ -30,6 +30,31 @@ func TestRunInitAuth_Success(t *testing.T) {
 	}
 }
 
+func TestRunInitAuth_RequestsProjectScope(t *testing.T) {
+	var got []string
+	auth := &mockAuthenticator{
+		requestCodeFunc: func(_ context.Context, scopes []string) (*device.CodeResponse, error) {
+			got = scopes
+			return &device.CodeResponse{UserCode: "ABCD-1234", VerificationURI: "https://github.com/login/device"}, nil
+		},
+	}
+	if _, _, err := runInitAuth(context.Background(), auth); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"repo", "read:org", "project"} {
+		found := false
+		for _, s := range got {
+			if s == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("requested scopes %v missing %q — supervisor project-board updates need it", got, want)
+		}
+	}
+}
+
 func TestRunInitAuth_UserLookupFailsOpen(t *testing.T) {
 	// The GitHub login resolution is fail-open: OAuth already succeeded, so a
 	// user lookup failure warns on stderr and yields an empty user — the


### PR DESCRIPTION
## Problem

The supervisor pipeline fails project-board status transitions:

```
Your token has not been granted the required scopes to execute this query.
The 'updateProjectV2ItemFieldValue' field requires one of the following
scopes: ['project'], but your token has only been granted the:
['gist', 'read:org', 'read:project', 'repo'] scopes.
```

Two causes (see discussion on #1544):

1. **Code bug (fixed here):** `cmd/cheasee-pi/init_auth.go` requested only `repo` and `read:org` in the device flow, so tokens minted by `cheasee-pi init`/`--reauth` never carry the `project` scope the supervisor needs for `updateProjectV2ItemFieldValue`.
2. **Environment (user action):** the supervisor shells out to `gh`, which uses its own token from `~/.config/gh` — reinstalling cheasee-pi does not refresh it.

## Fix

Add `"project"` to the `RequestCode` scope slice. `runReauth` delegates to `runInitAuth`, so both flows are covered. One test added asserting `repo`, `read:org`, `project` are all requested.

## For existing setups

```bash
gh auth refresh -h github.com -s project
```

## Verification

- `go test ./cmd/cheasee-pi/ -run TestRunInitAuth -count=1 -v` — all pass incl. new `TestRunInitAuth_RequestsProjectScope`
- Full package test suite passes