### PR TITLE
feat(#1548): agent/output.ts: split validateAgentOutput nested validation into per-field helpers

### DIFF
--- a/.pi/extensions/supervisor/agent/validation.ts
+++ b/.pi/extensions/supervisor/agent/validation.ts
@@ -11,6 +11,94 @@ interface ValidationResult {
 	errors: string[];
 }
 
+// ─── Nested validation helpers (extracted from validateAgentOutput, #1548) ──
+// Each helper owns one nested block, flattened to guard clauses (≤2 control-
+// flow nesting levels). They mutate the shared errors array in call order so
+// push order across fields is preserved byte-for-byte.
+
+function validateAuditScore(value: unknown, errors: string[]): void {
+	// absent/null auditScore passes
+	if (value === undefined || value === null) {
+		return;
+	}
+	if (typeof value !== "object" || Array.isArray(value)) {
+		errors.push("'auditScore' must be an object with 'passing' and 'total' fields");
+		return;
+	}
+	const score = value as Record<string, unknown>;
+	if (typeof score.passing !== "number" || typeof score.total !== "number") {
+		errors.push("'auditScore.passing' and 'auditScore.total' must be numbers");
+		return;
+	}
+	// Two independent ifs, never else-if: negative inputs where passing > total
+	// must push BOTH errors (verified pre-refactor behavior).
+	if (score.passing < 0 || score.total < 0) {
+		errors.push("'auditScore.passing' and 'auditScore.total' must be non-negative");
+	}
+	if (score.passing > score.total) {
+		errors.push(
+			`'auditScore.passing' (${score.passing}) cannot exceed 'auditScore.total' (${score.total})`,
+		);
+	}
+}
+
+function validateFinding(item: unknown, index: number, errors: string[]): void {
+	if (typeof item !== "object" || item === null) {
+		errors.push(`findings[${index}] must be an object`);
+		return; // maps the loop `continue` — skip this entry's remaining field checks
+	}
+	const finding = item as Record<string, unknown>;
+
+	// severity
+	if (
+		typeof finding.severity !== "string" ||
+		!VALID_SEVERITIES.has(finding.severity as FindingSeverity)
+	) {
+		errors.push(
+			`findings[${index}].severity must be one of: ${Array.from(VALID_SEVERITIES).join(", ")}`,
+		);
+	}
+
+	// dimension
+	if (typeof finding.dimension !== "string") {
+		errors.push(`findings[${index}].dimension must be a string`);
+	}
+
+	// symptom, consequence, remedy are required strings
+	if (typeof finding.symptom !== "string" || finding.symptom.trim() === "") {
+		errors.push(`findings[${index}].symptom is required and must be a non-empty string`);
+	}
+	if (typeof finding.consequence !== "string" || finding.consequence.trim() === "") {
+		errors.push(`findings[${index}].consequence is required and must be a non-empty string`);
+	}
+	if (typeof finding.remedy !== "string" || finding.remedy.trim() === "") {
+		errors.push(`findings[${index}].remedy is required and must be a non-empty string`);
+	}
+
+	// location (optional)
+	if (
+		finding.location !== undefined &&
+		finding.location !== null &&
+		typeof finding.location !== "string"
+	) {
+		errors.push(`findings[${index}].location must be a string if provided`);
+	}
+}
+
+function validateFindings(value: unknown, errors: string[]): void {
+	// absent/null findings passes
+	if (value === undefined || value === null) {
+		return;
+	}
+	if (!Array.isArray(value)) {
+		errors.push("'findings' must be an array if provided");
+		return;
+	}
+	for (let i = 0; i < value.length; i++) {
+		validateFinding(value[i], i, errors);
+	}
+}
+
 function validateAgentOutput(data: Record<string, unknown>): ValidationResult {
 	const errors: string[] = [];
 
@@ -61,77 +149,11 @@ function validateAgentOutput(data: Record<string, unknown>): ValidationResult {
 		errors.push("'summary' must be a string if provided");
 	}
 
-	// auditScore validation
-	if (data.auditScore !== undefined && data.auditScore !== null) {
-		if (typeof data.auditScore !== "object" || Array.isArray(data.auditScore)) {
-			errors.push("'auditScore' must be an object with 'passing' and 'total' fields");
-		} else {
-			const score = data.auditScore as Record<string, unknown>;
-			if (typeof score.passing !== "number" || typeof score.total !== "number") {
-				errors.push("'auditScore.passing' and 'auditScore.total' must be numbers");
-			} else {
-				if (score.passing < 0 || score.total < 0) {
-					errors.push("'auditScore.passing' and 'auditScore.total' must be non-negative");
-				}
-				if (score.passing > score.total) {
-					errors.push(
-						`'auditScore.passing' (${score.passing}) cannot exceed 'auditScore.total' (${score.total})`,
-					);
-				}
-			}
-		}
-	}
+	// auditScore validation — nested checks live in validateAuditScore
+	validateAuditScore(data.auditScore, errors);
 
-	// findings validation
-	if (data.findings !== undefined && data.findings !== null) {
-		if (!Array.isArray(data.findings)) {
-			errors.push("'findings' must be an array if provided");
-		} else {
-			for (let i = 0; i < data.findings.length; i++) {
-				const f = data.findings[i];
-				if (typeof f !== "object" || f === null) {
-					errors.push(`findings[${i}] must be an object`);
-					continue;
-				}
-				const finding = f as Record<string, unknown>;
-
-				// severity
-				if (
-					typeof finding.severity !== "string" ||
-					!VALID_SEVERITIES.has(finding.severity as FindingSeverity)
-				) {
-					errors.push(
-						`findings[${i}].severity must be one of: ${Array.from(VALID_SEVERITIES).join(", ")}`,
-					);
-				}
-
-				// dimension
-				if (typeof finding.dimension !== "string") {
-					errors.push(`findings[${i}].dimension must be a string`);
-				}
-
-				// symptom, consequence, remedy are required strings
-				if (typeof finding.symptom !== "string" || finding.symptom.trim() === "") {
-					errors.push(`findings[${i}].symptom is required and must be a non-empty string`);
-				}
-				if (typeof finding.consequence !== "string" || finding.consequence.trim() === "") {
-					errors.push(`findings[${i}].consequence is required and must be a non-empty string`);
-				}
-				if (typeof finding.remedy !== "string" || finding.remedy.trim() === "") {
-					errors.push(`findings[${i}].remedy is required and must be a non-empty string`);
-				}
-
-				// location (optional)
-				if (
-					finding.location !== undefined &&
-					finding.location !== null &&
-					typeof finding.location !== "string"
-				) {
-					errors.push(`findings[${i}].location must be a string if provided`);
-				}
-			}
-		}
-	}
+	// findings validation — nested checks live in validateFindings/validateFinding
+	validateFindings(data.findings, errors);
 
 	// targetStatus (optional, must be string if present)
 	if (

--- a/.pi/extensions/supervisor/test/agent-output.test.mts
+++ b/.pi/extensions/supervisor/test/agent-output.test.mts
@@ -269,6 +269,25 @@ describe("parseAgentOutput — schema validation", () => {
 		const result = parseAgentOutput(input);
 		assert.ok(isFailedParse(result));
 	});
+
+	it("pins exact FailedParse.error string built from errors.join('; ') (#1548 Phase 3)", () => {
+		// Union payload: missing agentName + dual-error auditScore + non-object finding —
+		// pushes scalar → auditScore → findings in exact order into the agent-facing string.
+		const input = JSON.stringify({
+			action: "COMPLETE",
+			auditScore: { passing: -1, total: -2 },
+			findings: [42],
+		});
+		const result = parseAgentOutput(input);
+		assert.ok(isFailedParse(result));
+		assert.equal(
+			(result as FailedParse).error,
+			"Agent output schema validation failed: Missing required field: 'agentName'; " +
+				"'auditScore.passing' and 'auditScore.total' must be non-negative; " +
+				"'auditScore.passing' (-1) cannot exceed 'auditScore.total' (-2); " +
+				"findings[0] must be an object",
+		);
+	});
 });
 
 // ─── Tests: parseAgentOutput — JSON in code fences ────────────────

--- a/.pi/extensions/supervisor/test/validation.test.mts
+++ b/.pi/extensions/supervisor/test/validation.test.mts
@@ -8,6 +8,9 @@
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { validateAgentOutput, VALID_SEVERITIES } from "../agent/validation.ts";
 
 const completeRecord = {
@@ -145,5 +148,346 @@ describe("validateAgentOutput — findings entries", () => {
 
 	it("VALID_SEVERITIES matches the audit severity enum", () => {
 		assert.deepEqual(Array.from(VALID_SEVERITIES).sort(), ["critical", "suggestion", "warning"]);
+	});
+});
+
+// ─── Golden-master characterization matrix (#1548) ─────────────────────
+// Full-array equality on { valid, errors } — byte-exact strings AND push
+// order. Expectation values below were generated from pre-refactor code;
+// guard-clause extraction must preserve them (issue #1548 principle 1).
+
+const base = { action: "COMPLETE", agentName: "a" };
+const EXCEED = "'auditScore.passing' (-1) cannot exceed 'auditScore.total' (-2)";
+
+describe("validateAgentOutput — golden-master matrix (characterization)", () => {
+	const rows: [string, Record<string, unknown>, { valid: boolean; errors: string[] }][] = [
+		[
+			"dual-negative auditScore co-fires both errors in fixed order",
+			{ ...base, auditScore: { passing: -1, total: -2 } },
+			{
+				valid: false,
+				errors: [
+					"'auditScore.passing' and 'auditScore.total' must be non-negative",
+					EXCEED,
+				],
+			},
+		],
+		[
+			"NaN passing passes (typeof number quirk)",
+			{ ...base, auditScore: { passing: NaN, total: 5 } },
+			{ valid: true, errors: [] },
+		],
+		[
+			"auditScore null passes (helper keeps internal guard)",
+			{ ...base, auditScore: null },
+			{ valid: true, errors: [] },
+		],
+		[
+			"findings null passes",
+			{ ...base, findings: null },
+			{ valid: true, errors: [] },
+		],
+		[
+			"zero-zero auditScore passes (type checks, not truthiness)",
+			{ ...base, auditScore: { passing: 0, total: 0 } },
+			{ valid: true, errors: [] },
+		],
+		[
+			"passing === total is valid (equality boundary)",
+			{ ...base, auditScore: { passing: 3, total: 3 } },
+			{ valid: true, errors: [] },
+		],
+		[
+			"passing > total pushes only cannot-exceed",
+			{ ...base, auditScore: { passing: 5, total: 3 } },
+			{ valid: false, errors: ["'auditScore.passing' (5) cannot exceed 'auditScore.total' (3)"] },
+		],
+		[
+			"fractional passing/total valid",
+			{ ...base, auditScore: { passing: 1.5, total: 2 } },
+			{ valid: true, errors: [] },
+		],
+		[
+			"fractional cannot-exceed interpolates verbatim",
+			{ ...base, auditScore: { passing: 2, total: 1.5 } },
+			{ valid: false, errors: ["'auditScore.passing' (2) cannot exceed 'auditScore.total' (1.5)"] },
+		],
+		[
+			"string passing → single numbers error",
+			{ ...base, auditScore: { passing: "5", total: 5 } },
+			{ valid: false, errors: ["'auditScore.passing' and 'auditScore.total' must be numbers"] },
+		],
+		[
+			"missing total → single numbers error",
+			{ ...base, auditScore: { passing: 1 } },
+			{ valid: false, errors: ["'auditScore.passing' and 'auditScore.total' must be numbers"] },
+		],
+		[
+			"auditScore array → must-be-object error",
+			{ ...base, auditScore: [1, 2] },
+			{ valid: false, errors: ["'auditScore' must be an object with 'passing' and 'total' fields"] },
+		],
+		[
+			"auditScore string → must-be-object error",
+			{ ...base, auditScore: "x" },
+			{ valid: false, errors: ["'auditScore' must be an object with 'passing' and 'total' fields"] },
+		],
+		[
+			"findings 42 → must-be-array error",
+			{ ...base, findings: 42 },
+			{ valid: false, errors: ["'findings' must be an array if provided"] },
+		],
+		[
+			"findings string → must-be-array error",
+			{ ...base, findings: "nope" },
+			{ valid: false, errors: ["'findings' must be an array if provided"] },
+		],
+		[
+			"non-object entry 42 → exactly one object error, fields skipped",
+			{ ...base, findings: [42] },
+			{ valid: false, errors: ["findings[0] must be an object"] },
+		],
+		[
+			"null entry → exactly one object error, fields skipped",
+			{ ...base, findings: [null] },
+			{ valid: false, errors: ["findings[0] must be an object"] },
+		],
+		[
+			"fully-bad entry pushes 5 errors in canonical order",
+			{ ...base, findings: [{ severity: "fatal", dimension: 7, symptom: "  ", consequence: 0, remedy: "" }] },
+			{
+				valid: false,
+				errors: [
+					"findings[0].severity must be one of: critical, warning, suggestion",
+					"findings[0].dimension must be a string",
+					"findings[0].symptom is required and must be a non-empty string",
+					"findings[0].consequence is required and must be a non-empty string",
+					"findings[0].remedy is required and must be a non-empty string",
+				],
+			},
+		],
+		[
+			"bare entry (severity only) → 4 errors without severity error",
+			{ ...base, findings: [{ severity: "warning" }] },
+			{
+				valid: false,
+				errors: [
+					"findings[0].dimension must be a string",
+					"findings[0].symptom is required and must be a non-empty string",
+					"findings[0].consequence is required and must be a non-empty string",
+					"findings[0].remedy is required and must be a non-empty string",
+				],
+			},
+		],
+		[
+			"non-string location → per-index location error",
+			{ ...base, findings: [{ severity: "warning", dimension: "d", symptom: "s", consequence: "c", remedy: "r", location: 42 }] },
+			{ valid: false, errors: ["findings[0].location must be a string if provided"] },
+		],
+		[
+			"null location valid",
+			{ ...base, findings: [{ severity: "warning", dimension: "d", symptom: "s", consequence: "c", remedy: "r", location: null }] },
+			{ valid: true, errors: [] },
+		],
+		[
+			"omitted location valid",
+			{ ...base, findings: [{ severity: "warning", dimension: "d", symptom: "s", consequence: "c", remedy: "r" }] },
+			{ valid: true, errors: [] },
+		],
+		[
+			"multi-index array: index interpolation and valid-entry skip",
+			{
+				...base,
+				findings: [
+					"x",
+					{ severity: "critical", dimension: "d", symptom: "s", consequence: "c", remedy: "r" },
+					{ severity: "nope", dimension: "d2", symptom: "", consequence: "c2", remedy: "r2" },
+				],
+			},
+			{
+				valid: false,
+				errors: [
+					"findings[0] must be an object",
+					"findings[2].severity must be one of: critical, warning, suggestion",
+					"findings[2].symptom is required and must be a non-empty string",
+				],
+			},
+		],
+		[
+			"union row pins helper call order scalar → auditScore → findings",
+			{
+				action: "COMPLETE",
+				agentName: null,
+				auditScore: { passing: -2, total: -1 },
+				findings: [{ severity: "ok", dimension: "d", symptom: "s", consequence: "c", remedy: "r" }],
+			},
+			{
+				valid: false,
+				errors: [
+					"Missing required field: 'agentName'",
+					"'auditScore.passing' and 'auditScore.total' must be non-negative",
+					"findings[0].severity must be one of: critical, warning, suggestion",
+				],
+			},
+		],
+	];
+
+	for (const [name, data, expected] of rows) {
+		it(name, () => {
+			assert.deepEqual(validateAgentOutput(data), expected);
+		});
+	}
+});
+
+// ─── Named quirk locks (#1548 Phase 2) ─────────────────────────────────
+// Each non-obvious behavior gets its own name so future strictness
+// changes can find and (deliberately) break them.
+
+describe("validateAgentOutput — quirk locks", () => {
+	it("dual-error co-fire: negative passing AND passing>total push two errors, never else-if", () => {
+		assert.deepEqual(validateAgentOutput({ ...base, auditScore: { passing: -1, total: -2 } }), {
+			valid: false,
+			errors: [
+				"'auditScore.passing' and 'auditScore.total' must be non-negative",
+				EXCEED,
+			],
+		});
+	});
+
+	it("NaN passing passes because typeof NaN === 'number' and NaN comparisons are false", () => {
+		assert.deepEqual(validateAgentOutput({ ...base, auditScore: { passing: NaN, total: 5 } }), {
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it("auditScore:null and findings:null pass with zero errors", () => {
+		assert.deepEqual(validateAgentOutput({ ...base, auditScore: null }), { valid: true, errors: [] });
+		assert.deepEqual(validateAgentOutput({ ...base, findings: null }), { valid: true, errors: [] });
+	});
+
+	it("zero-zero auditScore passes — validation is type-based, not truthiness", () => {
+		assert.deepEqual(validateAgentOutput({ ...base, auditScore: { passing: 0, total: 0 } }), {
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it("passing === total is valid (> not >=)", () => {
+		assert.deepEqual(validateAgentOutput({ ...base, auditScore: { passing: 3, total: 3 } }), {
+			valid: true,
+			errors: [],
+		});
+	});
+
+	it("continue-skip: non-object entry skips remaining field checks for that entry only", () => {
+		assert.deepEqual(
+			validateAgentOutput({
+				...base,
+				findings: [null, { severity: "bad", dimension: "d", symptom: "s", consequence: "c", remedy: "r" }],
+			}),
+			{
+				valid: false,
+				errors: [
+					"findings[0] must be an object",
+					"findings[1].severity must be one of: critical, warning, suggestion",
+				],
+			},
+		);
+	});
+});
+
+// ─── White-box structure pin (#1548 Phase 4) ────────────────────────────
+// Guards the refactor's shape (issue acceptance criterion: nested blocks
+// split into helper functions, each ≤ 2 control-flow nesting levels) via
+// source assertions — same precedent as output-facade.test.mts.
+
+describe("validation.ts — refactor structure (#1548)", () => {
+	const source = readFileSync(
+		resolve(dirname(fileURLToPath(import.meta.url)), "..", "agent/validation.ts"),
+		"utf8",
+	);
+
+	const HELPER_SIGNATURES = [
+		"function validateAuditScore(value: unknown, errors: string[]): void {",
+		"function validateFindings(value: unknown, errors: string[]): void {",
+		"function validateFinding(item: unknown, index: number, errors: string[]): void {",
+	] as const;
+
+	// Strip strings, template literals, and comments so brace counting only
+	// sees structural braces (template `${...}` interpolations would inflate it).
+	function structuralSource(src: string): string {
+		return src
+			.replace(/`[^`]*`/g, "")
+			.replace(/"(?:\\.|[^\\"])*"/g, "")
+			.replace(/'(?:\\.|[^\\'])*'/g, "")
+			.replace(/\/\*[\s\S]*?\*\//g, "")
+			.replace(/\/\/[^\n]*/g, "");
+	}
+
+	function functionBody(src: string, signature: string): string {
+		const sigIdx = src.indexOf(signature);
+		assert.ok(sigIdx >= 0, `${signature} must exist`);
+		const open = src.indexOf("{", sigIdx);
+		let depth = 0;
+		for (let i = open; i < src.length; i++) {
+			if (src[i] === "{") depth++;
+			else if (src[i] === "}") {
+				depth--;
+				if (depth === 0) return src.slice(open + 1, i);
+			}
+		}
+		assert.fail(`${signature} body never closes`);
+	}
+
+	function maxBraceDepth(body: string): number {
+		const clean = structuralSource(body);
+		let depth = 0;
+		let max = 0;
+		for (const ch of clean) {
+			if (ch === "{") {
+				depth++;
+				max = Math.max(max, depth);
+			} else if (ch === "}") depth--;
+		}
+		return max;
+	}
+
+	it("defines the three per-field helpers module-private with canonical signatures", () => {
+		for (const sig of HELPER_SIGNATURES) {
+			assert.ok(source.includes(sig), `${sig} must be defined`);
+		}
+		// Module-private: never listed in any export statement
+		assert.ok(source.includes("export { validateAgentOutput, VALID_SEVERITIES };"));
+		for (const name of ["validateAuditScore", "validateFindings", "validateFinding"]) {
+			assert.ok(
+				!new RegExp(`export[^;]*\\b${name}\\b`).test(source),
+				`${name} must not be exported`,
+			);
+		}
+	});
+
+	it("each helper body stays ≤ 2 control-flow nesting levels", () => {
+		for (const sig of HELPER_SIGNATURES) {
+			const depth = maxBraceDepth(functionBody(source, sig));
+			assert.ok(depth <= 2, `${sig} nests ${depth} levels deep — must be ≤ 2`);
+		}
+	});
+
+	it("validateAgentOutput keeps flat scalar checks in order and delegates nested blocks", () => {
+		const actionCheck = source.indexOf("Missing required field: 'action'");
+		const auditDelegate = source.indexOf("validateAuditScore(data.auditScore, errors);");
+		const findingsDelegate = source.indexOf("validateFindings(data.findings, errors);");
+		const targetStatusCheck = source.indexOf("'targetStatus' must be a string if provided");
+		for (const idx of [actionCheck, auditDelegate, findingsDelegate, targetStatusCheck]) {
+			assert.ok(idx >= 0, "expected source marker missing");
+		}
+		// scalar → auditScore → findings → targetStatus, matching pre-refactor push order
+		assert.ok(actionCheck < auditDelegate);
+		assert.ok(auditDelegate < findingsDelegate);
+		assert.ok(findingsDelegate < targetStatusCheck);
+		// orchestrator itself stays flat (≤ 2 levels) after delegation
+		const body = functionBody(source, "function validateAgentOutput(data: Record<string, unknown>): ValidationResult {");
+		assert.ok(maxBraceDepth(body) <= 2);
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1548

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| developer | ✓ SUCCESS | 6m 39s | 33.9K | 28 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 12m 54s | 33.2K | 22 | kimi-k3 |

**Total:** 2 runs · 19m 34s · 67.1K tokens · 50 tool calls · 3 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1548
Closes #1548