### PR TITLE
feat(#1598): SIMPLIFY: runInit — extract duplicated legacy-auth fallback block

### DIFF
--- a/cmd/cheasee-pi/init.go
+++ b/cmd/cheasee-pi/init.go
@@ -252,7 +252,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 		// Legacy path: API key only
 		fmt.Fprintf(os.Stderr, "  ℹ Using API-key-only mode.\n")
 		fmt.Fprintf(os.Stderr, "  ℹ Provider: %s\n", deps.Provider)
-		legacyProvider, legacyAPIKey, err = runInitLegacy(ctx, deps.APIKey, deps.Provider)
+		legacyProvider, legacyAPIKey, err = runInitLegacyAuth(ctx, deps)
 		if err != nil {
 			return err
 		}
@@ -264,7 +264,7 @@ func runInit(ctx context.Context, deps InitDeps) error {
 			if errors.Is(err, device.ErrUnsupported) {
 				fmt.Fprintf(os.Stderr, "  ⚠ GitHub OAuth device flow unavailable (the configured OAuth app may be invalid).\n")
 				fmt.Fprintf(os.Stderr, "  ℹ Falling back to API-key-only mode. Use --client-id to provide your own GitHub OAuth app.\n\n")
-				legacyProvider, legacyAPIKey, err = runInitLegacy(ctx, deps.APIKey, deps.Provider)
+				legacyProvider, legacyAPIKey, err = runInitLegacyAuth(ctx, deps)
 				if err != nil {
 					return err
 				}

--- a/cmd/cheasee-pi/init_auth.go
+++ b/cmd/cheasee-pi/init_auth.go
@@ -213,6 +213,17 @@ func runInitLegacy(ctx context.Context, apiKey string, provider string) (string,
 	return provider, apiKey, nil
 }
 
+// runInitLegacyAuth runs the API-key-only auth path and returns the legacy
+// (provider, apiKey) scalar pair. It is the shared tail of the two Phase-4
+// legacy fallback branches in runInit (--no-github and the ErrUnsupported
+// fallback); it does not print or stamp the workdir — the orchestrator owns
+// the stderr contract, the usingLegacyAuth flag, and the phase-7 patch.
+// Errors propagate bare (no %w re-wrap) so identity and messages stay
+// byte-identical.
+func runInitLegacyAuth(ctx context.Context, deps InitDeps) (string, string, error) {
+	return runInitLegacy(ctx, deps.APIKey, deps.Provider)
+}
+
 // promptAPIKey prompts the user for an API key (legacy).
 func promptAPIKey(provider string) (string, error) {
 	var apiKey string

--- a/cmd/cheasee-pi/init_auth_test.go
+++ b/cmd/cheasee-pi/init_auth_test.go
@@ -307,6 +307,62 @@ func TestRunInit_NoGitHubFlag(t *testing.T) {
 	}
 }
 
+func TestRunInit_ErrUnsupportedFallsBackToLegacy(t *testing.T) {
+	// GitHub device flow failing with device.ErrUnsupported must fall back to
+	// the legacy API-key path (call site #2): clone still runs and auth.json
+	// is written in the legacy patch shape (provider entry + repo_path, no
+	// github_token/github_user), with the fallback stderr contract intact.
+	testutil.RedirectConfigHome(t)
+	stubDockerCheck(t, nil, "24.0.9", nil)
+	testutil.SetGitConfig(t, testGitIdentityConfig)
+	clone := stubInitGit(t)
+
+	parent := t.TempDir()
+	workdir := filepath.Join(parent, "ws")
+	if err := os.MkdirAll(workdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	var err error
+	stderr := testutil.CaptureStderr(t, func() {
+		err = runInit(context.Background(), initDepsWithRepoURL(t, workdir, func(d *InitDeps) {
+			d.APIKey = FakeAPIKey
+			d.Ports = InitPorts{Auth: &mockAuthenticator{
+				requestCodeFunc: func(ctx context.Context, scopes []string) (*device.CodeResponse, error) {
+					return nil, device.ErrUnsupported
+				},
+			}}
+		}))
+	})
+	if err != nil {
+		t.Fatalf("ErrUnsupported must fall back to legacy, got: %v", err)
+	}
+	// Fallback stderr contract: both lines stay at the orchestrator call site.
+	if !strings.Contains(stderr, "⚠ GitHub OAuth device flow unavailable") {
+		t.Errorf("stderr must carry the device-flow-unavailable warning, got:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "ℹ Falling back to API-key-only mode") {
+		t.Errorf("stderr must carry the fallback notice, got:\n%s", stderr)
+	}
+	// Clone phase still runs on the fallback path.
+	if len(clone.cloneArgs) != 1 || len(clone.worktreeAdd) != 1 {
+		t.Fatalf("expected one bare clone + one worktree add, got %d/%d", len(clone.cloneArgs), len(clone.worktreeAdd))
+	}
+	// Legacy patch shape: provider entry + repo_path, no github fields.
+	authRaw := readAuthJSON(t)
+	if got := providerKey(t, authRaw, "opencode-go"); got != FakeAPIKey {
+		t.Errorf("expected API key %q under provider opencode-go, got %q", FakeAPIKey, got)
+	}
+	if got := authField(t, authRaw, "repo_path"); got != filepath.Join(workdir, "main") {
+		t.Errorf("expected repo_path %q, got %q", filepath.Join(workdir, "main"), got)
+	}
+	if _, ok := authRaw["github_token"]; ok {
+		t.Error("legacy fallback must not write github_token")
+	}
+	if _, ok := authRaw["github_user"]; ok {
+		t.Error("legacy fallback must not write github_user")
+	}
+}
+
 func TestRunInitLegacy_ReturnsScalars(t *testing.T) {
 	// runInitLegacy is auth-only: returns (provider, apiKey) scalars, does
 	// NOT save/extract/render — the orchestrator threads them into the
@@ -320,6 +376,59 @@ func TestRunInitLegacy_ReturnsScalars(t *testing.T) {
 	}
 	if provider != "opencode-go" {
 		t.Errorf("expected provider %q, got %q", "opencode-go", provider)
+	}
+}
+
+func TestRunInitLegacyAuth_ReturnsScalars(t *testing.T) {
+	// The helper is the shared tail of the two Phase-4 legacy branches in
+	// runInit: returns the legacy (provider, apiKey) scalar pair, no
+	// repo-path stamping.
+	provider, apiKey, err := runInitLegacyAuth(context.Background(), initDeps(t, func(d *InitDeps) {
+		d.APIKey = FakeAPIKey
+		d.Provider = "opencode-go"
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if apiKey != FakeAPIKey {
+		t.Errorf("expected API key %q, got %q", FakeAPIKey, apiKey)
+	}
+	if provider != "opencode-go" {
+		t.Errorf("expected provider %q, got %q", "opencode-go", provider)
+	}
+}
+
+func TestRunInitLegacyAuth_NoPrintsNoWorkdir(t *testing.T) {
+	// The helper is auth-only: it must neither print (the orchestrator owns
+	// the ℹ/⚠ stderr contract) nor consume the workdir (the orchestrator
+	// stamps repo_path in the phase-7 patch). The error path is a bare
+	// return from runInitLegacy — no seam forces promptAPIKey to fail, so no
+	// error-passthrough test is added for this refactor.
+	sentinel := t.TempDir()
+	var provider, apiKey string
+	var err error
+	stderr := testutil.CaptureStderr(t, func() {
+		provider, apiKey, err = runInitLegacyAuth(context.Background(), initDeps(t, func(d *InitDeps) {
+			d.APIKey = FakeAPIKey
+			d.Provider = "opencode-go"
+			d.Workdir = sentinel
+		}))
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("helper must not print to stderr, got: %q", stderr)
+	}
+	if provider != "opencode-go" || apiKey != FakeAPIKey {
+		t.Errorf("expected (opencode-go, %q), got (%q, %q)", FakeAPIKey, provider, apiKey)
+	}
+	entries, err := os.ReadDir(sentinel)
+	if err != nil {
+		t.Fatalf("read sentinel dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("helper must not write into the workdir, found %d entries", len(entries))
 	}
 }
 

--- a/cmd/cheasee-pi/init_split_test.go
+++ b/cmd/cheasee-pi/init_split_test.go
@@ -47,13 +47,14 @@ var wantInitDecls = map[string]string{
 	"func:gitDefaultBranch":  "init_clone.go",
 	"func:canonicalRepoURL":  "init_clone.go",
 	"func:removeInitResidue": "init_clone.go",
-	"func:wireUpstream":     "init_clone.go",
+	"func:wireUpstream":      "init_clone.go",
 
-	"func:runInitAuth":    "init_auth.go",
-	"func:runInitAPIKeys": "init_auth.go",
-	"func:runInitLegacy":  "init_auth.go",
-	"func:runReauth":      "init_auth.go",
-	"func:promptAPIKey":   "init_auth.go",
+	"func:runInitAuth":       "init_auth.go",
+	"func:runInitAPIKeys":    "init_auth.go",
+	"func:runInitLegacy":     "init_auth.go",
+	"func:runInitLegacyAuth": "init_auth.go",
+	"func:runReauth":         "init_auth.go",
+	"func:promptAPIKey":      "init_auth.go",
 
 	"func:runInitDockerCheck":       "init_scaffold.go",
 	"func:runInitScaffold":          "init_scaffold.go",
@@ -230,11 +231,12 @@ var initHelperDecls = map[string]string{
 // runInitFlowDecls pins the TestRunInit_* decls (colliding prefix) by flow
 // stage: auth seam, scaffold-only orchestration with mockAuthenticator.
 var runInitFlowDecls = map[string]string{
-	"func:TestRunInit_FullFlow":                   "init_auth_test.go",
-	"func:TestRunInit_NoGitHubFlag":               "init_auth_test.go",
-	"func:TestRunInit_ContextCancelledMidFlow":    "init_auth_test.go",
-	"func:TestRunInit_GitHubFlowClonesWorktree":   "init_prompt_test.go",
-	"func:TestRunInit_NoGitHubLegacySkipsGitInit": "init_prompt_test.go",
+	"func:TestRunInit_FullFlow":                        "init_auth_test.go",
+	"func:TestRunInit_NoGitHubFlag":                    "init_auth_test.go",
+	"func:TestRunInit_ErrUnsupportedFallsBackToLegacy": "init_auth_test.go",
+	"func:TestRunInit_ContextCancelledMidFlow":         "init_auth_test.go",
+	"func:TestRunInit_GitHubFlowClonesWorktree":        "init_prompt_test.go",
+	"func:TestRunInit_NoGitHubLegacySkipsGitInit":      "init_prompt_test.go",
 }
 
 // testSplitRules map decl name prefixes to their subject file. Rules are


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1598

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 19s | 73.9K | 40 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 23s | 20.6K | 8 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 6m 1s | 39.8K | 25 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 53s | 57.8K | 35 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 28s | 30.3K | 14 | gpt-5.6-luna |

**Total:** 5 runs · 13m 4s · 222.4K tokens · 122 tool calls · 9 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1598
Closes #1598