### PR TITLE
fix(up): prefer auth.json github_token over host GH_TOKEN export

### DIFF
--- a/cmd/cheasee-pi/cache_test.go
+++ b/cmd/cheasee-pi/cache_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -98,5 +99,21 @@ func TestCacheDir_neverInsideUserRepo(t *testing.T) {
 	}
 	if !strings.HasPrefix(dir, xdg) {
 		t.Errorf("cache dir %q must live under the user cache dir %q", dir, xdg)
+	}
+}
+
+// TestSmokeTestCLIVersionMatchesCliVersionKey guards the DinD smoke test's
+// hardcoded CLI_VERSION against cliVersionKey drift. The smoke computes the
+// compose cache dir from it, so a stale value only fails in CI as a cryptic
+// "docker-compose.yml: no such file or directory" (v0.55.3 bump missed it).
+func TestSmokeTestCLIVersionMatchesCliVersionKey(t *testing.T) {
+	path := filepath.Join("..", "..", "docker", "test", "cli-install-smoke.test.mts")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read smoke test %s: %v", path, err)
+	}
+	want := fmt.Sprintf(`CLI_VERSION = "%s"`, cliVersionKey)
+	if !strings.Contains(string(data), want) {
+		t.Errorf("smoke test must pin CLI_VERSION to %q to match cliVersionKey (cache dir is version-keyed)", cliVersionKey)
 	}
 }

--- a/cmd/cheasee-pi/embedded/docker/entrypoint.sh
+++ b/cmd/cheasee-pi/embedded/docker/entrypoint.sh
@@ -260,16 +260,17 @@ gosu agentuser git config --global --add url."https://github.com/".insteadOf "ss
 # Use gh as credential helper for HTTPS pushes
 gosu agentuser git config --global credential.helper "!/usr/bin/gh auth git-credential" 2>/dev/null || true
 
-# The host authenticates gh via the OS keyring — and only ~/.config/gh
-# (hosts.yml/config.yml) is bind-mounted, the keyring is NOT, so a fresh
-# container starts with NO gh token and every private-repo git operation
-# (skill-repo clones above all) dies with "could not read Username".
-# cheasee-pi auth persists the GitHub token in auth.json (bind-mounted), so
-# feed it to gh once. Skip when gh already works — never clobber a token the
-# user set up interactively inside the container.
+# cheasee-pi auth persists the GitHub token in auth.json (bind-mounted) and
+# that file is the single source of truth for the container's GitHub
+# credential: init/--reauth mint it with the scopes the supervisor needs
+# (repo, read:org, project). The bind-mounted ~/.config/gh may hold an older
+# token minted before the project scope existed, so import auth.json's token
+# into gh whenever gh's current token differs — not just when gh has none.
+# gating on gh auth status would keep the stale token forever.
 if [ -f /home/agentuser/.config/cheasee-pi/auth.json ]; then
     token=$(jq -r '.github_token // empty' /home/agentuser/.config/cheasee-pi/auth.json 2>/dev/null || true)
-    if [ -n "$token" ] && ! gosu agentuser gh auth status >/dev/null 2>&1; then
+    current=$(gosu agentuser gh auth token 2>/dev/null || true)
+    if [ -n "$token" ] && [ "$token" != "$current" ]; then
         echo "$token" | gosu agentuser gh auth login --with-token 2>/dev/null || true
     fi
 fi

