### PR TITLE
feat(#1603): Move pi-coding-agent install to end of Dockerfile so pi updates rebuild only the pi layer

### DIFF
--- a/cmd/cheasee-pi/build.go
+++ b/cmd/cheasee-pi/build.go
@@ -105,6 +105,9 @@ func runBuild(ctx context.Context, opts buildOptions) error {
 	// layers on the command text + ARG values, and an unchanging ARG
 	// would serve a stale pi from the layer cache — the "Update
 	// Available" nag pointing at a version the image never carries.
+	// The pi layer sits after the clone/npm-ci layers (Layer 6c), so this
+	// per-build bust re-runs only the pi install — clone + npm ci stay
+	// cached across builds.
 	stamp := fmt.Sprintf("%d", time.Now().Unix())
 	args := []string{"compose", "-f", composeFile, "build", "--build-arg", "PI_BUILD_STAMP=" + stamp}
 	if opts.noCache {

--- a/cmd/cheasee-pi/dockerfile_test.go
+++ b/cmd/cheasee-pi/dockerfile_test.go
@@ -101,6 +101,73 @@ func TestDockerfile_AppendSystemPromptSymlink(t *testing.T) {
 	}
 }
 
+func TestDockerfile_PiLayerAfterCloneBeforeEntrypoint(t *testing.T) {
+	content := readDockerfile(t)
+	// Issue #1603: the pi-coding-agent install is the one layer busted on
+	// every build (PI_BUILD_STAMP cache-busting contract), so it must sit
+	// AFTER the expensive clone/npm-ci/symlink layers (6b) and BEFORE the
+	// entrypoint COPY (7) — otherwise a pi bump re-runs the whole clone +
+	// npm ci. The byte-offset chain pins the order: clone < npm ci < symlink
+	// wiring < pi install < entrypoint COPY.
+	markers := []struct {
+		name string
+		text string
+	}{
+		{"clone (6b)", "git clone --depth 1 --branch ${CHEASEE_REF} https://github.com/SchneiderDaniel/cheasee-pi /opt/cheasee-pi"},
+		{"npm ci (6b)", "npm ci --no-audit --no-fund"},
+		{"symlink wiring (6b)", "chown -R agentuser:agentuser /home/agentuser/.pi"},
+		{"pi install (6c)", "npm install -g --force @earendil-works/pi-coding-agent"},
+		{"entrypoint COPY (7)", "COPY entrypoint.sh /usr/local/bin/entrypoint.sh"},
+	}
+	idxs := make([]int, len(markers))
+	for i, m := range markers {
+		idx := strings.Index(content, m.text)
+		if idx == -1 {
+			t.Fatalf("Dockerfile must contain %s marker %q (missing anchor — a reorder could silently pass)", m.name, m.text)
+		}
+		idxs[i] = idx
+	}
+	for i := 1; i < len(idxs); i++ {
+		if idxs[i-1] > idxs[i] {
+			t.Errorf("layer order broken: %s (offset %d) must precede %s (offset %d); the pi layer must sit after the 6b clone/npm-ci/symlink layers and before Layer 7's COPY", markers[i-1].name, idxs[i-1], markers[i].name, idxs[i])
+		}
+	}
+	// Renumered 5h -> 6c: the new header must be present and the old one gone
+	// (grep confirms "5h" appears nowhere else in the repo — renumber is safe).
+	if !strings.Contains(content, "Layer 6c: pi-coding-agent") {
+		t.Error("moved pi layer must be renumbered 'Layer 6c: pi-coding-agent'")
+	}
+	if strings.Contains(content, "Layer 5h") {
+		t.Error("old 'Layer 5h' header must be gone (pi layer renumbered to 6c)")
+	}
+	// Stamp contract stays inside the moved RUN (AC4): exactly one ARG and one
+	// echo, with the echo strictly between the install line and the Layer 7
+	// header — it cannot drift out of the RUN block.
+	if got := strings.Count(content, "ARG PI_BUILD_STAMP"); got != 1 {
+		t.Errorf("exactly one 'ARG PI_BUILD_STAMP' required (cache-busting contract), got %d", got)
+	}
+	echoLine := `echo "${PI_BUILD_STAMP}" >/var/lib/pi-build-stamp`
+	if got := strings.Count(content, echoLine); got != 1 {
+		t.Errorf("exactly one stamp echo (%q) required, got %d", echoLine, got)
+	}
+	installIdx := strings.Index(content, "npm install -g --force @earendil-works/pi-coding-agent")
+	layer7Idx := strings.Index(content, "# Layer 7:")
+	if installIdx == -1 || layer7Idx == -1 {
+		t.Fatal("pi install line or Layer 7 header missing")
+	}
+	echoIdx := strings.Index(content, echoLine)
+	if !(installIdx < echoIdx && echoIdx < layer7Idx) {
+		t.Errorf("stamp echo (offset %d) must sit inside the pi RUN: after the install line (offset %d) and before the Layer 7 header (offset %d)", echoIdx, installIdx, layer7Idx)
+	}
+	// No duplicate install, and the npm cache clean stays within the moved block.
+	if got := strings.Count(content, "npm install -g --force @earendil-works/pi-coding-agent"); got != 1 {
+		t.Errorf("exactly one pi install line required, got %d", got)
+	}
+	if block := content[installIdx:layer7Idx]; !strings.Contains(block, "npm cache clean --force") {
+		t.Error("moved pi RUN must retain 'npm cache clean --force'")
+	}
+}
+
 func TestDockerfile_PrivatePiSymlinkGuarded(t *testing.T) {
 	content := readDockerfile(t)
 	if !strings.Contains(content, "if [ -d /opt/cheasee-pi/private-pi ]") {

--- a/cmd/cheasee-pi/embedded/docker/Dockerfile
+++ b/cmd/cheasee-pi/embedded/docker/Dockerfile
@@ -226,21 +226,6 @@ RUN case "$(dpkg --print-architecture)" in \
 ENV PATH=/usr/local/go/bin:${PATH}
 
 # ---------------------------------------------------------------
-# Layer 5h: pi-coding-agent (last npm layer — pi version bumps
-#           don't invalidate expensive binary layers above)
-# ---------------------------------------------------------------
-ARG PI_VERSION=latest
-# Cache-busting stamp: any change to this ARG invalidates the npm layer,
-# so @latest is re-resolved on every build instead of reusing a stale layer.
-# Set it to a per-build value (e.g. $(date +%s)) via `docker compose build
-# --build-arg PI_BUILD_STAMP=$(date +%s)`.
-ARG PI_BUILD_STAMP
-RUN npm install -g --force @earendil-works/pi-coding-agent@${PI_VERSION} \
-    && npm cache clean --force \
-    && rm -rf /tmp/* \
-    && echo "${PI_BUILD_STAMP}" >/var/lib/pi-build-stamp
-
-# ---------------------------------------------------------------
 # Layer 6: Non-root user + workspace directory
 # ---------------------------------------------------------------
 RUN groupadd --gid 1001 agentuser && \
@@ -314,6 +299,26 @@ RUN mkdir -p /home/agentuser/.pi/agent/skills /home/agentuser/.pi/agent/prompts 
        fi \
     && if [ -f /opt/cheasee-pi/APPEND_SYSTEM.md ]; then ln -sfn /opt/cheasee-pi/APPEND_SYSTEM.md /home/agentuser/.pi/agent/APPEND_SYSTEM.md; fi \
     && chown -R agentuser:agentuser /home/agentuser/.pi
+
+# ---------------------------------------------------------------
+# Layer 6c: pi-coding-agent (last npm layer — pi bumps don't
+#           invalidate the expensive clone/npm-ci layer above)
+# ---------------------------------------------------------------
+# Placed AFTER Layer 6b (clone + npm ci + symlink wiring) so a pi update —
+# every build busts this layer via PI_BUILD_STAMP — only re-runs this npm
+# install; the expensive clone/npm-ci layers stay cached. Kept BEFORE
+# Layer 7's entrypoint COPY because that layer changes most frequently:
+# if pi sat absolute-last, every entrypoint/lib change would reinstall it.
+ARG PI_VERSION=latest
+# Cache-busting stamp: any change to this ARG invalidates the npm layer,
+# so @latest is re-resolved on every build instead of reusing a stale layer.
+# Set it to a per-build value (e.g. $(date +%s)) via `docker compose build
+# --build-arg PI_BUILD_STAMP=$(date +%s)`.
+ARG PI_BUILD_STAMP
+RUN npm install -g --force @earendil-works/pi-coding-agent@${PI_VERSION} \
+    && npm cache clean --force \
+    && rm -rf /tmp/* \
+    && echo "${PI_BUILD_STAMP}" >/var/lib/pi-build-stamp
 
 # ---------------------------------------------------------------
 # Layer 7: Entrypoint + worktree fix library (last – changes most frequently)

--- a/cmd/cheasee-pi/up.go
+++ b/cmd/cheasee-pi/up.go
@@ -363,6 +363,8 @@ func dockerComposeUp(ctx context.Context, composeDir, workspaceHostPath, contain
 	// Build with a per-build cache-busting stamp so the pi-coding-agent
 	// layer always re-resolves @latest (Docker caches RUN layers on the
 	// command text + ARG values; an unchanging ARG means a stale pi).
+	// The pi layer sits after the clone/npm-ci layers, so the bust re-runs
+	// only the pi install — clone + npm ci stay cached across builds.
 	stamp := fmt.Sprintf("%d", time.Now().Unix())
 	build := runCommandContext(ctx, "docker", "compose",
 		"-f", composeFile,

--- a/scripts/verify-pi-layer-cache.sh
+++ b/scripts/verify-pi-layer-cache.sh
@@ -188,8 +188,30 @@ echo "== build 3 (entrypoint.sh byte change, SAME PI_BUILD_STAMP as build 2) =="
 # only the entrypoint COPY can differ. Restore the context file afterwards
 # so the cache dir is left pristine.
 cp "$ENTRYPOINT_CACHE" "$ENTRYPOINT_BAK"
-restore_entrypoint() { cp "$ENTRYPOINT_BAK" "$ENTRYPOINT_CACHE" 2>/dev/null || true; }
-trap 'restore_entrypoint; rm -rf "$TMP"' EXIT
+# restore_entrypoint must NOT swallow failure: a failed restore leaves the
+# persistent build context (the CLI cache-dir entrypoint.sh) modified,
+# contaminating every later build. On success it returns 0; on failure it
+# reports to stderr and returns 1. The EXIT trap forces a non-zero exit when
+# the restore fails while still preserving the script's original failure
+# status when it was already exiting non-zero.
+restore_entrypoint() {
+  if ! cp "$ENTRYPOINT_BAK" "$ENTRYPOINT_CACHE" 2>/dev/null; then
+    echo "error: failed to restore $ENTRYPOINT_CACHE from backup — the persistent build context is left modified" >&2
+    return 1
+  fi
+}
+trap '
+  orig=$?
+  if restore_entrypoint; then
+    rm -rf "$TMP"
+    exit "$orig"
+  fi
+  # Restore failed (reported to stderr above): force non-zero, preferring the
+  # original failure status when the script was already failing.
+  rm -rf "$TMP"
+  if [ "$orig" -ne 0 ]; then exit "$orig"; fi
+  exit 1
+' EXIT
 printf '\n# verify-pi-layer-cache.sh marker\n' >>"$ENTRYPOINT_CACHE"
 compose_build "$STAMP2" "$TMP/build3.log"
 restore_entrypoint

--- a/scripts/verify-pi-layer-cache.sh
+++ b/scripts/verify-pi-layer-cache.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# scripts/verify-pi-layer-cache.sh
+#
+# Phase 2 (e2e) verification for issue #1603 — "Move pi-coding-agent install
+# to end of Dockerfile so pi updates rebuild only the pi layer".
+#
+# Asserts the Docker layer-cache behavior of the reordered Dockerfile:
+#
+#   build 1:  cheasee-pi build              (warms the cache)
+#   build 2:  cheasee-pi build              (PI_BUILD_STAMP differs → pi layer re-runs)
+#             → clone / npm ci / symlink RUN layers report CACHED   (AC1)
+#             → pi install RUN does NOT report CACHED (stamp bust works, AC4)
+#   build 3:  entrypoint.sh byte change (via extractor re-write) -> build
+#             → pi install RUN reports CACHED                        (AC3)
+#             → clone / npm ci still CACHED                          (AC1)
+#             → entrypoint COPY re-runs (bytes changed)
+#   boot:     docker run --rm cheasee-pi pi --version  → version printed     (AC5)
+#             stamp file present in the final image                          (AC4)
+#
+# Scope: the cache-hit guarantee holds ONLY for default builds. --prune /
+# --no-cache / --pull wipe the cache by design, and the floating
+# FROM debian:12-slim digest drift is the upper bound on any pi-only rebuild.
+#
+# The stamp is second-granular (build.go: fmt.Sprintf("%d", time.Now().Unix())),
+# so the script sleeps >= 1s between builds — same-second runs produce an
+# identical ARG and a full cache hit that proves nothing.
+#
+# Requires: cheasee-pi on PATH (or CHEASEE_PI_BIN=/path/to/cheasee-pi), a
+# working docker daemon, go toolchain (build 3 re-embeds the entrypoint
+# change), ~15-25 min. Run manually — never inside a CI/Auditor timebox.
+#
+# Usage: bash scripts/verify-pi-layer-cache.sh [workspace-dir]
+#        (workspace-dir defaults to this repo's root; must be a git repo)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKDIR="${1:-$REPO_ROOT}"
+CLI="${CHEASEE_PI_BIN:-cheasee-pi}"
+ENTRYPOINT_SRC="$REPO_ROOT/cmd/cheasee-pi/embedded/docker/entrypoint.sh"
+
+command -v "$CLI" >/dev/null 2>&1 || { echo "error: cheasee-pi CLI not found on PATH (set CHEASEE_PI_BIN)" >&2; exit 1; }
+command -v docker >/dev/null 2>&1 || { echo "error: docker not found" >&2; exit 1; }
+command -v go >/dev/null 2>&1 || { echo "error: go not found (needed to rebuild the CLI with the entrypoint change for build 3)" >&2; exit 1; }
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain -- cmd/cheasee-pi/embedded/docker/entrypoint.sh)" ]]; then
+  echo "error: entrypoint.sh has uncommitted changes — refusing to touch it (build 3 modifies then git-restores it)" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+# ──────────────────────────────────────────────
+# Build-log helpers. Two formats occur depending on who prints the progress:
+#   compose v2 non-TTY:  "=> [5/8] RUN git clone ..."   then "=> [5/8] CACHED"
+#   buildx non-TTY:      "#9 [5/8] RUN git clone ..."   then "#9 CACHED"
+# Both carry the "[n/m]" bracket on the header line, so we locate steps by
+# bracket and accept either outcome form.
+# ──────────────────────────────────────────────
+
+# step_bracket <log> <command-regex ERE> → the "[n/m]" label of the first step
+# whose printed command line matches. Empty when the step never ran.
+step_bracket() {
+  local log=$1 pat=$2
+  grep -E "$pat" "$log" 2>/dev/null | grep -oE '\[[0-9]+/[0-9]+\]' | head -n1 || true
+}
+
+# step_outcome <log> <bracket> <CACHED|DONE> → 0 when the step reports that
+# outcome in either log format.
+step_outcome() {
+  local log=$1 bracket=$2 outcome=$3 n
+  grep -F "$bracket $outcome" "$log" | grep -q . && return 0
+  n="$(grep -F "$bracket" "$log" | grep -oE '^#[0-9]+' | head -n1 || true)"
+  [[ -n "$n" ]] && grep -F "$n $outcome" "$log" | grep -q .
+}
+
+# assert_cached <log> <label> <command-regex ERE>
+assert_cached() {
+  local log=$1 label=$2 pat=$3 bracket
+  bracket="$(step_bracket "$log" "$pat")"
+  if [[ -z "$bracket" ]]; then
+    echo "  ✗ $label: step not found in build log (pattern: $pat)" >&2
+    return 1
+  fi
+  if step_outcome "$log" "$bracket" CACHED; then
+    echo "  ✓ $label: CACHED"
+  else
+    echo "  ✗ $label: NOT cached (step $bracket) — expected a cache hit" >&2
+    grep -F "$bracket" "$log" >&2 || true
+    return 1
+  fi
+}
+
+# assert_rerun <log> <label> <command-regex ERE> — the step re-executed
+# (reports DONE, not CACHED).
+assert_rerun() {
+  local log=$1 label=$2 pat=$3 bracket
+  bracket="$(step_bracket "$log" "$pat")"
+  if [[ -z "$bracket" ]]; then
+    echo "  ✗ $label: step not found in build log (pattern: $pat)" >&2
+    return 1
+  fi
+  if step_outcome "$log" "$bracket" CACHED; then
+    echo "  ✗ $label: CACHED but expected to re-execute (step $bracket)" >&2
+    return 1
+  fi
+  # compose's non-TTY summary prints executed steps as "[n/m] RUN <cmd> <dur>"
+  # with no separate DONE line; only buildx prints "#N DONE". A step line
+  # without CACHED in a completed build is a re-execution either way.
+  if step_outcome "$log" "$bracket" DONE || grep -q 'FINISHED' "$log"; then
+    echo "  ✓ $label: re-executed (no CACHED, build finished)"
+  else
+    echo "  ✗ $label: neither CACHED nor a completed build (step $bracket)" >&2
+    grep -F "$bracket" "$log" >&2 || true
+    return 1
+  fi
+}
+
+build() { # <out-log> — runs `cheasee-pi build` (default flags) in WORKDIR
+  (cd "$WORKDIR" && "$CLI" build) 2>&1 | tee "$1"
+}
+
+failures=0
+fail() { echo "  ✗ $1" >&2; failures=$((failures + 1)); }
+
+clone_pat='RUN git clone --depth 1 --branch ${CHEASEE_REF}'
+symlink_pat='RUN mkdir -p /home/agentuser/.pi/agent/skills'
+pi_pat='RUN npm install -g --force @earendil-works/pi-coding-agent'
+copy_pat='COPY entrypoint.sh /usr/local/bin/entrypoint.sh'
+
+echo "== build 1 (warm the cache) =="
+build "$TMP/build1.log"
+sleep 1 # stamp is second-granular — same-second builds would cache-hit entirely
+
+echo "== build 2 (same sources, new PI_BUILD_STAMP) =="
+build "$TMP/build2.log"
+echo "— AC1: expensive 6b layers stay cached on a pi-only rebuild —"
+assert_cached "$TMP/build2.log" "clone + npm ci (6b)" "$clone_pat" || fail "clone/npm-ci layer must be CACHED on build 2"
+assert_cached "$TMP/build2.log" "symlink wiring (6b)" "$symlink_pat" || fail "symlink layer must be CACHED on build 2"
+echo "— AC4: stamp bust still re-runs the pi install —"
+assert_rerun "$TMP/build2.log" "pi install (6c)" "$pi_pat" || fail "pi layer must re-execute on build 2 (stamp bust)"
+
+echo "== build 3 (entrypoint.sh byte change → extractor re-writes it) =="
+# Emulate an entrypoint-only release: append a marker to the embedded source,
+# rebuild the CLI (the extractor re-writes the cache dir's entrypoint.sh from
+# the new binary on `cheasee-pi build`), then restore the source.
+printf '\n# verify-pi-layer-cache.sh marker\n' >>"$ENTRYPOINT_SRC"
+restore_entrypoint() { git -C "$REPO_ROOT" checkout -- cmd/cheasee-pi/embedded/docker/entrypoint.sh 2>/dev/null || true; }
+trap 'restore_entrypoint; rm -rf "$TMP"' EXIT
+(cd "$REPO_ROOT" && go build -o "$TMP/cheasee-pi" ./cmd/cheasee-pi/)
+restore_entrypoint
+CLI="$TMP/cheasee-pi" build "$TMP/build3.log"
+echo "— AC3: entrypoint-only change must NOT reinstall pi —"
+assert_cached "$TMP/build3.log" "pi install (6c)" "$pi_pat" || fail "pi layer must be CACHED on build 3 (entrypoint-only change)"
+assert_cached "$TMP/build3.log" "clone + npm ci (6b)" "$clone_pat" || fail "clone/npm-ci layer must stay CACHED on build 3"
+assert_rerun "$TMP/build3.log" "entrypoint COPY (7)" "$copy_pat" || fail "entrypoint COPY must re-execute on build 3 (bytes changed)"
+
+echo "== boot checks =="
+if docker run --rm cheasee-pi pi --version; then
+  echo "  ✓ docker run --rm cheasee-pi pi --version (AC5)"
+else
+  fail "image must boot: docker run --rm cheasee-pi pi --version"
+fi
+if docker run --rm cheasee-pi sh -c 'test -f /var/lib/pi-build-stamp'; then
+  echo "  ✓ stamp file /var/lib/pi-build-stamp present in the final image (AC4)"
+else
+  fail "stamp file /var/lib/pi-build-stamp missing from the final image"
+fi
+
+echo
+if [[ $failures -eq 0 ]]; then
+  echo "PASS: pi layer is incremental — pi updates no longer rebuild clone + npm ci."
+  exit 0
+fi
+echo "FAIL: $failures assertion(s) failed" >&2
+exit 1

--- a/scripts/verify-pi-layer-cache.sh
+++ b/scripts/verify-pi-layer-cache.sh
@@ -6,28 +6,34 @@
 #
 # Asserts the Docker layer-cache behavior of the reordered Dockerfile:
 #
-#   build 1:  cheasee-pi build              (warms the cache)
-#   build 2:  cheasee-pi build              (PI_BUILD_STAMP differs → pi layer re-runs)
+#   build 1:  cheasee-pi build    (real CLI path — warms the cache)
+#   build 2:  compose build, stamp S2 held by the script (S2 != build 1's stamp)
 #             → clone / npm ci / symlink RUN layers report CACHED   (AC1)
 #             → pi install RUN does NOT report CACHED (stamp bust works, AC4)
-#   build 3:  entrypoint.sh byte change (via extractor re-write) -> build
+#   build 3:  entrypoint.sh byte change (cache-dir context file) + compose build
+#             with the SAME stamp S2 as build 2
 #             → pi install RUN reports CACHED                        (AC3)
 #             → clone / npm ci still CACHED                          (AC1)
 #             → entrypoint COPY re-runs (bytes changed)
-#   boot:     docker run --rm cheasee-pi pi --version  → version printed     (AC5)
+#   boot:     docker run --rm <project>-cheasee-pi pi --version → version printed (AC5)
 #             stamp file present in the final image                          (AC4)
+#
+# WHY COMPOSE-DIRECT FOR BUILDS 2/3: `cheasee-pi build` always injects a
+# fresh PI_BUILD_STAMP (build.go: fmt.Sprintf("%d", time.Now().Unix())) by
+# design. AC3 (entrypoint-only change must not reinstall pi) is only testable
+# when the stamp is HELD CONSTANT across builds 2→3, so those builds run
+# through `docker compose build` directly with the script's own stamp. Build 1
+# still exercises the real CLI path end-to-end.
 #
 # Scope: the cache-hit guarantee holds ONLY for default builds. --prune /
 # --no-cache / --pull wipe the cache by design, and the floating
 # FROM debian:12-slim digest drift is the upper bound on any pi-only rebuild.
 #
-# The stamp is second-granular (build.go: fmt.Sprintf("%d", time.Now().Unix())),
-# so the script sleeps >= 1s between builds — same-second runs produce an
-# identical ARG and a full cache hit that proves nothing.
-#
 # Requires: cheasee-pi on PATH (or CHEASEE_PI_BIN=/path/to/cheasee-pi), a
-# working docker daemon, go toolchain (build 3 re-embeds the entrypoint
-# change), ~15-25 min. Run manually — never inside a CI/Auditor timebox.
+# working docker daemon, ~15-25 min. Run manually — never inside a CI/Auditor
+# timebox. The compose/Dockerfile/entrypoint build context is the CLI's
+# version-keyed cache dir (populated by build 1's extract), which the script
+# resolves from `cheasee-pi --version`.
 #
 # Usage: bash scripts/verify-pi-layer-cache.sh [workspace-dir]
 #        (workspace-dir defaults to this repo's root; must be a git repo)
@@ -37,17 +43,30 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKDIR="${1:-$REPO_ROOT}"
 CLI="${CHEASEE_PI_BIN:-cheasee-pi}"
-ENTRYPOINT_SRC="$REPO_ROOT/cmd/cheasee-pi/embedded/docker/entrypoint.sh"
 
 command -v "$CLI" >/dev/null 2>&1 || { echo "error: cheasee-pi CLI not found on PATH (set CHEASEE_PI_BIN)" >&2; exit 1; }
 command -v docker >/dev/null 2>&1 || { echo "error: docker not found" >&2; exit 1; }
-command -v go >/dev/null 2>&1 || { echo "error: go not found (needed to rebuild the CLI with the entrypoint change for build 3)" >&2; exit 1; }
-if [[ -n "$(git -C "$REPO_ROOT" status --porcelain -- cmd/cheasee-pi/embedded/docker/entrypoint.sh)" ]]; then
-  echo "error: entrypoint.sh has uncommitted changes — refusing to touch it (build 3 modifies then git-restores it)" >&2
+
+# The compose build context lives in the CLI's version-keyed cache dir
+# (cache.go: os.UserCacheDir()/cheasee-pi/<cliVersion>). Version from the
+# CLI binary itself (--version → "cheasee-pi version 0.55.3"), so a custom
+# CHEASEE_PI_BIN build resolves its own cache key.
+CLI_VERSION="$("$CLI" --version | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+\.[0-9]+\.[0-9]+$/) print $i; exit }')"
+if [[ -z "$CLI_VERSION" ]]; then
+  echo "error: could not parse a semver from \`$CLI --version\` (got: $("$CLI" --version)) — cannot resolve the cache dir" >&2
   exit 1
 fi
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/cheasee-pi/${CLI_VERSION}"
+COMPOSE_FILE="$CACHE_DIR/docker-compose.yml"
+# Compose project for the script's own builds — compose tags the image as
+# <project>-cheasee-pi (the file's `name: cheasee-pi` and the CLI's per-repo
+# project name produce different tags, so the boot check resolves the image
+# dynamically instead of assuming a name).
+PROJECT="cheasee-pi-cacheverify"
 
 TMP="$(mktemp -d)"
+ENTRYPOINT_CACHE="$CACHE_DIR/entrypoint.sh"
+ENTRYPOINT_BAK="$TMP/entrypoint.sh.orig"
 trap 'rm -rf "$TMP"' EXIT
 # ──────────────────────────────────────────────
 # Build-log helpers. Two formats occur depending on who prints the progress:
@@ -119,6 +138,22 @@ build() { # <out-log> — runs `cheasee-pi build` (default flags) in WORKDIR
   (cd "$WORKDIR" && "$CLI" build) 2>&1 | tee "$1"
 }
 
+# compose_build <stamp> <out-log> — runs `docker compose build` directly with
+# the given PI_BUILD_STAMP (default flags), from the CLI's cache-dir build
+# context. Mirrors what build.go does for its compose argv (minus the CLI's
+# own stamp injection, which is the point: AC3 needs the stamp held constant).
+# Compose validates every volume spec even for `build`, so the workspace env
+# vars must be set (same env application as applyComposeEnv).
+compose_build() { # <stamp> <out-log>
+  local stamp=$1 out=$2
+  (cd "$CACHE_DIR" \
+    && WORKSPACE_HOST_PATH="$WORKDIR" \
+       WORKSPACE_BARE_PATH="$(dirname "$WORKDIR")/.bare" \
+       COMPOSE_PROJECT_NAME="$PROJECT" \
+       docker compose -f "$COMPOSE_FILE" build \
+         --build-arg "PI_BUILD_STAMP=$stamp") 2>&1 | tee "$out"
+}
+
 failures=0
 fail() { echo "  ✗ $1" >&2; failures=$((failures + 1)); }
 
@@ -127,40 +162,67 @@ symlink_pat='RUN mkdir -p /home/agentuser/.pi/agent/skills'
 pi_pat='RUN npm install -g --force @earendil-works/pi-coding-agent'
 copy_pat='COPY entrypoint.sh /usr/local/bin/entrypoint.sh'
 
-echo "== build 1 (warm the cache) =="
+echo "== build 1 (warm the cache, real CLI path) =="
 build "$TMP/build1.log"
-sleep 1 # stamp is second-granular — same-second builds would cache-hit entirely
+sleep 1 # stamp is second-granular — build 2's held stamp must differ from build 1's CLI stamp
 
-echo "== build 2 (same sources, new PI_BUILD_STAMP) =="
-build "$TMP/build2.log"
+# The CLI's build-1 stamp was generated inside the binary; we cannot observe
+# it. To guarantee build 2's stamp differs, derive it from the wall clock >=
+# 1s later (sleep above). Builds 2 and 3 share this stamp: AC3 requires
+# holding PI_BUILD_STAMP constant while only entrypoint bytes change.
+STAMP2="$(date +%s)"
+
+echo "== build 2 (same sources, new PI_BUILD_STAMP held by script) =="
+compose_build "$STAMP2" "$TMP/build2.log"
 echo "— AC1: expensive 6b layers stay cached on a pi-only rebuild —"
 assert_cached "$TMP/build2.log" "clone + npm ci (6b)" "$clone_pat" || fail "clone/npm-ci layer must be CACHED on build 2"
 assert_cached "$TMP/build2.log" "symlink wiring (6b)" "$symlink_pat" || fail "symlink layer must be CACHED on build 2"
 echo "— AC4: stamp bust still re-runs the pi install —"
 assert_rerun "$TMP/build2.log" "pi install (6c)" "$pi_pat" || fail "pi layer must re-execute on build 2 (stamp bust)"
 
-echo "== build 3 (entrypoint.sh byte change → extractor re-writes it) =="
-# Emulate an entrypoint-only release: append a marker to the embedded source,
-# rebuild the CLI (the extractor re-writes the cache dir's entrypoint.sh from
-# the new binary on `cheasee-pi build`), then restore the source.
-printf '\n# verify-pi-layer-cache.sh marker\n' >>"$ENTRYPOINT_SRC"
-restore_entrypoint() { git -C "$REPO_ROOT" checkout -- cmd/cheasee-pi/embedded/docker/entrypoint.sh 2>/dev/null || true; }
+echo "== build 3 (entrypoint.sh byte change, SAME PI_BUILD_STAMP as build 2) =="
+# Emulate an entrypoint-only release by appending a marker to the build
+# context's entrypoint.sh (the CLI cache-dir copy — the file Layer 7 COPYs
+# into the image). Build through compose with the stamp held at STAMP2 so the
+# pi layer's cache key (RUN text + ARG value) is byte-identical to build 2's:
+# only the entrypoint COPY can differ. Restore the context file afterwards
+# so the cache dir is left pristine.
+cp "$ENTRYPOINT_CACHE" "$ENTRYPOINT_BAK"
+restore_entrypoint() { cp "$ENTRYPOINT_BAK" "$ENTRYPOINT_CACHE" 2>/dev/null || true; }
 trap 'restore_entrypoint; rm -rf "$TMP"' EXIT
-(cd "$REPO_ROOT" && go build -o "$TMP/cheasee-pi" ./cmd/cheasee-pi/)
+printf '\n# verify-pi-layer-cache.sh marker\n' >>"$ENTRYPOINT_CACHE"
+compose_build "$STAMP2" "$TMP/build3.log"
 restore_entrypoint
-CLI="$TMP/cheasee-pi" build "$TMP/build3.log"
+# Build 3 done — the entrypoint context file is restored; relax the trap to
+# only clean the temp dir (a later failure must not re-clobber a deliberately
+# edited context).
+trap 'rm -rf "$TMP"' EXIT
 echo "— AC3: entrypoint-only change must NOT reinstall pi —"
 assert_cached "$TMP/build3.log" "pi install (6c)" "$pi_pat" || fail "pi layer must be CACHED on build 3 (entrypoint-only change)"
 assert_cached "$TMP/build3.log" "clone + npm ci (6b)" "$clone_pat" || fail "clone/npm-ci layer must stay CACHED on build 3"
 assert_rerun "$TMP/build3.log" "entrypoint COPY (7)" "$copy_pat" || fail "entrypoint COPY must re-execute on build 3 (bytes changed)"
 
 echo "== boot checks =="
-if docker run --rm cheasee-pi pi --version; then
-  echo "  ✓ docker run --rm cheasee-pi pi --version (AC5)"
-else
-  fail "image must boot: docker run --rm cheasee-pi pi --version"
+# Compose tags the built image as <project>-cheasee-pi (no `image:` key in
+# docker-compose.yml), so resolve it from the project instead of assuming
+# the bare name `cheasee-pi`. `docker compose build` only builds; no
+# containers exist, so `docker compose images` (which lists containers'
+# images) would print nothing. Resolve via the compose project label, with
+# the <project>-<service> name-scheme fallback.
+IMAGE="$(docker image ls --filter label=com.docker.compose.project="$PROJECT" --format '{{.Repository}}:{{.Tag}}' 2>/dev/null | head -n1)"
+if [[ -z "$IMAGE" ]]; then
+  IMAGE="$(docker image ls --format '{{.Repository}}:{{.Tag}}' "${PROJECT}-cheasee-pi" 2>/dev/null | head -n1)"
 fi
-if docker run --rm cheasee-pi sh -c 'test -f /var/lib/pi-build-stamp'; then
+if [[ -z "$IMAGE" ]]; then
+  echo "error: expected image from compose project $PROJECT was not built (docker image ls found nothing)" >&2
+  fail "image ${PROJECT}-cheasee-pi must exist after compose build"
+fi
+if docker run --rm "$IMAGE" pi --version; then
+  echo "  ✓ docker run --rm $IMAGE pi --version (AC5)"
+else
+  fail "image must boot: docker run --rm $IMAGE pi --version"
+fi
+if docker run --rm "$IMAGE" sh -c 'test -f /var/lib/pi-build-stamp'; then
   echo "  ✓ stamp file /var/lib/pi-build-stamp present in the final image (AC4)"
 else
   fail "stamp file /var/lib/pi-build-stamp missing from the final image"


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1603

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 4m 25s | 72.8K | 42 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 43s | 33.6K | 12 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 49s | 35.1K | 13 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 2m 57s | 62.7K | 29 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 54s | 86.5K | 34 | gpt-5.6-luna |
| developer | ✓ SUCCESS | 6m 20s | 119.3K | 49 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 31s | 100.6K | 30 | gpt-5.6-luna |
| developer | ✓ SUCCESS | 1m 19s | 33.9K | 18 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 39s | 96.1K | 34 | gpt-5.6-luna |

**Total:** 9 runs · 27m 38s · 640.6K tokens · 261 tool calls · 17 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1603
Closes #1603