### PR TITLE
fix(install): single canonical binary location

### DIFF
--- a/cmd/cheasee-pi/installation_doc_test.go
+++ b/cmd/cheasee-pi/installation_doc_test.go
@@ -13,18 +13,22 @@ func docPath() string {
 	return filepath.Join("..", "..", "docs", "installation.md")
 }
 
-// TestInstallationDoc_VersionMatchesRootCmd verifies that the VERSION
-// placeholder in docs/installation.md matches rootCmd.Version.
-func TestInstallationDoc_VersionMatchesRootCmd(t *testing.T) {
+// TestInstallationDoc_OneLineInstaller verifies the install flow is the
+// version-agnostic one-liner — the doc must NOT hardcode a version (a pinned
+// VERSION="x.y.z" in docs goes stale and silently installs an old release;
+// the one-liner always fetches latest).
+func TestInstallationDoc_OneLineInstaller(t *testing.T) {
 	data, err := os.ReadFile(docPath())
 	if err != nil {
 		t.Fatalf("reading docs/installation.md: %v", err)
 	}
 	content := string(data)
 
-	// Find the VERSION assignment line in the Go CLI path section
-	if !strings.Contains(content, `VERSION="`+rootCmd.Version+`"`) {
-		t.Errorf("docs/installation.md should contain VERSION=%q matching rootCmd.Version (%q)", rootCmd.Version, rootCmd.Version)
+	if !strings.Contains(content, "scripts/install.sh") {
+		t.Error("docs/installation.md should document the scripts/install.sh one-liner as the canonical install path")
+	}
+	if strings.Contains(content, `VERSION="`) {
+		t.Error("docs/installation.md must not hardcode VERSION=\"…\" — the one-liner installs the latest release; a pinned version goes stale")
 	}
 }
 
@@ -42,25 +46,28 @@ func TestInstallationDoc_NoIgnoreMissing(t *testing.T) {
 	}
 }
 
-// TestInstallationDoc_DownloadURLPattern verifies the doc contains a download
-// URL pattern matching GoReleaser archive naming for any supported platform.
-// linux/darwin use .tar.gz, windows uses .zip.
-func TestInstallationDoc_DownloadURLPattern(t *testing.T) {
-	data, err := os.ReadFile(docPath())
+// installScriptPath is the path to scripts/install.sh relative to this
+// package dir (tests run from cmd/cheasee-pi/).
+func installScriptPath() string {
+	return filepath.Join("..", "..", "scripts", "install.sh")
+}
+
+// TestInstallScript_DownloadURLPattern verifies the installer downloads
+// GoReleaser archives using the naming pattern for every supported platform
+// (linux/darwin .tar.gz, windows .zip).
+func TestInstallScript_DownloadURLPattern(t *testing.T) {
+	script := installScriptPath()
+	data, err := os.ReadFile(script)
 	if err != nil {
-		t.Fatalf("reading docs/installation.md: %v", err)
+		t.Fatalf("reading scripts/install.sh: %v", err)
 	}
 	content := string(data)
 
-	if !strings.Contains(content, ".tar.gz") && !strings.Contains(content, ".zip") {
-		t.Error("doc must reference .tar.gz (linux/mac) or .zip (windows) archive files")
+	if !strings.Contains(content, "cheasee-pi_${VERSION}_${OS}_${ARCH}") {
+		t.Error("install.sh must build the GoReleaser asset name: cheasee-pi_${VERSION}_${OS}_${ARCH}.${SUFFIX}")
 	}
-	hasTarball := strings.Contains(content, "cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz")
-	hasZip := strings.Contains(content, "cheasee-pi_${VERSION}_${OS}_${ARCH}.zip") ||
-		strings.Contains(content, "cheasee-pi_${VERSION}_windows_${ARCH}.zip") ||
-		strings.Contains(content, "_windows_${ARCH}.zip")
-	if !hasTarball && !hasZip {
-		t.Error("doc curl URL must use GoReleaser naming pattern: cheasee-pi_${VERSION}_${OS}_${ARCH}.(tar.gz|zip)")
+	if !strings.Contains(content, "tar.gz") || !strings.Contains(content, "zip") {
+		t.Error("install.sh must map linux/darwin → SUFFIX=tar.gz and windows → SUFFIX=zip")
 	}
 }
 

--- a/cmd/cheasee-pi/uninstall.go
+++ b/cmd/cheasee-pi/uninstall.go
@@ -19,7 +19,8 @@ var uninstallCmd = &cobra.Command{
 The uninstall command removes:
   1. Cache dir (compose/Dockerfile under the user cache dir)
   2. Auth config (~/.config/cheasee-pi/auth.json)
-  3. cheasee-pi binary (the running executable)
+  3. cheasee-pi binaries (the running executable plus every canonical
+     install location: ~/.local/bin and /usr/local/bin)
 
 Workspace files (.pi/, .git/, source checkouts) are never touched.
 Use --force to skip the confirmation prompt.`,
@@ -43,18 +44,12 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 	// CLI-managed assets live in the version-keyed cache dir, never the repo.
 	cacheDir, _ := CacheDir()
 
-	// Detect binary path — skip if running from Go build cache
-	binaryPath, _ := os.Executable()
-	if binaryPath != "" {
-		// Resolve symlinks to get real path
-		if resolved, err := filepath.EvalSymlinks(binaryPath); err == nil {
-			binaryPath = resolved
-		}
-		// Skip removal if binary is in a Go build cache or temp directory
-		if strings.Contains(binaryPath, "/go-build") || strings.Contains(binaryPath, "/tmp/go") {
-			binaryPath = ""
-		}
-	}
+	// Binary targets: the running executable plus every canonical install
+	// location (deduped, existing files). Removing only the executable
+	// stranded sibling copies — PATH order or sudo's secure_path can make
+	// the running copy differ from the one the next shell call resolves,
+	// leaving a stale binary shadowing the fresh install.
+	binaries := canonicalBinaryPaths()
 
 	// Show summary
 	fmt.Fprintf(os.Stderr, "The following will be removed:\n")
@@ -71,9 +66,9 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Binary
-	if binaryPath != "" {
-		fmt.Fprintf(os.Stderr, "  %s — will remove\n", binaryPath)
+	// Binaries
+	for _, p := range binaries {
+		fmt.Fprintf(os.Stderr, "  %s — will remove\n", p)
 	}
 
 	if !uninstallForce {
@@ -107,22 +102,54 @@ func runUninstallE(cmd *cobra.Command, _ []string) error {
 		os.Remove(filepath.Dir(authPath)) // best-effort
 	}
 
-	// Remove binary (last — running process keeps the file handle)
-	if binaryPath != "" {
-		binaryDir := filepath.Dir(binaryPath)
+	// Remove binaries (last — running process keeps the file handle)
+	for _, p := range binaries {
+		binaryDir := filepath.Dir(p)
 		// Check if parent dir is writable — if not, suggest sudo
 		if f, err := os.Stat(binaryDir); err == nil && f.Mode().Perm()&0o222 == 0 {
 			fmt.Fprintf(os.Stderr, "  ⚠ cannot remove binary — %s is not writable by you\n", binaryDir)
-			fmt.Fprintf(os.Stderr, "    Remove it manually: sudo rm %s\n", binaryPath)
-		} else if err := os.Remove(binaryPath); err != nil {
-			fmt.Fprintf(os.Stderr, "  ⚠ failed to remove binary at %s\n", binaryPath)
+			fmt.Fprintf(os.Stderr, "    Remove it manually: sudo rm %s\n", p)
+		} else if err := os.Remove(p); err != nil {
+			fmt.Fprintf(os.Stderr, "  ⚠ failed to remove binary at %s\n", p)
 			fmt.Fprintf(os.Stderr, "    Cause: %v\n", err)
-			fmt.Fprintf(os.Stderr, "    Remove it manually: sudo rm %s\n", binaryPath)
+			fmt.Fprintf(os.Stderr, "    Remove it manually: sudo rm %s\n", p)
 		} else {
-			fmt.Fprintf(os.Stderr, "  ✓ Removed binary\n")
+			fmt.Fprintf(os.Stderr, "  ✓ Removed binary %s\n", p)
 		}
 	}
 
 	fmt.Fprintf(os.Stderr, "\n✅ Uninstall complete.\n")
 	return nil
+}
+
+// canonicalBinaryPaths returns the binary targets uninstall must remove: the
+// running executable (symlink-resolved; Go build-cache/tmp runs skipped)
+// plus the canonical install locations ~/.local/bin and /usr/local/bin.
+// Deduped; only existing files are listed so the summary stays quiet about
+// absent paths.
+func canonicalBinaryPaths() []string {
+	add := func(seen map[string]bool, out []string, p string) []string {
+		if p == "" || seen[p] {
+			return out
+		}
+		if _, err := os.Stat(p); err != nil {
+			return out
+		}
+		seen[p] = true
+		return append(out, p)
+	}
+	seen := map[string]bool{}
+	out := []string{}
+	if exe, err := os.Executable(); err == nil {
+		if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+			exe = resolved
+		}
+		if !strings.Contains(exe, "/go-build") && !strings.Contains(exe, "/tmp/go") {
+			out = add(seen, out, exe)
+		}
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		out = add(seen, out, filepath.Join(home, ".local", "bin", "cheasee-pi"))
+	}
+	return add(seen, out, "/usr/local/bin/cheasee-pi")
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -137,8 +137,8 @@ Remove cheasee-pi configuration and CLI-managed assets.
 
 | | |
 |---|---|
-| **Does** | Removes the version-keyed cache dir (compose/Dockerfile), `~/.config/cheasee-pi/auth.json`, and the running binary. Workspace files (`.pi/`, `.git/`, source checkouts) are never touched. |
-| **Checks** | Shows a summary and asks for confirmation (`--force` skips). Skips binary removal when running from a Go build cache; warns when the binary's directory is not writable. |
+| **Does** | Removes the version-keyed cache dir (compose/Dockerfile), `~/.config/cheasee-pi/auth.json`, and every cheasee-pi binary (the running executable plus the canonical install locations `~/.local/bin` and `/usr/local/bin`, deduped). Workspace files (`.pi/`, `.git/`, source checkouts) are never touched. |
+| **Checks** | Shows a summary and asks for confirmation (`--force` skips). Skips build-cache/tmp binaries; warns when a binary's directory is not writable. |
 | **Inputs** | Flags: `--force`. |
 
 ## Environment variables

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -22,22 +22,19 @@ nav_order: 2
 ### Linux / macOS
 
 ```bash
-# Set version (check latest at https://github.com/SchneiderDaniel/cheasee-pi/releases)
-VERSION="0.55.3"
+curl -fsL https://raw.githubusercontent.com/SchneiderDaniel/cheasee-pi/main/scripts/install.sh | bash
+```
 
-# Detect platform
-OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-ARCH=$(uname -m)
-case "$ARCH" in x86_64) ARCH="amd64" ;; aarch64|arm64) ARCH="arm64" ;; esac
+Installs to `~/.local/bin` (the single canonical location — no sudo needed).
+If `~/.local/bin` is not on your PATH, add it to your shell config:
 
-# Download, extract, install
-curl -fsL "https://github.com/SchneiderDaniel/cheasee-pi/releases/download/v${VERSION}/cheasee-pi_${VERSION}_${OS}_${ARCH}.tar.gz" \
-  | tar xz && sudo mv cheasee-pi /usr/local/bin/
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 ```
 
 {:.note-title}
 > macOS
-> Gatekeeper may block the unsigned binary. Run `xattr -d com.apple.quarantine /usr/local/bin/cheasee-pi` or Ctrl-click → Open in Finder.
+> Gatekeeper may block the unsigned binary. Run `xattr -d com.apple.quarantine ~/.local/bin/cheasee-pi` or Ctrl-click → Open in Finder.
 
 ### Windows
 
@@ -281,7 +278,9 @@ Add `--force` to skip the confirmation prompt, `--dry-run` to preview what would
 
 ### CLI command
 
-`cheasee-pi uninstall` removes the cache dir, auth config, and the running binary:
+`cheasee-pi uninstall` removes the cache dir, auth config, and every
+cheasee-pi binary (the running executable plus the canonical install
+locations `~/.local/bin` and `/usr/local/bin`):
 
 ```bash
 cheasee-pi uninstall

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -55,18 +55,21 @@ else
   tar -xzf "$TMPDIR/$ASSET" -C "$TMPDIR"
 fi
 
-# Prefer /usr/local/bin (sudo if needed), fall back to ~/.local/bin
-if [ -w /usr/local/bin ]; then
-  DEST="/usr/local/bin"
-  mv "$TMPDIR/cheasee-pi" "$DEST/"
-elif command -v sudo &>/dev/null; then
-  DEST="/usr/local/bin"
-  sudo mv "$TMPDIR/cheasee-pi" "$DEST/"
-else
-  DEST="${HOME}/.local/bin"
-  mkdir -p "$DEST"
-  mv "$TMPDIR/cheasee-pi" "$DEST/"
-  echo "  Installed to $DEST — ensure it's on your PATH"
+# Single canonical location: ~/.local/bin — no sudo, no /usr/local/bin
+# branch. Two possible homes caused stale-copy shadowing: an install or
+# uninstall run from one PATH position left the sibling binary behind, and
+# the leftover copy won every bare `cheasee-pi` call (e.g. a pre-v0.55.3
+# binary shadowing a fresh install). A legacy /usr/local/bin copy is swept
+# best-effort, keeping the invariant: at most one cheasee-pi binary on PATH.
+DEST="${HOME}/.local/bin"
+mkdir -p "$DEST"
+mv "$TMPDIR/cheasee-pi" "$DEST/"
+if [ -e /usr/local/bin/cheasee-pi ]; then
+  if rm -f /usr/local/bin/cheasee-pi 2>/dev/null; then
+    echo "  ✓ Removed legacy copy /usr/local/bin/cheasee-pi (single-location policy)"
+  else
+    echo "  ⚠ Legacy copy still at /usr/local/bin/cheasee-pi — remove manually: sudo rm /usr/local/bin/cheasee-pi" >&2
+  fi
 fi
 
 chmod +x "$DEST/cheasee-pi"


### PR DESCRIPTION
## Problem

Two possible install locations (`/usr/local/bin`, `~/.local/bin`) + two
uninstallers with different scope stranded stale binaries:

- `scripts/install.sh` picked a destination conditionally (writable check /
  sudo presence) → installs landed in different places over time.
- `cheasee-pi uninstall` removed only `os.Executable()` → under
  `sudo` (secure_path → /usr/local/bin), a sibling copy at
  `~/.local/bin` survived and — being earlier in PATH — kept
  shadowing the fresh install. A pre-v0.55.3 leftover running the
  reauth flow is exactly how the token lost its `project` scope.
- `docs/installation.md` hardcoded `VERSION="0.55.3"` — goes stale and
  silently installs an old release.

## Change

- **install.sh**: always installs to `~/.local/bin` (no sudo, user-writable,
  no root-owned binary). Best-effort sweep of a legacy
  `/usr/local/bin/cheasee-pi` with a manual `sudo rm` hint when not
  writable. Invariant: at most one cheasee-pi binary on PATH after install.
- **`cheasee-pi uninstall`**: removes the running executable PLUS the two
  canonical install locations (deduped, existing only). No uninstaller ×
  sudo combination can strand a copy again.
- **Docs**: install guide uses the version-agnostic one-liner; uninstall
  docs match the widened scope.
- **Tests**: doc version-pin test repointed at `scripts/install.sh`
  (asserts GoReleaser asset naming) instead of a hardcoded doc version.

## Notes

- `TestUninstallScript_DryRunMatchesGoPaths` + `test/uninstall-script.test.sh`
  fail on THIS machine with a real `/usr/local/bin/cheasee-pi` present
  (uninstall can't elevate without password sudo) — reproducible on main
  before this change; clean CI runners pass.