### PR TITLE
feat(#1593): ICA: Collapse fileRepository's two dialects into one

### DIFF
--- a/cmd/cheasee-pi/config.go
+++ b/cmd/cheasee-pi/config.go
@@ -3,92 +3,16 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
 
-// Auth represents the authentication configuration.
-//
-// Serialization produces per-provider JSON when Provider is set:
-//
-//	{"<provider>": {"key": "..."}, "github_token": "...", ...}
-//
-// When Provider is empty (legacy or GitHub-only), the api_key field
-// is written at the top level for backward compatibility.
-type Auth struct {
-	APIKey      string `json:"-"`
-	GitHubToken string `json:"github_token,omitempty"`
-	GitHubUser  string `json:"github_user,omitempty"`
-	RepoPath    string `json:"repo_path,omitempty"`
-	Provider    string `json:"-"`
-}
-
-// MarshalJSON implements json.Marshaler for Auth.
-// When Provider is set and APIKey is non-empty, the key is written under
-// a per-provider object: {"<provider>": {"key": "..."}}.
-// When Provider is empty, api_key is written at the top level for backward
-// compatibility.
-func (a *Auth) MarshalJSON() ([]byte, error) {
-	m := make(map[string]any)
-	if a.Provider != "" && a.APIKey != "" {
-		m[a.Provider] = map[string]string{"key": a.APIKey}
-	} else if a.Provider == "" {
-		m["api_key"] = a.APIKey
-	}
-	if a.GitHubToken != "" {
-		m["github_token"] = a.GitHubToken
-	}
-	if a.GitHubUser != "" {
-		m["github_user"] = a.GitHubUser
-	}
-	if a.RepoPath != "" {
-		m["repo_path"] = a.RepoPath
-	}
-	return json.Marshal(m)
-}
-
-// UnmarshalJSON implements json.Unmarshaler for Auth.
-// Supports both the per-provider format and the legacy flat format.
-func (a *Auth) UnmarshalJSON(data []byte) error {
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	// Handle flat api_key (legacy format)
-	if apiKeyRaw, ok := raw["api_key"]; ok {
-		var v string
-		if err := json.Unmarshal(apiKeyRaw, &v); err == nil {
-			a.APIKey = v
-		}
-	}
-
-	// Scan all keys — any key with a nested {"key": "..."} is a provider entry
-	for k, v := range raw {
-		switch k {
-		case "github_token":
-			json.Unmarshal(v, &a.GitHubToken) //nolint: errcheck
-		case "github_user":
-			json.Unmarshal(v, &a.GitHubUser) //nolint: errcheck
-		case "repo_path":
-			json.Unmarshal(v, &a.RepoPath) //nolint: errcheck
-		case "api_key":
-			// already handled above
-		default:
-			var entry struct {
-				Key string `json:"key"`
-			}
-			if err := json.Unmarshal(v, &entry); err == nil && entry.Key != "" {
-				a.Provider = k
-				a.APIKey = entry.Key
-			}
-		}
-	}
-
-	return nil
-}
-
-// fileRepository persists and loads Auth config as a JSON file on disk.
+// fileRepository persists and reads the auth config as a JSON file on disk.
+// One dialect: fileRepository owns the raw-map patch module
+// (readRawMap / writeRawMap / updateAuth) and every caller goes through it,
+// so multi-provider files survive all mutations — the typed codec that
+// clobbered all but one provider is gone.
 type fileRepository struct{}
 
 func (r *fileRepository) configPath() (string, error) {
@@ -139,48 +63,58 @@ func (r *fileRepository) Path() (string, error) {
 	return r.configPath()
 }
 
-// Load reads the auth config from disk. Returns empty Auth if file does not exist.
-func (r *fileRepository) Load(_ context.Context) (*Auth, error) {
-	path, err := r.configPath()
+// updateAuth is the single read-merge-write chokepoint for auth.json: every
+// writer reads the current map, applies its patch via fn, then atomically
+// rewrites. Malformed existing content errors before any write, so a corrupt
+// auth.json is never overwritten. Cross-process writer serialization (flock)
+// lands here later if parallel cheasee-pi processes become a use case.
+// ponytail: single-writer assumption; serialize here if that ever breaks.
+func (r *fileRepository) updateAuth(ctx context.Context, fn func(map[string]json.RawMessage) error) error {
+	raw, err := r.readRawMap()
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return &Auth{}, nil
-		}
-		return nil, err
+	if err := fn(raw); err != nil {
+		return err
 	}
-
-	var auth Auth
-	if err := json.Unmarshal(data, &auth); err != nil {
-		return nil, err
-	}
-	return &auth, nil
+	return r.writeRawMap(raw)
 }
 
-// Save writes the auth config to disk atomically (write to .tmp then rename).
-func (r *fileRepository) Save(_ context.Context, auth *Auth) error {
-	auth.APIKey = dedupeKey(auth.APIKey) // guard against accidental double-paste
+// reservedAuthKeys are the top-level auth.json fields that are not provider
+// entries. Enumerated once here; AddProvider/SetLegacyAuth refuse them
+// (fail-closed against the `pi auth add github_token` clobber foot-gun) and
+// ListProviders filters them.
+var reservedAuthKeys = map[string]struct{}{
+	"github_token": {},
+	"github_user":  {},
+	"repo_path":    {},
+	"api_key":      {},
+}
 
-	path, err := r.configPath()
+// isReservedAuthKey reports whether key names a reserved auth.json field
+// rather than a provider entry.
+func isReservedAuthKey(key string) bool {
+	_, ok := reservedAuthKeys[key]
+	return ok
+}
+
+// GitHubToken returns the github_token from auth.json. Missing file and
+// absent key both yield ("", nil) — the fail-to-fallback behavior pi up
+// relies on for GH_TOKEN assembly; malformed content errors instead.
+func (r *fileRepository) GitHubToken(ctx context.Context) (string, error) {
+	raw, err := r.readRawMap()
 	if err != nil {
-		return err
+		return "", err
 	}
-
-	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return err
+	rawToken, ok := raw["github_token"]
+	if !ok {
+		return "", nil
 	}
-
-	data, err := json.MarshalIndent(auth, "", "  ")
-	if err != nil {
-		return err
+	var token string
+	if err := json.Unmarshal(rawToken, &token); err != nil {
+		return "", err
 	}
-
-	return atomicWrite(path, data, 0600)
+	return token, nil
 }
 
 // readRawAuth reads the auth config file as a raw JSON map.
@@ -240,19 +174,18 @@ func dedupeKey(key string) string {
 
 // AddProvider adds or updates a provider API key in the auth config.
 // Other providers and GitHub token fields are preserved.
-func (r *fileRepository) AddProvider(_ context.Context, provider, key string) error {
+func (r *fileRepository) AddProvider(ctx context.Context, provider, key string) error {
+	if isReservedAuthKey(provider) {
+		return fmt.Errorf("provider name %q is reserved for an auth.json field and cannot be used as a provider", provider)
+	}
 	key = dedupeKey(key) // guard against accidental double-paste
 
-	raw, err := r.readRawMap()
-	if err != nil {
-		return err
-	}
-
-	// Build the provider entry: {"<provider>": {"key": "..."}}
-	entry, _ := json.Marshal(map[string]string{"key": key})
-	raw[provider] = entry
-
-	return r.writeRawMap(raw)
+	return r.updateAuth(ctx, func(raw map[string]json.RawMessage) error {
+		// Build the provider entry: {"<provider>": {"key": "..."}}
+		entry, _ := json.Marshal(map[string]string{"key": key})
+		raw[provider] = entry
+		return nil
+	})
 }
 
 // UpdateGitHubAuth patches the github_token, github_user, and repo_path
@@ -260,39 +193,60 @@ func (r *fileRepository) AddProvider(_ context.Context, provider, key string) er
 // flat api_key. Missing auth.json → creates a file containing only the
 // github fields. Merge-safe by construction (raw-map patch, same as
 // AddProvider).
-func (r *fileRepository) UpdateGitHubAuth(_ context.Context, token, user, repoPath string) error {
-	raw, err := r.readRawMap()
-	if err != nil {
-		return err
-	}
-	for key, val := range map[string]string{
-		"github_token": token,
-		"github_user":  user,
-		"repo_path":    repoPath,
-	} {
-		enc, err := json.Marshal(val)
-		if err != nil {
-			return err
+func (r *fileRepository) UpdateGitHubAuth(ctx context.Context, token, user, repoPath string) error {
+	return r.updateAuth(ctx, func(raw map[string]json.RawMessage) error {
+		for key, val := range map[string]string{
+			"github_token": token,
+			"github_user":  user,
+			"repo_path":    repoPath,
+		} {
+			enc, err := json.Marshal(val)
+			if err != nil {
+				return err
+			}
+			raw[key] = enc
 		}
-		raw[key] = enc
+		return nil
+	})
+}
+
+// SetLegacyAuth writes the legacy init credentials (--no-github or the
+// device-flow fallback) as a merge-safe raw-map patch: the per-provider
+// entry {"<provider>": {"key": …}}, the flat api_key, and repo_path — the
+// legacy top-level api_key write becomes one more raw-map key. Preserves
+// every provider entry and the github fields; the typed Save it replaces
+// was a whole-file reset that clobbered them.
+func (r *fileRepository) SetLegacyAuth(ctx context.Context, provider, apiKey, repoPath string) error {
+	if isReservedAuthKey(provider) {
+		return fmt.Errorf("provider name %q is reserved for an auth.json field and cannot be used as a provider", provider)
 	}
-	return r.writeRawMap(raw)
+	apiKey = dedupeKey(apiKey) // guard against accidental double-paste
+
+	return r.updateAuth(ctx, func(raw map[string]json.RawMessage) error {
+		entry, _ := json.Marshal(map[string]string{"key": apiKey})
+		raw[provider] = entry
+		apiKeyJSON, _ := json.Marshal(apiKey)
+		raw["api_key"] = apiKeyJSON
+		repoPathJSON, _ := json.Marshal(repoPath)
+		raw["repo_path"] = repoPathJSON
+		return nil
+	})
 }
 
 // RemoveProvider deletes a provider entry from the auth config.
-func (r *fileRepository) RemoveProvider(_ context.Context, provider string) error {
-	raw, err := r.readRawMap()
-	if err != nil {
-		return err
+func (r *fileRepository) RemoveProvider(ctx context.Context, provider string) error {
+	if isReservedAuthKey(provider) {
+		return fmt.Errorf("provider name %q is reserved for an auth.json field and cannot be removed", provider)
 	}
-
-	delete(raw, provider)
-	return r.writeRawMap(raw)
+	return r.updateAuth(ctx, func(raw map[string]json.RawMessage) error {
+		delete(raw, provider)
+		return nil
+	})
 }
 
 // ListProviders returns all configured provider API keys.
-// Filters out non-provider keys (github_token, github_user, repo_path, api_key).
-func (r *fileRepository) ListProviders(_ context.Context) (map[string]string, error) {
+// Filters out the reserved (non-provider) keys.
+func (r *fileRepository) ListProviders(ctx context.Context) (map[string]string, error) {
 	raw, err := r.readRawMap()
 	if err != nil {
 		return nil, err
@@ -300,8 +254,7 @@ func (r *fileRepository) ListProviders(_ context.Context) (map[string]string, er
 
 	result := make(map[string]string)
 	for k, v := range raw {
-		switch k {
-		case "github_token", "github_user", "repo_path", "api_key":
+		if isReservedAuthKey(k) {
 			continue
 		}
 		var entry struct {

--- a/cmd/cheasee-pi/config_test.go
+++ b/cmd/cheasee-pi/config_test.go
@@ -7,145 +7,261 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/SchneiderDaniel/cheasee-pi/cmd/cheasee-pi/testutil"
 )
 
-func TestConfigSave_Load(t *testing.T) {
+// writeAuthFile seeds auth.json with the given raw content under a fresh
+// config home (t.Setenv XDG_CONFIG_HOME). Reads afterwards go through the
+// config-home helpers (readAuthJSON/authJSONBytes).
+func writeAuthFile(t *testing.T, content string) {
+	t.Helper()
+	dir := testutil.RedirectConfigHome(t)
+	path := filepath.Join(dir, "cheasee-pi", "auth.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddProvider_MultipleProvidersListed(t *testing.T) {
+	// The regression the typed dialect failed: the old Save round-trip
+	// clobbered all but one provider; the raw-map patch keeps both.
 	testutil.RedirectConfigHome(t)
-
 	cfg := &fileRepository{}
-	auth := &Auth{APIKey: FakeAPIKey}
-
 	ctx := context.Background()
-	if err := cfg.Save(ctx, auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
+	if err := cfg.AddProvider(ctx, "openai", "key-openai"); err != nil {
+		t.Fatalf("AddProvider openai: %v", err)
 	}
-
-	loaded, err := cfg.Load(ctx)
+	if err := cfg.AddProvider(ctx, "anthropic", "key-anthropic"); err != nil {
+		t.Fatalf("AddProvider anthropic: %v", err)
+	}
+	providers, err := cfg.ListProviders(ctx)
 	if err != nil {
-		t.Fatalf("Load failed: %v", err)
+		t.Fatalf("ListProviders: %v", err)
 	}
-	if loaded.APIKey != FakeAPIKey {
-		t.Errorf("expected API key %q, got %q", FakeAPIKey, loaded.APIKey)
+	if len(providers) != 2 || providers["openai"] != "key-openai" || providers["anthropic"] != "key-anthropic" {
+		t.Errorf("both providers must survive the second AddProvider, got %v", providers)
 	}
 }
 
-func TestConfigSave_CreatesDirectory(t *testing.T) {
-	dir := testutil.RedirectConfigHome(t)
-
-	cfg := &fileRepository{}
-	auth := &Auth{APIKey: FakeAPIKey}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	// Verify directory was created
-	configDir := filepath.Join(dir, "cheasee-pi")
-	info, err := os.Stat(configDir)
-	if err != nil {
-		t.Fatalf("config directory not created: %v", err)
-	}
-	if !info.IsDir() {
-		t.Error("config path is not a directory")
-	}
-}
-
-func TestConfigSave_ValidJSON(t *testing.T) {
+func TestUpdateGitHubAuth_PreservesProvidersViaPublicMethods(t *testing.T) {
+	// UpdateGitHubAuth after AddProvider × 2: both providers survive and the
+	// github fields are patched — driven entirely through the public surface
+	// (no hand-written auth.json).
 	testutil.RedirectConfigHome(t)
-
 	cfg := &fileRepository{}
-	auth := &Auth{APIKey: FakeAPIKey}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
+	ctx := context.Background()
+	if err := cfg.AddProvider(ctx, "openai", "key-openai"); err != nil {
+		t.Fatalf("AddProvider openai: %v", err)
+	}
+	if err := cfg.AddProvider(ctx, "anthropic", "key-anthropic"); err != nil {
+		t.Fatalf("AddProvider anthropic: %v", err)
+	}
+	if err := cfg.UpdateGitHubAuth(ctx, "new-token", "octocat", "/ws"); err != nil {
+		t.Fatalf("UpdateGitHubAuth: %v", err)
 	}
 
-	path, err := cfg.Path()
+	providers, err := cfg.ListProviders(ctx)
 	if err != nil {
-		t.Fatalf("Path failed: %v", err)
+		t.Fatalf("ListProviders: %v", err)
 	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("failed to read auth.json: %v", err)
+	if providers["openai"] != "key-openai" || providers["anthropic"] != "key-anthropic" {
+		t.Errorf("both providers must survive the github patch, got %v", providers)
 	}
-
-	var result map[string]any
-	if err := json.Unmarshal(data, &result); err != nil {
-		t.Fatalf("invalid JSON: %v", err)
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "github_token"); got != "new-token" {
+		t.Errorf("github_token must be patched, got %q", got)
 	}
-	if result["api_key"] != FakeAPIKey {
-		t.Errorf("expected api_key %q, got %v", FakeAPIKey, result["api_key"])
+	if got := authField(t, raw, "github_user"); got != "octocat" {
+		t.Errorf("github_user must be patched, got %q", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws" {
+		t.Errorf("repo_path must be patched, got %q", got)
 	}
 }
 
-func TestConfigSave_AtomicWrite(t *testing.T) {
+func TestSetLegacyAuth_WritesAllThreeKeys(t *testing.T) {
+	// Legacy init patch: provider entry {"<provider>":{"key":…}} + flat
+	// api_key + repo_path (the legacy top-level api_key write is one more
+	// raw-map key); the provider is listable and a raw-map read shows all
+	// three keys.
 	testutil.RedirectConfigHome(t)
-
 	cfg := &fileRepository{}
-	auth := &Auth{APIKey: FakeAPIKey}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
+	if err := cfg.SetLegacyAuth(context.Background(), "opencode-go", FakeAPIKey, "/ws"); err != nil {
+		t.Fatalf("SetLegacyAuth: %v", err)
 	}
-
-	path, err := cfg.Path()
+	providers, err := cfg.ListProviders(context.Background())
 	if err != nil {
-		t.Fatalf("Path failed: %v", err)
+		t.Fatalf("ListProviders: %v", err)
 	}
-
-	// Verify no .tmp file remains
-	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
-		t.Error("temporary .tmp file should not exist after successful Save")
+	if providers["opencode-go"] != FakeAPIKey {
+		t.Errorf("expected provider entry for opencode-go, got %v", providers)
+	}
+	raw := readAuthJSON(t)
+	if len(raw) != 3 {
+		t.Fatalf("expected api_key + provider + repo_path (3 keys), got %v", raw)
+	}
+	if got := providerKey(t, raw, "opencode-go"); got != FakeAPIKey {
+		t.Errorf("provider entry key = %q, want %q", got, FakeAPIKey)
+	}
+	if got := authField(t, raw, "api_key"); got != FakeAPIKey {
+		t.Errorf("flat api_key = %q, want %q", got, FakeAPIKey)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws" {
+		t.Errorf("repo_path = %q, want %q", got, "/ws")
 	}
 }
 
-func TestConfigLoad_FileNotExists(t *testing.T) {
+func TestSetLegacyAuth_PreservesProviders(t *testing.T) {
+	// SetLegacyAuth after AddProvider: merge-safe, existing provider entries
+	// are preserved (the typed Save this replaces reset the whole file).
 	testutil.RedirectConfigHome(t)
-
 	cfg := &fileRepository{}
-	loaded, err := cfg.Load(context.Background())
+	ctx := context.Background()
+	if err := cfg.AddProvider(ctx, "openai", "key-openai"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SetLegacyAuth(ctx, "opencode-go", "legacy-key", "/ws"); err != nil {
+		t.Fatalf("SetLegacyAuth: %v", err)
+	}
+	providers, err := cfg.ListProviders(ctx)
 	if err != nil {
-		t.Fatalf("Load of non-existent file should return empty Auth, got error: %v", err)
+		t.Fatalf("ListProviders: %v", err)
 	}
-	if loaded == nil {
-		t.Fatal("Load should return non-nil Auth")
+	if providers["openai"] != "key-openai" || providers["opencode-go"] != "legacy-key" {
+		t.Errorf("existing provider must survive SetLegacyAuth, got %v", providers)
 	}
-	if loaded.APIKey != "" {
-		t.Errorf("expected empty API key, got %q", loaded.APIKey)
-	}
-}
-
-func TestConfigLoad_InvalidJSON(t *testing.T) {
-	dir := testutil.RedirectConfigHome(t)
-
-	// Create auth.json with invalid JSON
-	path := filepath.Join(dir, "cheasee-pi", "auth.json")
-	os.MkdirAll(filepath.Dir(path), 0700)
-	os.WriteFile(path, []byte("{invalid json}"), 0600)
-
-	cfg := &fileRepository{}
-	_, err := cfg.Load(context.Background())
-	if err == nil {
-		t.Fatal("expected error for invalid JSON")
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "api_key"); got != "legacy-key" {
+		t.Errorf("flat api_key = %q, want %q", got, "legacy-key")
 	}
 }
 
-func TestConfigLoad_PathIsDirectory(t *testing.T) {
-	dir := testutil.RedirectConfigHome(t)
-
-	// Create auth.json as a directory
-	path := filepath.Join(dir, "cheasee-pi", "auth.json")
-	os.MkdirAll(path, 0700)
-
+func TestSetLegacyAuth_PreservesGitHubFields(t *testing.T) {
+	// SetLegacyAuth after UpdateGitHubAuth: github_token/github_user survive
+	// the legacy patch; repo_path is one of the three keys SetLegacyAuth
+	// owns and is overwritten (pinned deliberately).
+	testutil.RedirectConfigHome(t)
 	cfg := &fileRepository{}
-	_, err := cfg.Load(context.Background())
-	if err == nil {
-		t.Fatal("expected error when auth.json is a directory")
+	ctx := context.Background()
+	if err := cfg.UpdateGitHubAuth(ctx, "tkn", "octocat", "/ws"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.SetLegacyAuth(ctx, "opencode-go", "legacy-key", "/ws2"); err != nil {
+		t.Fatalf("SetLegacyAuth: %v", err)
+	}
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "github_token"); got != "tkn" {
+		t.Errorf("github_token must survive SetLegacyAuth, got %q", got)
+	}
+	if got := authField(t, raw, "github_user"); got != "octocat" {
+		t.Errorf("github_user must survive SetLegacyAuth, got %q", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws2" {
+		t.Errorf("repo_path = %q, want %q", got, "/ws2")
+	}
+}
+
+func TestSetLegacyAuth_EmptyAPIKeyPinned(t *testing.T) {
+	// Deliberate contract, pinned: SetLegacyAuth always writes all three
+	// keys even for an empty key — the provider entry carries {"key": ""},
+	// api_key is written empty, repo_path is written. ListProviders drops
+	// empty-key entries (matching AddProvider), so nothing is listed.
+	testutil.RedirectConfigHome(t)
+	cfg := &fileRepository{}
+	if err := cfg.SetLegacyAuth(context.Background(), "opencode-go", "", "/ws"); err != nil {
+		t.Fatalf("SetLegacyAuth with empty key must succeed: %v", err)
+	}
+	raw := readAuthJSON(t)
+	if len(raw) != 3 {
+		t.Fatalf("all three keys must be written for an empty key, got %v", raw)
+	}
+	if got := providerKey(t, raw, "opencode-go"); got != "" {
+		t.Errorf("provider entry key = %q, want empty", got)
+	}
+	if got := authField(t, raw, "api_key"); got != "" {
+		t.Errorf("flat api_key = %q, want empty", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws" {
+		t.Errorf("repo_path = %q, want %q", got, "/ws")
+	}
+	providers, err := cfg.ListProviders(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(providers) != 0 {
+		t.Errorf("empty-key provider entries must not be listed, got %v", providers)
+	}
+}
+
+func TestReservedKeyRejected(t *testing.T) {
+	// AddProvider/RemoveProvider with a reserved auth.json key fail closed —
+	// killing the `pi auth add github_token` clobber foot-gun — and leave
+	// the file untouched.
+	for _, tc := range []struct {
+		name string
+		key  string
+	}{
+		{"github_token", "github_token"},
+		{"github_user", "github_user"},
+		{"repo_path", "repo_path"},
+		{"api_key", "api_key"},
+	} {
+		t.Run("add "+tc.name, func(t *testing.T) {
+			writeAuthFile(t, `{"openai":{"key":"k"}}`)
+			before := authJSONBytes(t)
+
+			cfg := &fileRepository{}
+			err := cfg.AddProvider(context.Background(), tc.key, "sneaky")
+			if err == nil {
+				t.Fatal("expected error for reserved provider name")
+			}
+			if !bytes.Equal(before, authJSONBytes(t)) {
+				t.Error("auth.json must be unchanged after a reserved-key AddProvider")
+			}
+		})
+		t.Run("remove "+tc.name, func(t *testing.T) {
+			writeAuthFile(t, `{"github_token":"t","openai":{"key":"k"}}`)
+			before := authJSONBytes(t)
+
+			cfg := &fileRepository{}
+			err := cfg.RemoveProvider(context.Background(), tc.key)
+			if err == nil {
+				t.Fatal("expected error for reserved provider name")
+			}
+			if !bytes.Equal(before, authJSONBytes(t)) {
+				t.Error("auth.json must be unchanged after a reserved-key RemoveProvider")
+			}
+		})
+	}
+}
+
+func TestRemoveProvider_RemovesOnlyNamedProvider(t *testing.T) {
+	writeAuthFile(t, `{"openai":{"key":"k1"},"anthropic":{"key":"k2"},"github_token":"t","repo_path":"/ws"}`)
+	cfg := &fileRepository{}
+	if err := cfg.RemoveProvider(context.Background(), "openai"); err != nil {
+		t.Fatalf("RemoveProvider: %v", err)
+	}
+	raw := readAuthJSON(t)
+	if _, ok := raw["openai"]; ok {
+		t.Error("named provider must be removed")
+	}
+	providers, err := cfg.ListProviders(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if providers["anthropic"] != "k2" {
+		t.Errorf("other providers must survive RemoveProvider, got %v", providers)
+	}
+	if got := authField(t, raw, "github_token"); got != "t" {
+		t.Errorf("github_token must survive RemoveProvider, got %q", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws" {
+		t.Errorf("repo_path must survive RemoveProvider, got %q", got)
 	}
 }
 
@@ -161,351 +277,6 @@ func TestConfigPath(t *testing.T) {
 	expected := filepath.Join(dir, "cheasee-pi", "auth.json")
 	if path != expected {
 		t.Errorf("expected path %q, got %q", expected, path)
-	}
-}
-
-func TestConfigSave_EmptyAPIKey(t *testing.T) {
-	testutil.RedirectConfigHome(t)
-
-	cfg := &fileRepository{}
-	auth := &Auth{APIKey: ""}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save of empty API key should succeed: %v", err)
-	}
-
-	// Verify stored as empty string in JSON
-	path, _ := cfg.Path()
-	data, _ := os.ReadFile(path)
-	if !strings.Contains(string(data), `"api_key": ""`) {
-		t.Errorf("expected empty api_key in JSON, got: %s", string(data))
-	}
-}
-
-func TestConfigSave_SpecialChars(t *testing.T) {
-	testutil.RedirectConfigHome(t)
-
-	specialKey := `key-"quoted"-with\backslash and ünicode`
-	cfg := &fileRepository{}
-	auth := &Auth{APIKey: specialKey}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	loaded, err := cfg.Load(context.Background())
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-	if loaded.APIKey != specialKey {
-		t.Errorf("round-trip failed: expected %q, got %q", specialKey, loaded.APIKey)
-	}
-}
-
-func TestAuthPerProvider_MarshalHasProviderSlot(t *testing.T) {
-	auth := &Auth{
-		APIKey:   FakeAPIKey,
-		Provider: "opencode-go",
-	}
-
-	data := marshalAuth(t, auth)
-
-	// Must contain the provider-keyed object
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("Unmarshal of output failed: %v", err)
-	}
-
-	providerEntry, ok := raw["opencode-go"]
-	if !ok {
-		t.Fatal("expected 'opencode-go' key in marshaled JSON")
-	}
-	entry, ok := providerEntry.(map[string]any)
-	if !ok {
-		t.Fatal("expected provider entry to be an object")
-	}
-	if entry["key"] != FakeAPIKey {
-		t.Errorf("expected key %q, got %v", FakeAPIKey, entry["key"])
-	}
-
-	// Must NOT have flat api_key field
-	if _, ok := raw["api_key"]; ok {
-		t.Error("expected no flat 'api_key' field when Provider is set")
-	}
-}
-
-func TestAuthPerProvider_MarshalNoProviderWritesFlat(t *testing.T) {
-	auth := &Auth{
-		APIKey: FakeAPIKey,
-		// Provider is empty — should write flat api_key
-	}
-
-	data := marshalAuth(t, auth)
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("Unmarshal of output failed: %v", err)
-	}
-
-	if _, ok := raw["api_key"]; !ok {
-		t.Error("expected flat 'api_key' field when Provider is empty")
-	}
-	if raw["api_key"] != FakeAPIKey {
-		t.Errorf("expected api_key %q, got %v", FakeAPIKey, raw["api_key"])
-	}
-}
-
-func TestAuthPerProvider_MarshalEmptyProviderNoKey(t *testing.T) {
-	// GitHub-only auth: no Provider, no APIKey
-	// When Provider is empty, api_key is always written at top level for
-	// backward compatibility (even if empty string), preserving the
-	// pre-existing TestConfigSave_EmptyAPIKey contract.
-	auth := &Auth{
-		GitHubToken: FakeGitHubToken,
-		GitHubUser:  "testuser",
-		RepoPath:    "/workspace",
-	}
-
-	data := marshalAuth(t, auth)
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("Unmarshal of output failed: %v", err)
-	}
-
-	// api_key is written even when empty because Provider is empty —
-	// this maintains backward compat with pre-existing TestConfigSave_EmptyAPIKey
-	if v, ok := raw["api_key"]; ok {
-		if v != "" {
-			t.Errorf("expected empty api_key string, got %v", v)
-		}
-	} else {
-		t.Error("expected 'api_key' field (empty) for backward compat when Provider is empty")
-	}
-	if raw["github_token"] != FakeGitHubToken {
-		t.Errorf("expected github_token %q, got %v", FakeGitHubToken, raw["github_token"])
-	}
-}
-
-func TestAuthPerProvider_UnmarshalProviderFormat(t *testing.T) {
-	data := fmt.Appendf(nil, `{
-		"opencode-go": {"key": "%s"},
-		"github_token": "%s",
-		"github_user": "testuser",
-		"repo_path": "/workspace"
-	}`, FakeAPIKey, FakeGitHubToken)
-
-	var auth Auth
-	if err := json.Unmarshal(data, &auth); err != nil {
-		t.Fatalf("Unmarshal of provider format failed: %v", err)
-	}
-
-	if auth.APIKey != FakeAPIKey {
-		t.Errorf("expected APIKey %q, got %q", FakeAPIKey, auth.APIKey)
-	}
-	if auth.Provider != "opencode-go" {
-		t.Errorf("expected Provider 'opencode-go', got %q", auth.Provider)
-	}
-	if auth.GitHubToken != FakeGitHubToken {
-		t.Errorf("expected GitHubToken %q, got %q", FakeGitHubToken, auth.GitHubToken)
-	}
-	if auth.GitHubUser != "testuser" {
-		t.Errorf("expected GitHubUser 'testuser', got %q", auth.GitHubUser)
-	}
-	if auth.RepoPath != "/workspace" {
-		t.Errorf("expected RepoPath '/workspace', got %q", auth.RepoPath)
-	}
-}
-
-func TestAuthPerProvider_UnmarshalFlatFormat(t *testing.T) {
-	data := fmt.Appendf(nil, `{"api_key": "%s", "github_token": "%s"}`, FakeAPIKey, FakeGitHubToken)
-
-	var auth Auth
-	if err := json.Unmarshal(data, &auth); err != nil {
-		t.Fatalf("Unmarshal of flat format failed: %v", err)
-	}
-
-	if auth.APIKey != FakeAPIKey {
-		t.Errorf("expected APIKey %q, got %q", FakeAPIKey, auth.APIKey)
-	}
-	if auth.Provider != "" {
-		t.Errorf("expected empty Provider for flat format, got %q", auth.Provider)
-	}
-	if auth.GitHubToken != FakeGitHubToken {
-		t.Errorf("expected GitHubToken %q, got %q", FakeGitHubToken, auth.GitHubToken)
-	}
-}
-
-func TestAuthPerProvider_SaveWritesJqParseableOutput(t *testing.T) {
-	testutil.RedirectConfigHome(t)
-
-	cfg := &fileRepository{}
-	auth := &Auth{
-		APIKey:   FakeAPIKey,
-		Provider: "opencode-go",
-	}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	// Read raw file and verify it's valid JSON with expected structure
-	path, _ := cfg.Path()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("ReadFile failed: %v", err)
-	}
-
-	var raw map[string]any
-	if err := json.Unmarshal(data, &raw); err != nil {
-		t.Fatalf("Saved file is not valid JSON: %v", err)
-	}
-
-	entry, ok := raw["opencode-go"]
-	if !ok {
-		t.Fatal("saved file must contain provider key 'opencode-go'")
-	}
-	entryMap, ok := entry.(map[string]any)
-	if !ok {
-		t.Fatal("provider entry must be an object")
-	}
-	if entryMap["key"] != FakeAPIKey {
-		t.Errorf("expected key %q, got %v", FakeAPIKey, entryMap["key"])
-	}
-}
-
-func TestAuthPerProvider_UnmarshalEmptyObject(t *testing.T) {
-	data := []byte(`{}`)
-
-	var auth Auth
-	if err := json.Unmarshal(data, &auth); err != nil {
-		t.Fatalf("Unmarshal of empty object failed: %v", err)
-	}
-
-	if auth.APIKey != "" {
-		t.Errorf("expected empty APIKey, got %q", auth.APIKey)
-	}
-	if auth.GitHubToken != "" {
-		t.Errorf("expected empty GitHubToken, got %q", auth.GitHubToken)
-	}
-}
-
-func TestAuthPerProvider_UnmarshalMalformedJSON(t *testing.T) {
-	data := []byte(`{not json}`)
-
-	var auth Auth
-	err := json.Unmarshal(data, &auth)
-	if err == nil {
-		t.Fatal("expected error for malformed JSON")
-	}
-}
-
-func TestAuthPerProvider_RoundTripWithProvider(t *testing.T) {
-	testutil.RedirectConfigHome(t)
-
-	cfg := &fileRepository{}
-	auth := &Auth{
-		APIKey:      FakeAPIKey,
-		Provider:    "opencode-go",
-		GitHubToken: FakeGitHubToken,
-		GitHubUser:  "testuser",
-		RepoPath:    "/some/path",
-	}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	loaded, err := cfg.Load(context.Background())
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-	if loaded.APIKey != FakeAPIKey {
-		t.Errorf("expected api_key %q, got %q", FakeAPIKey, loaded.APIKey)
-	}
-	if loaded.Provider != "opencode-go" {
-		t.Errorf("expected Provider 'opencode-go', got %q", loaded.Provider)
-	}
-	if loaded.GitHubToken != FakeGitHubToken {
-		t.Errorf("expected GitHubToken %q, got %q", FakeGitHubToken, loaded.GitHubToken)
-	}
-	if loaded.GitHubUser != "testuser" {
-		t.Errorf("expected GitHubUser 'testuser', got %q", loaded.GitHubUser)
-	}
-	if loaded.RepoPath != "/some/path" {
-		t.Errorf("expected RepoPath '/some/path', got %q", loaded.RepoPath)
-	}
-}
-
-func TestAuthPerProvider_MarshalOmitGitHubTokenWhenEmpty(t *testing.T) {
-	auth := &Auth{
-		APIKey:   FakeAPIKey,
-		Provider: "openai",
-	}
-
-	data := marshalAuth(t, auth)
-
-	if bytes.Contains(data, []byte("github_token")) {
-		t.Error("expected no github_token in output when empty")
-	}
-	if !bytes.Contains(data, []byte("openai")) {
-		t.Error("expected openai provider key in output")
-	}
-}
-
-func TestConfigBackwardCompat_OldAuthLoads(t *testing.T) {
-	dir := testutil.RedirectConfigHome(t)
-
-	// Write old-format auth.json
-	oldDir := filepath.Join(dir, "cheasee-pi")
-	os.MkdirAll(oldDir, 0700)
-	oldPath := filepath.Join(oldDir, "auth.json")
-	oldContent := fmt.Sprintf(`{"api_key": "%s"}`, FakeAPIKey)
-	os.WriteFile(oldPath, []byte(oldContent), 0600)
-
-	cfg := &fileRepository{}
-	auth, err := cfg.Load(context.Background())
-	if err != nil {
-		t.Fatalf("Load of old format failed: %v", err)
-	}
-	if auth.APIKey != FakeAPIKey {
-		t.Errorf("expected API key %q, got %q", FakeAPIKey, auth.APIKey)
-	}
-	if auth.GitHubToken != "" {
-		t.Errorf("expected empty GitHubToken for old format, got %q", auth.GitHubToken)
-	}
-}
-
-func TestConfigBackwardCompat_RoundTripPreservesNewFields(t *testing.T) {
-	testutil.RedirectConfigHome(t)
-
-	cfg := &fileRepository{}
-	auth := &Auth{
-		APIKey:      FakeAPIKey,
-		GitHubToken: FakeGitHubToken,
-		GitHubUser:  "testuser",
-		RepoPath:    "/some/path",
-	}
-
-	if err := cfg.Save(context.Background(), auth); err != nil {
-		t.Fatalf("Save failed: %v", err)
-	}
-
-	loaded, err := cfg.Load(context.Background())
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-	if loaded.APIKey != FakeAPIKey {
-		t.Errorf("expected api_key %q, got %q", FakeAPIKey, loaded.APIKey)
-	}
-	if loaded.GitHubToken != FakeGitHubToken {
-		t.Errorf("expected GitHubToken %q, got %q", FakeGitHubToken, loaded.GitHubToken)
-	}
-	if loaded.GitHubUser != "testuser" {
-		t.Errorf("expected GitHubUser 'testuser', got %q", loaded.GitHubUser)
-	}
-	if loaded.RepoPath != "/some/path" {
-		t.Errorf("expected RepoPath '/some/path', got %q", loaded.RepoPath)
 	}
 }
 
@@ -628,14 +399,284 @@ func TestUpdateGitHubAuth_AtomicWritePermsAndRoundTrip(t *testing.T) {
 		t.Error("no .tmp file may remain after UpdateGitHubAuth")
 	}
 
-	auth, err := cfg.Load(context.Background())
+	token, err := cfg.GitHubToken(context.Background())
 	if err != nil {
-		t.Fatalf("Load round-trip: %v", err)
+		t.Fatalf("GitHubToken round-trip: %v", err)
 	}
-	if auth.GitHubToken != "new-token" || auth.GitHubUser != "octocat" || auth.RepoPath != "/ws" {
-		t.Errorf("Load round-trip shows the new token/user, got %+v", auth)
+	if token != "new-token" {
+		t.Errorf("GitHubToken round-trip shows the new token, got %q", token)
+	}
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "github_user"); got != "octocat" {
+		t.Errorf("github_user = %q, want octocat", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws" {
+		t.Errorf("repo_path = %q, want /ws", got)
 	}
 	if providers, err := cfg.ListProviders(context.Background()); err != nil || len(providers) != 0 {
 		t.Errorf("no providers should be present, got %v (err %v)", providers, err)
+	}
+}
+
+// ──────────────────────────────────────────────
+// GitHubToken / ListProviders error classes
+// ──────────────────────────────────────────────
+
+func TestGitHubToken_MissingFileAndAbsentKey(t *testing.T) {
+	// Missing file, absent key, and empty {} config all yield ("", nil) — the
+	// fail-to-fallback contract pi up's GH_TOKEN chain relies on.
+	testutil.RedirectConfigHome(t)
+	cfg := &fileRepository{}
+	tok, err := cfg.GitHubToken(context.Background())
+	if err != nil || tok != "" {
+		t.Fatalf("missing file: GitHubToken = (%q, %v), want (\"\", nil)", tok, err)
+	}
+
+	writeAuthFile(t, `{"openai":{"key":"k"}}`)
+	tok, err = cfg.GitHubToken(context.Background())
+	if err != nil || tok != "" {
+		t.Fatalf("absent key: GitHubToken = (%q, %v), want (\"\", nil)", tok, err)
+	}
+
+	writeAuthFile(t, `{}`)
+	tok, err = cfg.GitHubToken(context.Background())
+	if err != nil || tok != "" {
+		t.Fatalf("empty {}: GitHubToken = (%q, %v), want (\"\", nil)", tok, err)
+	}
+}
+
+func TestGitHubToken_PresentAndOldFlatFormatReadable(t *testing.T) {
+	writeAuthFile(t, `{"github_token":"tok-123","openai":{"key":"k"},"api_key":"legacy"}`)
+	cfg := &fileRepository{}
+	tok, err := cfg.GitHubToken(context.Background())
+	if err != nil {
+		t.Fatalf("GitHubToken: %v", err)
+	}
+	if tok != "tok-123" {
+		t.Errorf("GitHubToken = %q, want tok-123", tok)
+	}
+
+	// Old flat format {"api_key":…} + {"github_token":…} stays readable:
+	// ListProviders skips api_key (it is not a provider), GitHubToken
+	// returns the token, no error.
+	writeAuthFile(t, fmt.Sprintf(`{"api_key": %q, "github_token": "tok-456"}`, FakeAPIKey))
+	tok, err = cfg.GitHubToken(context.Background())
+	if err != nil || tok != "tok-456" {
+		t.Fatalf("old flat format: GitHubToken = (%q, %v), want tok-456", tok, err)
+	}
+	providers, err := cfg.ListProviders(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(providers) != 0 {
+		t.Errorf("api_key must not be listed as a provider, got %v", providers)
+	}
+}
+
+func TestGitHubToken_Malformed(t *testing.T) {
+	writeAuthFile(t, `{"github_token": 42}`) // non-string token
+	cfg := &fileRepository{}
+	if _, err := cfg.GitHubToken(context.Background()); err == nil {
+		t.Error("malformed github_token must error")
+	}
+}
+
+func TestListProvidersErrorClasses(t *testing.T) {
+	testutil.RedirectConfigHome(t)
+	cfg := &fileRepository{}
+	providers, err := cfg.ListProviders(context.Background())
+	if err != nil || len(providers) != 0 {
+		t.Fatalf("missing file: ListProviders = (%v, %v), want (empty map, nil)", providers, err)
+	}
+
+	writeAuthFile(t, `{invalid json}`)
+	if _, err := cfg.ListProviders(context.Background()); err == nil {
+		t.Error("invalid JSON must error")
+	}
+
+	dir := testutil.RedirectConfigHome(t)
+	path := filepath.Join(dir, "cheasee-pi", "auth.json")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cfg.ListProviders(context.Background()); err == nil {
+		t.Error("auth.json as a directory must error")
+	}
+	if _, err := cfg.GitHubToken(context.Background()); err == nil {
+		t.Error("auth.json as a directory must error for GitHubToken too")
+	}
+}
+
+// ──────────────────────────────────────────────
+// Malformed-no-overwrite across all four writers
+// ──────────────────────────────────────────────
+
+func TestWriters_MalformedExistingErrorsWithoutOverwrite(t *testing.T) {
+	// The no-overwrite-on-malformed contract holds for every writer via the
+	// updateAuth chokepoint (UpdateGitHubAuth has its own dedicated test).
+	writers := []struct {
+		name string
+		run  func(*fileRepository, context.Context) error
+	}{
+		{"AddProvider", func(cfg *fileRepository, ctx context.Context) error {
+			return cfg.AddProvider(ctx, "openai", "k")
+		}},
+		{"SetLegacyAuth", func(cfg *fileRepository, ctx context.Context) error {
+			return cfg.SetLegacyAuth(ctx, "opencode-go", "k", "/ws")
+		}},
+		{"RemoveProvider", func(cfg *fileRepository, ctx context.Context) error {
+			return cfg.RemoveProvider(ctx, "openai")
+		}},
+	}
+	for _, w := range writers {
+		t.Run(w.name, func(t *testing.T) {
+			writeAuthFile(t, `{invalid json}`)
+			before := authJSONBytes(t)
+			err := w.run(&fileRepository{}, context.Background())
+			if err == nil {
+				t.Fatal("expected error for malformed existing auth.json")
+			}
+			if !bytes.Equal(before, authJSONBytes(t)) {
+				t.Error("malformed auth.json must not be overwritten")
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────
+// Write shape: perms, dir mode, special chars, dedupe, reserved set
+// ──────────────────────────────────────────────
+
+func TestConfigWrite_CreatesDir0700File0600NoTmp(t *testing.T) {
+	// Pin the single dir mode after Save's 0700 died: writeRawMap's
+	// MkdirAll(dir, 0700) is the only creator, files are 0600 secrets, and
+	// no .tmp may remain after the atomic rename.
+	dir := testutil.RedirectConfigHome(t)
+	cfg := &fileRepository{}
+	if err := cfg.SetLegacyAuth(context.Background(), "opencode-go", FakeAPIKey, "/ws"); err != nil {
+		t.Fatalf("SetLegacyAuth: %v", err)
+	}
+
+	configDir := filepath.Join(dir, "cheasee-pi")
+	dirInfo, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatalf("config directory not created: %v", err)
+	}
+	if !dirInfo.IsDir() {
+		t.Error("config path is not a directory")
+	}
+	if dirInfo.Mode().Perm() != 0700 {
+		t.Errorf("config dir mode = %v, want 0700", dirInfo.Mode().Perm())
+	}
+
+	path := filepath.Join(configDir, "auth.json")
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat auth.json: %v", err)
+	}
+	if fileInfo.Mode().Perm() != 0600 {
+		t.Errorf("auth.json mode = %v, want 0600", fileInfo.Mode().Perm())
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Error("no .tmp file may remain after the patch write")
+	}
+}
+
+func TestConfigSpecialChars_RoundTrip(t *testing.T) {
+	// Special-char keys survive the raw-map round-trip through both writers:
+	// AddProvider → ListProviders and SetLegacyAuth → raw-map read (re-homes
+	// the old Save/Load special-chars contract).
+	specialKey := `key-"quoted"-with\backslash and ünicode`
+	testutil.RedirectConfigHome(t)
+	cfg := &fileRepository{}
+	ctx := context.Background()
+	if err := cfg.AddProvider(ctx, "openai", specialKey); err != nil {
+		t.Fatalf("AddProvider: %v", err)
+	}
+	providers, err := cfg.ListProviders(ctx)
+	if err != nil {
+		t.Fatalf("ListProviders: %v", err)
+	}
+	if providers["openai"] != specialKey {
+		t.Errorf("AddProvider round-trip failed: expected %q, got %q", specialKey, providers["openai"])
+	}
+
+	if err := cfg.SetLegacyAuth(ctx, "opencode-go", specialKey, "/ws with space"); err != nil {
+		t.Fatalf("SetLegacyAuth: %v", err)
+	}
+	raw := readAuthJSON(t)
+	if got := providerKey(t, raw, "opencode-go"); got != specialKey {
+		t.Errorf("SetLegacyAuth round-trip failed: expected %q, got %q", specialKey, got)
+	}
+	if got := authField(t, raw, "repo_path"); got != "/ws with space" {
+		t.Errorf("repo_path round-trip failed: expected %q, got %q", "/ws with space", got)
+	}
+}
+
+func TestDedupeKey(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"doubled half dedupes", "abcdabcd", "abcd"},
+		{"repeated short half dedupes", "abab", "ab"},
+		{"odd length no-op", "abcde", "abcde"},
+		{"prefix-unequal halves no-op", "abxxcd", "abxxcd"},
+		{"short key no-op", "abc", "abc"},
+		{"single char no-op", "a", "a"},
+	}
+	for _, tc := range cases {
+		if got := dedupeKey(tc.in); got != tc.want {
+			t.Errorf("dedupeKey(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDedupeKeyGuardOnWriters(t *testing.T) {
+	// The dedupe guard survives on both writers that take a key: AddProvider
+	// and SetLegacyAuth (the old Save guard died with the typed codec).
+	testutil.RedirectConfigHome(t)
+	cfg := &fileRepository{}
+	ctx := context.Background()
+	if err := cfg.AddProvider(ctx, "openai", "abcdabcd"); err != nil {
+		t.Fatal(err)
+	}
+	providers, err := cfg.ListProviders(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if providers["openai"] != "abcd" {
+		t.Errorf("AddProvider must dedupe pasted keys, got %q", providers["openai"])
+	}
+
+	if err := cfg.SetLegacyAuth(ctx, "opencode-go", "xyzxyz", "/ws"); err != nil {
+		t.Fatal(err)
+	}
+	raw := readAuthJSON(t)
+	if got := providerKey(t, raw, "opencode-go"); got != "xyz" {
+		t.Errorf("SetLegacyAuth provider entry must dedupe pasted keys, got %q", got)
+	}
+	if got := authField(t, raw, "api_key"); got != "xyz" {
+		t.Errorf("SetLegacyAuth api_key must dedupe pasted keys, got %q", got)
+	}
+}
+
+func TestIsReservedAuthKey(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		{"github_token", true},
+		{"github_user", true},
+		{"repo_path", true},
+		{"api_key", true},
+		{"openai", false},
+		{"opencode-go", false},
+		{"GitHub_Token", false}, // reserved set is case-sensitive
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isReservedAuthKey(tc.key); got != tc.want {
+			t.Errorf("isReservedAuthKey(%q) = %v, want %v", tc.key, got, tc.want)
+		}
 	}
 }

--- a/cmd/cheasee-pi/helpers_test.go
+++ b/cmd/cheasee-pi/helpers_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"os"
 	"os/exec"
@@ -330,16 +329,6 @@ func pinPassthroughEnv(t *testing.T) string {
 	}
 	t.Setenv("PATH", bin)
 	return xdg
-}
-
-// marshalAuth JSON-marshals auth, failing the test on error.
-func marshalAuth(t *testing.T, auth *Auth) []byte {
-	t.Helper()
-	data, err := json.Marshal(auth)
-	if err != nil {
-		t.Fatalf("Marshal failed: %v", err)
-	}
-	return data
 }
 
 // initDeps builds a runInit dependency set with the common test defaults:

--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -238,38 +238,43 @@ func runInit(ctx context.Context, deps InitDeps) error {
 	// Auth config is file I/O under the OS user config dir — no port.
 	cfg := &fileRepository{}
 
-	// Phase 4: Authentication
-	var auth *Auth
-	var err error
+	// Phase 4: Authentication. Credentials are threaded to the phase-7
+	// raw-map patch as scalars — either the legacy (provider, apiKey) pair
+	// or the GitHub (token, user) pair; usingLegacyAuth picks the patch
+	// shape (a typed *Auth round-trip would clobber other providers).
+	var (
+		legacyProvider, legacyAPIKey string
+		ghToken, ghUser              string
+		usingLegacyAuth              bool
+		err                          error
+	)
 	if deps.NoGitHub {
 		// Legacy path: API key only
 		fmt.Fprintf(os.Stderr, "  ℹ Using API-key-only mode.\n")
 		fmt.Fprintf(os.Stderr, "  ℹ Provider: %s\n", deps.Provider)
-		auth, err = runInitLegacy(ctx, cfg, deps.APIKey, deps.Provider)
+		legacyProvider, legacyAPIKey, err = runInitLegacy(ctx, deps.APIKey, deps.Provider)
 		if err != nil {
 			return err
 		}
-		auth.RepoPath = deps.Workdir
+		usingLegacyAuth = true
 	} else {
-		token, user, err := runInitAuth(ctx, deps.Ports.Auth)
+		var token, user string
+		token, user, err = runInitAuth(ctx, deps.Ports.Auth)
 		if err != nil {
 			if errors.Is(err, device.ErrUnsupported) {
 				fmt.Fprintf(os.Stderr, "  ⚠ GitHub OAuth device flow unavailable (the configured OAuth app may be invalid).\n")
 				fmt.Fprintf(os.Stderr, "  ℹ Falling back to API-key-only mode. Use --client-id to provide your own GitHub OAuth app.\n\n")
-				auth, err = runInitLegacy(ctx, cfg, deps.APIKey, deps.Provider)
+				legacyProvider, legacyAPIKey, err = runInitLegacy(ctx, deps.APIKey, deps.Provider)
 				if err != nil {
 					return err
 				}
-				auth.RepoPath = deps.Workdir
+				usingLegacyAuth = true
 			} else {
 				return fmt.Errorf("GitHub authentication failed: %w", err)
 			}
 		} else {
-			auth = &Auth{
-				GitHubToken: token,
-				GitHubUser:  user,
-				RepoPath:    deps.Workdir,
-			}
+			ghToken = token
+			ghUser = user
 		}
 	}
 
@@ -299,7 +304,6 @@ func runInit(ctx context.Context, deps InitDeps) error {
 		if err := gitCloneWorktree(ctx, repoURL, deps.Workdir); err != nil {
 			return err
 		}
-		auth.RepoPath = deps.Workdir
 	}
 
 	// Phases 6-9 (scaffold → skill repos → save auth → API key setup) run
@@ -312,7 +316,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 		// Phase 6: Scaffold cheasee-settings.json (never overwrites) — the
 		// canonical repo URL and resolved GitHub login are threaded in; the
 		// legacy --no-github path carries both empty.
-		if err := runInitScaffold(ctx, deps, repoURL, auth.GitHubUser); err != nil {
+		if err := runInitScaffold(ctx, deps, repoURL, ghUser); err != nil {
 			return fmt.Errorf("settings scaffold: %w", err)
 		}
 
@@ -322,9 +326,18 @@ func runInit(ctx context.Context, deps InitDeps) error {
 			return fmt.Errorf("skill repo setup: %w", err)
 		}
 
-		// Phase 7: Save auth config
-		if err := cfg.Save(ctx, auth); err != nil {
-			return fmt.Errorf("save auth config: %w", err)
+		// Phase 7: Save auth config — merge-safe raw-map patches on the single
+		// auth.json format (the typed codec that clobbered other providers is
+		// gone). Legacy: provider entry + api_key + repo_path; GitHub:
+		// github_token/github_user/repo_path with all providers preserved.
+		if usingLegacyAuth {
+			if err := cfg.SetLegacyAuth(ctx, legacyProvider, legacyAPIKey, deps.Workdir); err != nil {
+				return fmt.Errorf("save auth config: %w", err)
+			}
+		} else {
+			if err := cfg.UpdateGitHubAuth(ctx, ghToken, ghUser, deps.Workdir); err != nil {
+				return fmt.Errorf("save auth config: %w", err)
+			}
 		}
 
 		path, _ := cfg.Path()

--- a/cmd/cheasee-pi/init_auth.go
+++ b/cmd/cheasee-pi/init_auth.go
@@ -198,18 +198,19 @@ func runReauth(ctx context.Context, deps InitDeps) error {
 	return nil
 }
 
-// runInitLegacy is an auth-only helper that returns an *Auth with the API key.
-// It does NOT save, extract, or render — the orchestrator handles those.
-func runInitLegacy(ctx context.Context, cfg *fileRepository, apiKey string, provider string) (*Auth, error) {
+// runInitLegacy is an auth-only helper that returns the provider and API key
+// as scalars. It does NOT save, extract, or render — the orchestrator
+// threads them into the phase-7 SetLegacyAuth raw-map patch.
+func runInitLegacy(ctx context.Context, apiKey string, provider string) (string, string, error) {
 	if apiKey == "" {
 		key, err := promptAPIKey(provider)
 		if err != nil {
-			return nil, fmt.Errorf("API key prompt failed: %w", err)
+			return "", "", fmt.Errorf("API key prompt failed: %w", err)
 		}
 		apiKey = key
 	}
 
-	return &Auth{APIKey: apiKey, Provider: provider}, nil
+	return provider, apiKey, nil
 }
 
 // promptAPIKey prompts the user for an API key (legacy).

--- a/cmd/cheasee-pi/init_auth_test.go
+++ b/cmd/cheasee-pi/init_auth_test.go
@@ -242,12 +242,12 @@ func TestRunInit_FullFlow(t *testing.T) {
 			t.Errorf(".pi/%s missing after full flow: %v", dir, err)
 		}
 	}
-	auth := loadAuthJSON(t)
-	if auth.GitHubUser != MockGitHubUser {
-		t.Errorf("auth.json github_user = %q, want %q", auth.GitHubUser, MockGitHubUser)
+	authRaw := readAuthJSON(t)
+	if got := authField(t, authRaw, "github_user"); got != MockGitHubUser {
+		t.Errorf("auth.json github_user = %q, want %q", got, MockGitHubUser)
 	}
-	if auth.GitHubToken != FakeGitHubToken {
-		t.Errorf("auth.json github_token = %q, want %q", auth.GitHubToken, FakeGitHubToken)
+	if got := authField(t, authRaw, "github_token"); got != FakeGitHubToken {
+		t.Errorf("auth.json github_token = %q, want %q", got, FakeGitHubToken)
 	}
 }
 
@@ -284,12 +284,15 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 	if !authJSONExists(t) {
 		t.Error("Save should be called on legacy path")
 	}
-	auth := loadAuthJSON(t)
-	if auth.APIKey != FakeAPIKey {
-		t.Errorf("expected API key %q, got %q", FakeAPIKey, auth.APIKey)
+	authRaw := readAuthJSON(t)
+	if got := providerKey(t, authRaw, "opencode-go"); got != FakeAPIKey {
+		t.Errorf("expected API key %q, got %q", FakeAPIKey, got)
 	}
-	if auth.RepoPath != workdir {
-		t.Errorf("expected RepoPath %q, got %q", workdir, auth.RepoPath)
+	if got := authField(t, authRaw, "repo_path"); got != workdir {
+		t.Errorf("expected repo_path %q, got %q", workdir, got)
+	}
+	if got := authField(t, authRaw, "api_key"); got != FakeAPIKey {
+		t.Errorf("expected flat api_key %q, got %q", FakeAPIKey, got)
 	}
 	// Legacy path: the repo URL is never threaded, so no repository section —
 	// but the .pi skeleton still exists (pi needs the dirs on both paths).
@@ -304,20 +307,19 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 	}
 }
 
-func TestRunInitLegacy_ReturnsAuth(t *testing.T) {
-	// runInitLegacy is auth-only: returns *Auth, does NOT save/extract/render
-	auth, err := runInitLegacy(context.Background(), &fileRepository{}, FakeAPIKey, "opencode-go")
+func TestRunInitLegacy_ReturnsScalars(t *testing.T) {
+	// runInitLegacy is auth-only: returns (provider, apiKey) scalars, does
+	// NOT save/extract/render — the orchestrator threads them into the
+	// phase-7 SetLegacyAuth raw-map patch.
+	provider, apiKey, err := runInitLegacy(context.Background(), FakeAPIKey, "opencode-go")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if auth.APIKey != FakeAPIKey {
-		t.Errorf("expected API key %q, got %q", FakeAPIKey, auth.APIKey)
+	if apiKey != FakeAPIKey {
+		t.Errorf("expected API key %q, got %q", FakeAPIKey, apiKey)
 	}
-	if auth.RepoPath != "" {
-		t.Errorf("expected empty RepoPath from runInitLegacy (orchestrator fills it), got %q", auth.RepoPath)
-	}
-	if auth.GitHubToken != "" {
-		t.Errorf("expected empty GitHubToken, got %q", auth.GitHubToken)
+	if provider != "opencode-go" {
+		t.Errorf("expected provider %q, got %q", "opencode-go", provider)
 	}
 }
 
@@ -411,15 +413,15 @@ func TestRunReauth_RedoesAuthAndPreservesProviders(t *testing.T) {
 		t.Errorf("reauth must not create <parent>/.bare: %v", statErr)
 	}
 
-	auth := loadAuthJSON(t)
-	if auth.GitHubToken != FakeGitHubToken {
-		t.Errorf("expected fresh github_token %q, got %q", FakeGitHubToken, auth.GitHubToken)
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "github_token"); got != FakeGitHubToken {
+		t.Errorf("expected fresh github_token %q, got %q", FakeGitHubToken, got)
 	}
-	if auth.GitHubUser != "octocat" {
-		t.Errorf("expected github_user %q, got %q", "octocat", auth.GitHubUser)
+	if got := authField(t, raw, "github_user"); got != "octocat" {
+		t.Errorf("expected github_user %q, got %q", "octocat", got)
 	}
-	if auth.RepoPath != workdir {
-		t.Errorf("expected repo_path %q, got %q", workdir, auth.RepoPath)
+	if got := authField(t, raw, "repo_path"); got != workdir {
+		t.Errorf("expected repo_path %q, got %q", workdir, got)
 	}
 	providers, err := (&fileRepository{}).ListProviders(context.Background())
 	if err != nil {
@@ -468,9 +470,15 @@ func TestRunReauth_NoInputSkipsProviderPhase(t *testing.T) {
 	if confirmCalled {
 		t.Error("--no-input must not call ConfirmFn (the flag is the confirmation)")
 	}
-	auth := loadAuthJSON(t)
-	if auth.GitHubToken != FakeGitHubToken || auth.GitHubUser != "octocat" || auth.RepoPath != workdir {
-		t.Errorf("auth.json must carry the fresh github fields, got %+v", auth)
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "github_token"); got != FakeGitHubToken {
+		t.Errorf("auth.json must carry the fresh github_token, got %q", got)
+	}
+	if got := authField(t, raw, "github_user"); got != "octocat" {
+		t.Errorf("auth.json must carry the fresh github_user, got %q", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != workdir {
+		t.Errorf("auth.json must carry the fresh repo_path, got %q", got)
 	}
 }
 
@@ -491,9 +499,15 @@ func TestRunReauth_CreatesAuthJSONWhenMissing(t *testing.T) {
 	if !authJSONExists(t) {
 		t.Fatal("reauth must create auth.json when missing")
 	}
-	auth := loadAuthJSON(t)
-	if auth.GitHubToken != FakeGitHubToken || auth.GitHubUser != "octocat" || auth.RepoPath != workdir {
-		t.Errorf("expected fresh github fields, got %+v", auth)
+	raw := readAuthJSON(t)
+	if got := authField(t, raw, "github_token"); got != FakeGitHubToken {
+		t.Errorf("expected fresh github_token, got %q", got)
+	}
+	if got := authField(t, raw, "github_user"); got != "octocat" {
+		t.Errorf("expected fresh github_user, got %q", got)
+	}
+	if got := authField(t, raw, "repo_path"); got != workdir {
+		t.Errorf("expected fresh repo_path, got %q", got)
 	}
 }
 

--- a/cmd/cheasee-pi/init_helpers_test.go
+++ b/cmd/cheasee-pi/init_helpers_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"context"
+	"encoding/json"
 	"os"
 	"testing"
 )
@@ -17,14 +17,48 @@ func authJSONExists(t *testing.T) bool {
 	return err == nil
 }
 
-func loadAuthJSON(t *testing.T) *Auth {
+// readAuthJSON returns the raw auth.json contents for the current config
+// home decoded into a map, failing the test if the file is missing or
+// malformed. The typed codec is gone, so tests read the raw-map dialect.
+func readAuthJSON(t *testing.T) map[string]json.RawMessage {
 	t.Helper()
 	cfg := &fileRepository{}
-	auth, err := cfg.Load(context.Background())
+	path, err := cfg.Path()
 	if err != nil {
-		t.Fatalf("load auth.json: %v", err)
+		t.Fatalf("auth path: %v", err)
 	}
-	return auth
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read auth.json: %v", err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("parse auth.json: %v", err)
+	}
+	return raw
+}
+
+// authField returns the string value of a top-level auth.json field.
+func authField(t *testing.T, raw map[string]json.RawMessage, key string) string {
+	t.Helper()
+	var s string
+	if err := json.Unmarshal(raw[key], &s); err != nil {
+		t.Fatalf("auth.json %q: %v", key, err)
+	}
+	return s
+}
+
+// providerKey returns the key of a provider entry ({"<provider>": {"key": …}})
+// from a raw auth.json map.
+func providerKey(t *testing.T, raw map[string]json.RawMessage, provider string) string {
+	t.Helper()
+	var entry struct {
+		Key string `json:"key"`
+	}
+	if err := json.Unmarshal(raw[provider], &entry); err != nil {
+		t.Fatalf("auth.json provider %q: %v", provider, err)
+	}
+	return entry.Key
 }
 
 // authJSONBytes returns the raw auth.json contents for the current config

--- a/cmd/cheasee-pi/init_split_test.go
+++ b/cmd/cheasee-pi/init_split_test.go
@@ -216,11 +216,15 @@ var testSplitFiles = []string{
 // The rest of the original init_test.go helpers moved to helpers_test.go
 // (mocks, seam stubs, initDeps) and testutil/ (SetGitConfig,
 // RedirectConfigHome, ReadEnvFile, ReadSettingsRaw, CaptureStderr) when main
-// consolidated test scaffolding; only the auth helpers remain.
+// consolidated test scaffolding; only the auth helpers remain (loadAuthJSON
+// became readAuthJSON when the typed codec died — tests now read the
+// raw-map dialect).
 var initHelperDecls = map[string]string{
 	"func:authJSONExists": "init_helpers_test.go",
 	"func:authJSONBytes":  "init_helpers_test.go",
-	"func:loadAuthJSON":   "init_helpers_test.go",
+	"func:readAuthJSON":   "init_helpers_test.go",
+	"func:authField":      "init_helpers_test.go",
+	"func:providerKey":    "init_helpers_test.go",
 }
 
 // runInitFlowDecls pins the TestRunInit_* decls (colliding prefix) by flow
@@ -262,22 +266,12 @@ var testSplitRules = []prefixRule{
 
 // mergedTestDecls are the decls moved from init_test.go into existing test
 // files. The check is one-directional: the moved decls must be present, but
-// pre-existing decls in those files are not part of the inventory.
+// pre-existing decls in those files are not part of the inventory. All
+// config_test.go entries were removed when the typed dialect (Auth +
+// MarshalJSON/UnmarshalJSON/Load/Save) collapsed into the raw-map module —
+// the codec pins and backward-compat Load tests died with it and their
+// contracts re-homed against GitHubToken/ListProviders.
 var mergedTestDecls = map[string][]string{
-	"config_test.go": {
-		"func:TestAuthPerProvider_MarshalHasProviderSlot",
-		"func:TestAuthPerProvider_MarshalNoProviderWritesFlat",
-		"func:TestAuthPerProvider_MarshalEmptyProviderNoKey",
-		"func:TestAuthPerProvider_UnmarshalProviderFormat",
-		"func:TestAuthPerProvider_UnmarshalFlatFormat",
-		"func:TestAuthPerProvider_SaveWritesJqParseableOutput",
-		"func:TestAuthPerProvider_UnmarshalEmptyObject",
-		"func:TestAuthPerProvider_UnmarshalMalformedJSON",
-		"func:TestAuthPerProvider_RoundTripWithProvider",
-		"func:TestAuthPerProvider_MarshalOmitGitHubTokenWhenEmpty",
-		"func:TestConfigBackwardCompat_OldAuthLoads",
-		"func:TestConfigBackwardCompat_RoundTripPreservesNewFields",
-	},
 	"embed_test.go": {
 		"func:TestExtract_SkipsPiSubtree",
 	},

--- a/cmd/cheasee-pi/init_usecase_test.go
+++ b/cmd/cheasee-pi/init_usecase_test.go
@@ -90,7 +90,7 @@ func TestInitUseCase_NoDockerCheckFlag(t *testing.T) {
 	if !authJSONExists(t) {
 		t.Error("Save should be called when --no-docker-check is set")
 	}
-	if got := loadAuthJSON(t).APIKey; got != FakeAPIKey {
+	if got := providerKey(t, readAuthJSON(t), "opencode-go"); got != FakeAPIKey {
 		t.Errorf("expected saved key %q, got %q", FakeAPIKey, got)
 	}
 }
@@ -110,7 +110,7 @@ func TestInitUseCase_HappyPathWithAPIKeyFlag(t *testing.T) {
 	if !authJSONExists(t) {
 		t.Error("Save should be called on happy path")
 	}
-	if got := loadAuthJSON(t).APIKey; got != FakeAPIKey {
+	if got := providerKey(t, readAuthJSON(t), "opencode-go"); got != FakeAPIKey {
 		t.Errorf("expected API key %q, got %q", FakeAPIKey, got)
 	}
 }

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -491,8 +491,8 @@ func buildEnvFlags(ctx context.Context) (map[string]string, error) {
 	// back to the process env, then gh's credential store.
 	// ponytail: single-precedence if-chain; revisit if multiple GitHub
 	// identities per host become a real use case.
-	if auth, err := repo.Load(ctx); err == nil && auth.GitHubToken != "" {
-		envMap["GH_TOKEN"] = auth.GitHubToken
+	if tok, err := repo.GitHubToken(ctx); err == nil && tok != "" {
+		envMap["GH_TOKEN"] = tok
 	} else if val := os.Getenv("GH_TOKEN"); val != "" {
 		envMap["GH_TOKEN"] = val
 	} else if token, err := extractGHToken(); err == nil && token != "" {


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1593

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 3m 25s | 162.1K | 28 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 2m 9s | 50.5K | 22 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 27s | 55.6K | 27 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 6m 36s | 142.2K | 67 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 6m 15s | 49.9K | 22 | kimi-k3 |

**Total:** 5 runs · 19m 51s · 460.4K tokens · 166 tool calls · 8 failed (5%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1593
Closes #1593