--- a/cmd/cheasee-pi/entrypoint_test.go
+++ b/cmd/cheasee-pi/entrypoint_test.go
@@ -236,12 +236,12 @@ func TestEntrypoint_DefinesRepointFile(t *testing.T) {
 func TestEntrypoint_RepointFileContract(t *testing.T) {
 	content := readEntrypoint(t)
 	for _, want := range []string{
-		"[ -L \"$agent_file\" ]",                 // re-link only under a [ -L ] guard
-		"readlink \"$agent_file\"",              // readlink no-op detection
-		"= \"$repo_file\"",                      // skip when already at the repo file
-		"ln -sfn \"$repo_file\" \"$agent_file\"", // re-point with ln -sfn
+		"[ -L \"$agent_file\" ]",                       // re-link only under a [ -L ] guard
+		"readlink \"$agent_file\"",                     // readlink no-op detection
+		"= \"$repo_file\"",                             // skip when already at the repo file
+		"ln -sfn \"$repo_file\" \"$agent_file\"",       // re-point with ln -sfn
 		"chown -h agentuser:agentuser \"$agent_file\"", // chown -h the link
-		"[ -e \"$repo_file\" ] || return 0",      // missing repo file → baked link stays
+		"[ -e \"$repo_file\" ] || return 0",            // missing repo file → baked link stays
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("re_point_file must honor the re_point contract (%q)", want)
@@ -288,10 +288,10 @@ func TestCommittedSettings_PrivatePathsPointAtOpt(t *testing.T) {
 func TestCommittedSettings_TrackedPathsRepoLocal(t *testing.T) {
 	content := readCommittedSettings(t)
 	for _, want := range []string{
-		"\"rtk\"",          // extensions: tracked local extension kept
-		"\".pi/skills\"",   // skills: tracked local dir kept
-		"\"cheasee-pi\"",   // theme unchanged
-		"ponytail",         // packages unchanged
+		"\"rtk\"",        // extensions: tracked local extension kept
+		"\".pi/skills\"", // skills: tracked local dir kept
+		"\"cheasee-pi\"", // theme unchanged
+		"ponytail",       // packages unchanged
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("committed settings must keep %q", want)
@@ -446,5 +446,42 @@ func TestEntrypoint_InstallSkillReposMissingSettingsNoop(t *testing.T) {
 func TestEntrypoint_SyntaxValidBash(t *testing.T) {
 	if err := exec.Command("bash", "-n", entrypointPath()).Run(); err != nil {
 		t.Errorf("entrypoint.sh must pass bash -n: %v", err)
+	}
+}
+
+// ──────────────────────────────────────────────
+// Phase 5b: container gh credential sync (single source of truth)
+// ──────────────────────────────────────────────
+
+func TestEntrypoint_GhTokenSyncReadsAuthJSON(t *testing.T) {
+	content := readEntrypoint(t)
+	for _, want := range []string{
+		"/home/agentuser/.config/cheasee-pi/auth.json",
+		"jq -r '.github_token // empty'",
+		"gh auth token",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("gh token sync must read auth.json and compare against gh's current token (%q)", want)
+		}
+	}
+}
+
+func TestEntrypoint_GhTokenSyncImportsOnMismatch(t *testing.T) {
+	content := readEntrypoint(t)
+	if !strings.Contains(content, `[ "$token" != "$current" ]`) {
+		t.Error("gh token sync must import auth.json's token when gh's current token differs (not only when gh has no token)")
+	}
+	if !strings.Contains(content, "gh auth login --with-token") {
+		t.Error("gh token sync must import via gh auth login --with-token")
+	}
+	if strings.Contains(content, "! gosu agentuser gh auth status") {
+		t.Error("gh token sync must not gate on gh auth status (a bind-mounted stale token would always pass it)")
+	}
+}
+
+func TestEntrypoint_GhTokenSyncNoopWhenAuthMissing(t *testing.T) {
+	content := readEntrypoint(t)
+	if !strings.Contains(content, `[ -n "$token" ]`) {
+		t.Error("gh token sync must no-op when auth.json has no github_token")
 	}
 }

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -464,11 +464,21 @@ func buildEnvFlags(ctx context.Context) (map[string]string, error) {
 		}
 	}
 
-	// 4. Extract gh token if not already in env
-	if os.Getenv("GH_TOKEN") == "" {
-		if token, err := extractGHToken(); err == nil && token != "" {
-			envMap["GH_TOKEN"] = token
-		}
+	// 4. GitHub token. The container's GH_TOKEN must be the credential
+	// cheasee-pi init/--reauth minted into auth.json — its scope list
+	// (repo, read:org, project) is what the supervisor needs for the
+	// project-board status moves. A GH_TOKEN exported in the host shell or
+	// gh's own credential (gh auth token) may predate the project scope and
+	// silently strip that permission, so auth.json wins when present; fall
+	// back to the process env, then gh's credential store.
+	// ponytail: single-precedence if-chain; revisit if multiple GitHub
+	// identities per host become a real use case.
+	if auth, err := repo.Load(ctx); err == nil && auth.GitHubToken != "" {
+		envMap["GH_TOKEN"] = auth.GitHubToken
+	} else if val := os.Getenv("GH_TOKEN"); val != "" {
+		envMap["GH_TOKEN"] = val
+	} else if token, err := extractGHToken(); err == nil && token != "" {
+		envMap["GH_TOKEN"] = token
 	}
 
 	return envMap, nil

--- a/cmd/cheasee-pi/up_test.go
+++ b/cmd/cheasee-pi/up_test.go
@@ -610,6 +610,43 @@ func TestBuildEnvFlags_passthroughEnvVars(t *testing.T) {
 	}
 }
 
+func TestBuildEnvFlags_authGitHubTokenWinsOverProcessEnv(t *testing.T) {
+	pinPassthroughEnv(t)
+	cfg := &fileRepository{}
+	if err := cfg.UpdateGitHubAuth(context.Background(), "tkn-from-auth", "octocat", ""); err != nil {
+		t.Fatalf("seed github_token: %v", err)
+	}
+	t.Setenv("GH_TOKEN", "stale-process-token")
+
+	env := buildEnvFlagsOrFatal(t)
+	if got := env["GH_TOKEN"]; got != "tkn-from-auth" {
+		t.Errorf("auth.json github_token should win over process env GH_TOKEN, got %q", got)
+	}
+}
+
+func TestBuildEnvFlags_authGitHubTokenUsedWithoutProcessEnv(t *testing.T) {
+	pinPassthroughEnv(t)
+	cfg := &fileRepository{}
+	if err := cfg.UpdateGitHubAuth(context.Background(), "tkn-from-auth", "octocat", ""); err != nil {
+		t.Fatalf("seed github_token: %v", err)
+	}
+
+	env := buildEnvFlagsOrFatal(t)
+	if got := env["GH_TOKEN"]; got != "tkn-from-auth" {
+		t.Errorf("expected auth.json github_token, got %q", got)
+	}
+}
+
+func TestBuildEnvFlags_noAuthTokenFallsBackToProcessEnv(t *testing.T) {
+	pinPassthroughEnv(t)
+	t.Setenv("GH_TOKEN", "process-token")
+
+	env := buildEnvFlagsOrFatal(t)
+	if got := env["GH_TOKEN"]; got != "process-token" {
+		t.Errorf("expected process GH_TOKEN fallback when auth.json has no github_token, got %q", got)
+	}
+}
+
 func TestBuildEnvFlags_authWinsOverProcessEnv(t *testing.T) {
 	pinPassthroughEnv(t)
 	seedAuth(t, map[string]string{"openai": "from-auth"})

--- a/docker/test/cli-install-smoke.test.mts
+++ b/docker/test/cli-install-smoke.test.mts
@@ -88,7 +88,7 @@ const POLL_INTERVAL_MS = 5_000;
  * The cache dir is version-keyed so an upgraded binary never mixes stale
  * compose/Dockerfile content with new embedded assets.
  */
-const CLI_VERSION = "0.55.2";
+const CLI_VERSION = "0.55.3";
 
 /**
  * Compute the CLI cache dir (compose/Dockerfile live there,


### PR DESCRIPTION
## Root cause: three token stores, one init, silent divergence

`cheasee-pi init`/`--reauth` mints the only scope-correct token (`repo, read:org, project`) and writes it to `~/.config/cheasee-pi/auth.json` (bind-mounted into the container). Every downstream consumer, however, read a different, unmanaged credential:

| Consumer | Read from | Result |
|---|---|---|
| Container `GH_TOKEN` (`cheasee-pi up` → `buildEnvFlags`) | host process env export, else `gh auth token` | stale host export / gh credential wins; **auth.json never consulted** |
| Container `gh` (git pushes, supervisor `hosts.yml` fallback) | entrypoint imports auth.json → gh | guarded by `! gh auth status`; hosts.yml is bind-mounted so gh always "works" → **stale token kept forever** |

So an init-minted correct token rotted in auth.json while stale exports and gh's own store kept shadowing it — "correct at init, wrong afterwards".

## Fix: one source of truth — auth.json

1. **`up.go` `buildEnvFlags`** — container `GH_TOKEN` precedence becomes:
   ```
   auth.json github_token  >  process env GH_TOKEN  >  gh auth token
   ```
   auth.json wins whenever present, so a stale host `GH_TOKEN` export can no longer shadow the init token. Tests: `TestBuildEnvFlags_authGitHubTokenWinsOverProcessEnv`, `TestBuildEnvFlags_authGitHubTokenUsedWithoutProcessEnv`, `TestBuildEnvFlags_noAuthTokenFallsBackToProcessEnv` (+ all 18 existing `TestBuildEnvFlags_*` green).

2. **`entrypoint.sh`** — import auth.json's token into container gh whenever gh's current token **differs** from it (tokens compared via `gh auth token`), replacing the `! gh auth status` gate that never fired on a bind-mounted stale hosts.yml. Also heals the supervisor's `hosts.yml` fallback and git credential helper for the raw `docker compose up` path (no `cheasee-pi up` env injection). Contract tests: `TestEntrypoint_GhTokenSync*`.

Full suite + vet + gofmt clean (only pre-existing dirty files untouched).

## Reporter action (still required, separate from this fix)

The token must carry `project` — run `cheasee-pi init --reauth` with a **v0.55.3+** binary (pre-fix binaries mint `read:org, repo` only), then recreate the container. Verify:

```bash
jq -r '.github_token // empty' ~/.config/cheasee-pi/auth.json | GH_TOKEN="$(cat)" gh api -i /user | grep -i x-oauth-scopes
# must show: read:org, repo, project
```