### PR TITLE
feat(#1545): session-stats.ts: replace identity nested ternary with Set membership

### DIFF
--- a/.pi/extensions/session-logger/renderer/session-stats.ts
+++ b/.pi/extensions/session-logger/renderer/session-stats.ts
@@ -16,6 +16,9 @@ import type { PerTurnState } from "../per-turn.ts";
 import { handleModelChanges } from "../session-utils.ts";
 import { loadSessionEntries } from "./parse.ts";
 
+/** Tool calls that modify files on disk — everything else is filtered out of fileModifications. */
+const FILE_MOD_TOOLS = new Set(["read", "write", "edit"]);
+
 // ── Parsed session data (used by metadata + markdown) ──
 
 export interface ParsedSessionStats {
@@ -111,14 +114,7 @@ function accumulateMessageStats(acc: StatsAccumulator, entry: any): void {
 		// File modifications from tool calls
 		for (const c of msg.content ?? []) {
 			if (c.type === "toolCall") {
-				const action =
-					c.name === "read"
-						? "read"
-						: c.name === "write"
-							? "write"
-							: c.name === "edit"
-								? "edit"
-								: null;
+				const action = FILE_MOD_TOOLS.has(c.name) ? c.name : null;
 				if (action) {
 					acc.fileMods.push({
 						action,

--- a/.pi/extensions/session-logger/test/session-logger-renderer.test.mts
+++ b/.pi/extensions/session-logger/test/session-logger-renderer.test.mts
@@ -1117,6 +1117,156 @@ describe("parseSessionStats — subagent tool calls from supervisor custom entri
 // renderSessionToMarkdown — subagent tool calls in Tool Usage table
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// parseSessionStats — fileModifications action filter (Set membership)
+// ---------------------------------------------------------------------------
+
+describe("parseSessionStats — fileModifications action filter (Set membership)", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "session-logger-filemods-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeJsonl(entries: Record<string, unknown>[]): string {
+		const filepath = path.join(tmpDir, "test-session.jsonl");
+		const header = {
+			type: "session",
+			id: "test-session-filemods",
+			timestamp: "2025-06-01T10:00:00Z",
+			cwd: "/tmp",
+			version: 1,
+		};
+		const lines = [header, ...entries].map((e) => JSON.stringify(e)).join("\n") + "\n";
+		fs.writeFileSync(filepath, lines, "utf-8");
+		return filepath;
+	}
+
+	function parseFileMods(entries: Record<string, unknown>[]) {
+		const parsed = parseSessionStats(writeJsonl(entries));
+		assert.ok(parsed, "should parse");
+		return parsed.fileModifications;
+	}
+
+	function assistantWithToolCalls(toolCalls: Record<string, unknown>[]) {
+		return {
+			type: "message",
+			timestamp: "2025-06-01T10:01:00Z",
+			message: {
+				role: "assistant",
+				content: toolCalls,
+			},
+		};
+	}
+
+	it("read/write/edit toolCalls produce one entry each with identity action, in push order", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "toolCall", name: "read", arguments: { path: "a.txt" } },
+				{ type: "toolCall", name: "write", arguments: { path: "b.txt", content: "abc" } },
+				{ type: "toolCall", name: "edit", arguments: { path: "c.txt" } },
+			]),
+		]);
+
+		assert.strictEqual(fileMods.length, 3, "exactly 3 entries");
+		assert.deepStrictEqual(
+			fileMods.map((m) => m.action),
+			["read", "write", "edit"],
+			"action equals name for each, order read→write→edit",
+		);
+	});
+
+	it("non-file-mod tool names (bash, web_search, ripgrep_search) produce no entries", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "toolCall", name: "bash", arguments: { command: "ls" } },
+				{ type: "toolCall", name: "web_search", arguments: { query: "x" } },
+				{ type: "toolCall", name: "ripgrep_search", arguments: { query: "x" } },
+			]),
+		]);
+
+		assert.deepStrictEqual(fileMods, [], "null path → no fileMods entry");
+	});
+
+	it("case/whitespace variants of read/edit never match (=== semantics preserved)", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "toolCall", name: "READ", arguments: { path: "a" } },
+				{ type: "toolCall", name: "Edit", arguments: { path: "b" } },
+				{ type: "toolCall", name: "read ", arguments: { path: "c" } },
+				{ type: "toolCall", name: "read\n", arguments: { path: "d" } },
+			]),
+		]);
+
+		assert.deepStrictEqual(fileMods, [], "no case/whitespace variant matches");
+	});
+
+	it("empty string and missing name produce no entries", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "toolCall", name: "", arguments: { path: "a" } },
+				{ type: "toolCall", arguments: { path: "b" } },
+			]),
+		]);
+
+		assert.deepStrictEqual(fileMods, [], "empty/missing name → no entry");
+	});
+
+	it("write size branch preserved: content.length when present, undefined when absent", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "toolCall", name: "write", arguments: { path: "a.txt", content: "abc" } },
+				{ type: "toolCall", name: "write", arguments: { path: "b.txt" } },
+			]),
+		]);
+
+		assert.strictEqual(fileMods.length, 2);
+		assert.strictEqual(fileMods[0].action, "write");
+		assert.strictEqual(fileMods[0].size, 3, "size = content.length");
+		assert.strictEqual(fileMods[1].action, "write");
+		assert.strictEqual(fileMods[1].size, undefined, "no content → size undefined");
+	});
+
+	it("read/edit entries never carry size even when arguments.content present", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "toolCall", name: "read", arguments: { path: "a.txt", content: "x" } },
+				{ type: "toolCall", name: "edit", arguments: { path: "b.txt", content: "y" } },
+			]),
+		]);
+
+		assert.strictEqual(fileMods.length, 2);
+		assert.strictEqual(fileMods[0].size, undefined, "read carries no size");
+		assert.strictEqual(fileMods[1].size, undefined, "edit carries no size (write-only)");
+	});
+
+	it("toolCall without arguments.path falls back to ?", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([{ type: "toolCall", name: "read" }]),
+		]);
+
+		assert.strictEqual(fileMods.length, 1);
+		assert.strictEqual(fileMods[0].path, "?", "path ?? \"?\" fallback preserved");
+	});
+
+	it("interleaved non-toolCall content items are skipped, toolCalls still captured", () => {
+		const fileMods = parseFileMods([
+			assistantWithToolCalls([
+				{ type: "text", text: "thinking" },
+				{ type: "toolCall", name: "read", arguments: { path: "a.txt" } },
+				{ type: "text", text: "more" },
+			]),
+		]);
+
+		assert.strictEqual(fileMods.length, 1, "only toolCall entry captured");
+		assert.strictEqual(fileMods[0].action, "read");
+	});
+});
+
 describe("renderSessionToMarkdown — subagent tool calls in Tool Usage table", () => {
 	let tmpDir: string;
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1545

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 10m 58s | 83.9K | 36 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 21s | 17.8K | 5 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 36s | 31.4K | 7 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 48s | 31.3K | 9 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 32s | 19.9K | 16 | kimi-k3 |

**Total:** 5 runs · 15m 15s · 184.2K tokens · 73 tool calls · 5 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1545
Closes #1545