### PR TITLE
feat(#1547): tsc-checkpoint: consolidate direction-label mapping, stop test re-implementing prod logic

### DIFF
--- a/.pi/extensions/tsc-checkpoint/format.ts
+++ b/.pi/extensions/tsc-checkpoint/format.ts
@@ -8,6 +8,28 @@
 import type { TscDiagnostic, DiagnosticTrend } from "./types.ts";
 
 /**
+ * Direction → label mapping, shared by TUI and JSON/structured output.
+ * Keyed on the literal direction union so a new direction value fails
+ * compilation until a label is added here.
+ */
+const DIRECTION_LABELS: Record<DiagnosticTrend["direction"], { tui: string; json: string }> = {
+	regressed: { tui: "⚠️ regression", json: "regressed ↑" },
+	improved: { tui: "✓ improved", json: "improved ↓" },
+	stable: { tui: "→ stable", json: "stable →" },
+};
+
+/**
+ * Resolve the display label for a trend direction in a given output style.
+ * Call sites select the style ("tui" for markdown, "json" for structured).
+ */
+export function directionLabel(
+	direction: DiagnosticTrend["direction"],
+	style: "tui" | "json",
+): string {
+	return DIRECTION_LABELS[direction][style];
+}
+
+/**
  * Format diagnostics as grouped, sorted, developer-readable output.
  *
  * Groups diagnostics by file, sorts files alphabetically, sorts
@@ -66,13 +88,7 @@ export function formatDiagnosticsJson(
 	} else {
 		const baseSummary = `${diagnostics.length} type error(s) found`;
 		if (trend) {
-			const directionLabel =
-				trend.direction === "regressed"
-					? "regressed ↑"
-					: trend.direction === "improved"
-						? "improved ↓"
-						: "stable →";
-			summary = `${baseSummary} (${directionLabel} ${trend.delta}, was ${trend.previous})`;
+			summary = `${baseSummary} (${directionLabel(trend.direction, "json")} ${trend.delta}, was ${trend.previous})`;
 		} else {
 			summary = baseSummary;
 		}

--- a/.pi/extensions/tsc-checkpoint/index.ts
+++ b/.pi/extensions/tsc-checkpoint/index.ts
@@ -25,7 +25,7 @@ import {
 	resolveDiagnosticFilePath,
 } from "./adapter.ts";
 import { DiagnosticsWatcher } from "./watcher.ts";
-import { formatDiagnostics, formatDiagnosticsJson } from "./format.ts";
+import { formatDiagnostics, formatDiagnosticsJson, directionLabel } from "./format.ts";
 import { runTscCheckpoint } from "./checkpoint.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -44,7 +44,7 @@ export {
 	resolveDiagnosticFilePath,
 } from "./adapter.ts";
 export { DiagnosticsWatcher } from "./watcher.ts";
-export { formatDiagnostics, formatDiagnosticsJson } from "./format.ts";
+export { formatDiagnostics, formatDiagnosticsJson, directionLabel } from "./format.ts";
 export { runTscCheckpoint } from "./checkpoint.ts";
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -130,13 +130,7 @@ export default function tscCheckpoint(pi: ExtensionAPI): void {
 					const errorCount = diagnostics.length;
 					let msg = `## TSC Checkpoint — ${errorCount} Type Error(s) Found`;
 					if (trend) {
-						const directionLabel =
-							trend.direction === "regressed"
-								? "⚠️ regression"
-								: trend.direction === "improved"
-									? "✓ improved"
-									: "→ stable";
-						msg += ` (${directionLabel})`;
+						msg += ` (${directionLabel(trend.direction, "tui")})`;
 					}
 					msg += `\n\n${formatted}`;
 					pi.sendUserMessage?.(msg, { deliverAs: "followUp" });

--- a/.pi/extensions/tsc-checkpoint/test/format.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/format.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, it } from "node:test";
 
-import { formatDiagnostics, formatDiagnosticsJson } from "../format.ts";
+import { formatDiagnostics, formatDiagnosticsJson, directionLabel } from "../format.ts";
 
 import type { TscDiagnostic, DiagnosticTrend } from "../types.ts";
 
@@ -243,6 +243,29 @@ describe("formatDiagnosticsJson", () => {
 		assert.ok(result.summary.includes("was 1"));
 	});
 
+	it("summary includes stable → label for stable trend", () => {
+		const diags: TscDiagnostic[] = [
+			{
+				file: "src/a.ts",
+				line: 5,
+				column: 3,
+				severity: "Error",
+				message: "err",
+				code: "TS2304",
+				filePath: "/project/src/a.ts",
+			},
+		];
+		const trend: DiagnosticTrend = {
+			current: 2,
+			previous: 2,
+			direction: "stable",
+			delta: 0,
+		};
+		const result = formatDiagnosticsJson(diags, trend);
+		assert.ok(result.summary.includes("stable →"));
+		assert.ok(result.summary.includes("1 type error(s) found"));
+	});
+
 	it("fileCount counts unique filePaths", () => {
 		const diags: TscDiagnostic[] = [
 			{
@@ -276,5 +299,23 @@ describe("formatDiagnosticsJson", () => {
 		const result = formatDiagnosticsJson(diags);
 		assert.strictEqual(result.diagnostics.length, 3);
 		assert.strictEqual(result.fileCount, 2); // Two unique files
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// directionLabel — shared direction→label mapping (Issue #1547)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("directionLabel", () => {
+	it("maps every direction to its TUI label (hardcoded literals)", () => {
+		assert.strictEqual(directionLabel("regressed", "tui"), "⚠️ regression");
+		assert.strictEqual(directionLabel("improved", "tui"), "✓ improved");
+		assert.strictEqual(directionLabel("stable", "tui"), "→ stable");
+	});
+
+	it("maps every direction to its JSON label (hardcoded literals)", () => {
+		assert.strictEqual(directionLabel("regressed", "json"), "regressed ↑");
+		assert.strictEqual(directionLabel("improved", "json"), "improved ↓");
+		assert.strictEqual(directionLabel("stable", "json"), "stable →");
 	});
 });

--- a/.pi/extensions/tsc-checkpoint/test/index.test.ts
+++ b/.pi/extensions/tsc-checkpoint/test/index.test.ts
@@ -21,6 +21,7 @@ import {
 	resolveDiagnosticFilePath,
 	formatDiagnostics,
 	formatDiagnosticsJson,
+	directionLabel,
 	runTscCheckpoint,
 	diagnosticToTscDiagnostic,
 } from "../index.ts";
@@ -166,7 +167,7 @@ function createCheckHandler(mockCtx?: {
 				const formatted = formatDiagnostics(diagnostics);
 				let msg = `## TSC Checkpoint — ${diagnostics.length} Type Error(s) Found`;
 				if (trend) {
-					msg += ` (${trend.direction === "regressed" ? "⚠️ regression" : trend.direction === "improved" ? "✓ improved" : "→ stable"})`;
+					msg += ` (${directionLabel(trend.direction, "tui")})`;
 				}
 				msg += `\n\n${formatted}`;
 				messages.push({ content: msg, options: { deliverAs: "followUp" } });
@@ -623,6 +624,35 @@ describe("Mode-adapted output (/check with ctx.mode)", () => {
 	it("resolveDiagnosticFilePath is still exported from index.ts", async () => {
 		const mod = await import("../index.ts");
 		assert.strictEqual(typeof mod.resolveDiagnosticFilePath, "function");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Issue #1547 — direction-label consolidation (verify-removal guard)
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("direction-label consolidation", () => {
+	it("index.ts no longer contains the inlined direction ternary", () => {
+		const content = fs.readFileSync(resolve(import.meta.dirname, "../index.ts"), "utf-8");
+		const ternaryLine = content
+			.split("\n")
+			.find((line) => line.includes("trend.direction === ") && line.includes("?"));
+		assert.ok(
+			ternaryLine === undefined,
+			`Expected inlined direction ternary to be removed from index.ts, but found: "${ternaryLine?.trim()}"`,
+		);
+	});
+
+	it("index.test.ts no longer re-implements the direction ternary", () => {
+		const marker = "trend.direction" + ' === "regressed"';
+		const content = fs.readFileSync(resolve(import.meta.dirname, "index.test.ts"), "utf-8");
+		const ternaryLine = content
+			.split("\n")
+			.find((line) => line.includes(marker) && line.includes("?"));
+		assert.ok(
+			ternaryLine === undefined,
+			`Expected inlined direction ternary to be removed from index.test.ts, but found: "${ternaryLine?.trim()}"`,
+		);
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1547

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 28m 15s | 55.9K | 21 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 3m 39s | 30.9K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 3m 52s | 31.4K | 9 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 5m 5s | 38.1K | 22 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 7m 42s | 18.7K | 9 | kimi-k3 |

**Total:** 5 runs · 48m 32s · 175.1K tokens · 73 tool calls · 3 failed (4%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1547
Closes #1547