### PR TITLE
feat(#1610): SIMPLIFY: build.go — delete build --no-cache compat alias, rebuild is the no-cache path

### DIFF
--- a/cmd/cheasee-pi/build.go
+++ b/cmd/cheasee-pi/build.go
@@ -13,7 +13,6 @@ import (
 var (
 	buildWorkdir       string
 	buildNoDockerCheck bool
-	buildNoCache       bool
 )
 
 var buildCmd = &cobra.Command{
@@ -28,13 +27,11 @@ runtime.
 The compose/Dockerfile come from the CLI-managed cache dir
 (version-keyed, extracted on demand); the workspace is only used for git
 verification and resource settings. build reuses the Docker layer cache;
-use 'cheasee-pi rebuild' for a full no-cache rebuild plus prune, or the
---no-cache flag (kept as a compatibility alias).
+use 'cheasee-pi rebuild' for a full no-cache rebuild plus prune.
 
 Examples:
   cheasee-pi build                 # rebuild image (cached)
   cheasee-pi rebuild               # full rebuild from scratch (no cache + prune)
-  cheasee-pi build --no-cache      # legacy alias for a full rebuild
   cheasee-pi build --workdir ..     # rebuild in specific workspace`,
 	DisableAutoGenTag: true,
 	RunE:              runBuildE,
@@ -44,36 +41,22 @@ func init() {
 	rootCmd.AddCommand(buildCmd)
 	buildCmd.Flags().StringVar(&buildWorkdir, "workdir", "", "Working directory (default: current directory)")
 	buildCmd.Flags().BoolVar(&buildNoDockerCheck, "no-docker-check", false, "Skip Docker Engine check")
-	buildCmd.Flags().BoolVar(&buildNoCache, "no-cache", false, "Force full rebuild from scratch (ignore Docker layer cache)")
 }
 
-// buildOptions parameterizes the compose-build core shared by `build` and
-// `rebuild`: which flags compose receives, whether dangling images/build
-// cache are pruned around the build, and how the build step is labelled.
-type buildOptions struct {
-	noCache   bool // pass --no-cache (ignore the Docker layer cache)
-	pull      bool // pass --pull (refresh the base image)
-	prune     bool // prune dangling images + build cache
-	prunePost bool // prune AFTER the build (rebuild); false = before (build --no-cache compat)
-	label     bool // mark the build label as a full rebuild
-}
 
 func runBuildE(cmd *cobra.Command, _ []string) error {
 	ctx := cmd.Context()
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return runBuild(ctx, buildOptions{
-		noCache: buildNoCache,
-		prune:   buildNoCache,
-	})
+	return runBuild(ctx, false, false)
 }
 
 // runBuild is the shared build core: compose-arg construction, stamp
-// injection, prune ordering and labels. `build` is the cached surface,
-// `rebuild` the no-cache full rebuild; the --no-cache flag on `build` keeps
-// its historical pre-build prune as a compat path.
-func runBuild(ctx context.Context, opts buildOptions) error {
+// injection, prune and label. `build` is the cached surface (noCache=false,
+// pull=false); `rebuild` is the single no-cache path (noCache=true,
+// pull=true), pruning dangling images + build cache after the build.
+func runBuild(ctx context.Context, noCache, pull bool) error {
 	workdir, err := resolveWorkdir(buildWorkdir)
 	if err != nil {
 		return fmt.Errorf("resolve workdir: %w", err)
@@ -110,18 +93,11 @@ func runBuild(ctx context.Context, opts buildOptions) error {
 	// cached across builds.
 	stamp := fmt.Sprintf("%d", time.Now().Unix())
 	args := []string{"compose", "-f", composeFile, "build", "--build-arg", "PI_BUILD_STAMP=" + stamp}
-	if opts.noCache {
+	if noCache {
 		args = append(args, "--no-cache")
 	}
-	if opts.pull {
+	if pull {
 		args = append(args, "--pull")
-	}
-
-	if opts.prune && !opts.prunePost {
-		// Full rebuild re-extracts every layer beside the existing image;
-		// stale build cache + dangling images can fill the disk first.
-		pruneDanglingImages()
-		pruneBuildCache()
 	}
 
 	buildCmd := runCommandContext(ctx, "docker", args...)
@@ -136,11 +112,8 @@ func runBuild(ctx context.Context, opts buildOptions) error {
 	buildCmd.SetStderr(os.Stderr)
 
 	label := "Building container image"
-	if opts.noCache {
-		label += " (no cache)"
-	}
-	if opts.label {
-		label += ", full rebuild"
+	if noCache {
+		label += " (no cache), full rebuild"
 	}
 	fmt.Fprintf(os.Stderr, "  ℹ %s...\n", label)
 	if err := buildCmd.Run(); err != nil {
@@ -153,12 +126,11 @@ func runBuild(ctx context.Context, opts buildOptions) error {
 	// followed by a plain start silently serves the stale image.
 	fmt.Fprintf(os.Stderr, "  ℹ Running containers keep the old image — apply with `cheasee-pi start --build` or `cheasee-pi down` + `cheasee-pi start`\n")
 
-	if opts.prune && opts.prunePost {
+	if noCache {
 		// Rebuild reclaims the image it just orphaned: the previous image
-		// turns dangling the moment the new build finishes (vs the pre-build
-		// prune of `build --no-cache`, which only reclaims leftovers of
-		// prior runs). Failed builds skip this — BuildKit self-cleans
-		// intermediates and `clean` is the deep-clean path.
+		// turns dangling the moment the new build finishes. Failed builds
+		// skip this — BuildKit self-cleans intermediates and `clean` is the
+		// deep-clean path.
 		pruneDanglingImages()
 		pruneBuildCache()
 	}

--- a/cmd/cheasee-pi/build_test.go
+++ b/cmd/cheasee-pi/build_test.go
@@ -24,11 +24,9 @@ func resetBuildState(t *testing.T) {
 	t.Helper()
 	buildWorkdir = ""
 	buildNoDockerCheck = false
-	buildNoCache = false
 	t.Cleanup(func() {
 		buildWorkdir = ""
 		buildNoDockerCheck = false
-		buildNoCache = false
 	})
 }
 
@@ -89,9 +87,7 @@ func logIndex(log []string, prefix string) int {
 }
 
 // composeArgv returns the captured compose-build argv ("docker compose -f ...")
-// from the serial log, or nil when no compose build ran. The prune commands
-// may precede the build (`build --no-cache` compat), so never assume the
-// compose entry is log[0].
+// from the serial log, or nil when no compose build ran.
 func (s *buildTestStub) composeArgv() []string {
 	for _, entry := range s.log {
 		if strings.HasPrefix(entry, "run:docker compose") {
@@ -132,6 +128,60 @@ func TestRebuildCmd_Flags(t *testing.T) {
 	}
 	if rebuildCmd.Flags().Lookup("no-cache") != nil {
 		t.Error("rebuild must NOT expose --no-cache (no-cache is inherent to the command)")
+	}
+}
+
+func TestBuildCmd_Registered(t *testing.T) {
+	found := false
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "build" {
+			found = true
+			if c.RunE == nil {
+				t.Error("buildCmd.RunE must be non-nil (use RunE, not Run)")
+			}
+		}
+	}
+	if !found {
+		t.Error("buildCmd must be registered on rootCmd")
+	}
+}
+
+func TestBuildCmd_NoNoCacheFlag(t *testing.T) {
+	if buildCmd.Flags().Lookup("workdir") == nil {
+		t.Error("build must expose --workdir")
+	}
+	if buildCmd.Flags().Lookup("no-docker-check") == nil {
+		t.Error("build must expose --no-docker-check")
+	}
+	if buildCmd.Flags().Lookup("no-cache") != nil {
+		t.Error("build must NOT expose --no-cache (rebuild is the no-cache path)")
+	}
+}
+
+func TestBuildCmd_Help_NoAlias(t *testing.T) {
+	output, err := testutil.RunCobra(t, rootCmd, "build", "--help")
+	if err != nil {
+		t.Fatalf("build --help: %v", err)
+	}
+	if !strings.Contains(output, "cheasee-pi rebuild") {
+		t.Errorf("build --help should point at 'cheasee-pi rebuild' for the full no-cache path\n--- output:\n%s", output)
+	}
+	for _, forbid := range []string{"--no-cache", "compatibility alias"} {
+		if strings.Contains(output, forbid) {
+			t.Errorf("build --help must not mention %q\n--- output:\n%s", forbid, output)
+		}
+	}
+}
+
+func TestBuildCmd_NoCacheFlagRejected(t *testing.T) {
+	stub := &buildTestStub{}
+	stub.install(t)
+	_, err := testutil.RunCobra(t, rootCmd, "build", "--no-cache")
+	if err == nil || !strings.Contains(err.Error(), "unknown flag: --no-cache") {
+		t.Fatalf("build --no-cache must fail with 'unknown flag: --no-cache', got %v", err)
+	}
+	if len(stub.log) != 0 {
+		t.Errorf("build --no-cache must invoke zero docker commands, got %v", stub.log)
 	}
 }
 
@@ -217,9 +267,11 @@ func TestRunBuildE_CachedBuildNoFlagsNoPrune(t *testing.T) {
 
 	stub := &buildTestStub{}
 	stub.install(t)
-	if err := runBuildE(&cobra.Command{}, nil); err != nil {
-		t.Fatalf("runBuildE: %v", err)
-	}
+	stderr := testutil.CaptureStderr(t, func() {
+		if err := runBuildE(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runBuildE: %v", err)
+		}
+	})
 	argv := stub.composeArgv()
 	for _, flag := range []string{"--no-cache", "--pull"} {
 		if slices.Contains(argv, flag) {
@@ -231,37 +283,11 @@ func TestRunBuildE_CachedBuildNoFlagsNoPrune(t *testing.T) {
 			t.Errorf("cached build must issue zero prune commands, got %v", stub.log)
 		}
 	}
-}
-
-func TestRunBuildE_NoCacheKeepsPreBuildPrune(t *testing.T) {
-	resetBuildState(t)
-	buildNoDockerCheck = true
-	buildNoCache = true
-	t.Setenv("XDG_CACHE_HOME", t.TempDir())
-	root := buildWorkspaceFixture(t)
-	chdir(t, root)
-
-	stub := &buildTestStub{}
-	stub.install(t)
-	if err := runBuildE(&cobra.Command{}, nil); err != nil {
-		t.Fatalf("runBuildE: %v", err)
+	if !strings.Contains(stderr, "Building container image...\n") {
+		t.Errorf("cached build must print the plain build label, got %q", stderr)
 	}
-	argv := stub.composeArgv()
-	if !slices.Contains(argv, "--no-cache") {
-		t.Errorf("build --no-cache must pass --no-cache, got %v", argv)
-	}
-	if slices.Contains(argv, "--pull") {
-		t.Errorf("build --no-cache must NOT pass --pull (compat path unchanged), got %v", argv)
-	}
-	composeIdx := logIndex(stub.log, "run:docker compose")
-	imagesIdx := logIndex(stub.log, "exec:docker images")
-	pruneIdx := logIndex(stub.log, "exec:docker image prune")
-	buildxIdx := logIndex(stub.log, "exec:docker buildx")
-	if composeIdx == -1 || imagesIdx == -1 || pruneIdx == -1 || buildxIdx == -1 {
-		t.Fatalf("expected compose build + full prune sequence, log: %v", stub.log)
-	}
-	if !(imagesIdx < composeIdx) {
-		t.Errorf("build --no-cache must prune BEFORE the build (compat ordering), log: %v", stub.log)
+	if strings.Contains(stderr, "full rebuild") {
+		t.Errorf("cached build must not carry the full-rebuild marker, got %q", stderr)
 	}
 }
 
@@ -540,8 +566,33 @@ func TestDailyUsageDoc_RebuildCommand(t *testing.T) {
 	if !strings.Contains(section, "rebuild = no-cache full rebuild + prune") {
 		t.Error("the section must state 'rebuild = no-cache full rebuild + prune' (naming inversion vs VS Code)")
 	}
-	if !strings.Contains(section, "compatibility") || !strings.Contains(section, "build --no-cache") {
-		t.Error("the section must demote 'cheasee-pi build --no-cache' to a compatibility note")
+	// The raw compose line keeps --no-cache --pull (direct docker compose, not
+	// the CLI flag); the CLI alias `cheasee-pi build --no-cache` must be gone.
+	if strings.Contains(section, "cheasee-pi build --no-cache") {
+		t.Error("the section must not claim 'cheasee-pi build --no-cache' as a compat path (rebuild is the only no-cache path)")
+	}
+}
+
+func TestCLIDoc_BuildNoAlias(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "cli.md"))
+	if err != nil {
+		t.Fatalf("reading docs/cli.md: %v", err)
+	}
+	content := string(data)
+	start := strings.Index(content, "## `cheasee-pi build` / `rebuild`")
+	if start == -1 {
+		t.Fatal("cli.md must have a '## `cheasee-pi build` / `rebuild`' section")
+	}
+	section := content[start:]
+
+	if !strings.Contains(section, "rebuild") {
+		t.Error("the build/rebuild section must point at `rebuild` as the no-cache path")
+	}
+	if strings.Contains(section, "--no-cache") {
+		t.Error("the build/rebuild section must not list --no-cache (rebuild is the no-cache path)")
+	}
+	if strings.Contains(section, "compatibility alias") {
+		t.Error("the build/rebuild section must not claim a compatibility alias")
 	}
 }
 

--- a/cmd/cheasee-pi/rebuild.go
+++ b/cmd/cheasee-pi/rebuild.go
@@ -25,8 +25,7 @@ pruned (containers are left untouched; that is 'cheasee-pi clean').
 
 Note: rebuild = no-cache full rebuild + prune. This inverts VS Code's
 "Rebuild Container" naming (which is the cached variant) — use 'cheasee-pi
-build' for the cached rebuild, or 'cheasee-pi build --no-cache' for the
-legacy flag path.
+build' for the cached rebuild.
 
 Examples:
   cheasee-pi rebuild               # full rebuild from scratch + prune
@@ -48,11 +47,5 @@ func runRebuildE(cmd *cobra.Command, _ []string) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return runBuild(ctx, buildOptions{
-		noCache:   true,
-		pull:      true,
-		prune:     true,
-		prunePost: true,
-		label:     true,
-	})
+	return runBuild(ctx, true, true)
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -100,14 +100,13 @@ workspace settings.
 ## `cheasee-pi build` / `rebuild`
 
 Rebuild the Docker image without starting the container. `build` reuses the
-Docker layer cache; `rebuild` is a full no-cache rebuild plus prune
-(`build --no-cache` is a compatibility alias for a full rebuild).
+Docker layer cache; `rebuild` is a full no-cache rebuild plus prune.
 
 | | |
 |---|---|
 | **Does** | Rebuilds the image from the compose/Dockerfile in the version-keyed cache dir; passes `CHEASEEPI_MEMORY` from `cheasee-settings.json` as a build arg. |
 | **Checks** | Runs from a git repo (settings + git identity come from it). Docker gate unless `--no-docker-check`. Compose validates every volume spec, so the workspace path must resolve. |
-| **Inputs** | Flags: `--workdir`, `--no-docker-check`, `--no-cache`. Reads `cheasee-settings.json` (`docker.memory`). |
+| **Inputs** | Flags: `--workdir`, `--no-docker-check`. Reads `cheasee-settings.json` (`docker.memory`). |
 | **Note** | A cached build does not apply the new image to a running container — apply with `cheasee-pi start --build` or `cheasee-pi down` + `cheasee-pi start`. |
 
 ## `cheasee-pi down`

--- a/docs/daily-usage.md
+++ b/docs/daily-usage.md
@@ -318,9 +318,7 @@ WORKSPACE_HOST_PATH=$(pwd) WORKSPACE_BARE_PATH=$(dirname "$(pwd)")/.bare \
     -f ~/.cache/cheasee-pi/<version>/docker-compose.yml build --no-cache --pull
 ```
 
-rebuild = no-cache full rebuild + prune. `cheasee-pi build --no-cache` is kept
-as a compatibility alias (same rebuild, but prunes before the build and does
-not pass `--pull`). Use `rebuild` when:
+rebuild = no-cache full rebuild + prune. Use `rebuild` when:
 - Base image (`debian:12-slim`) has security updates — `rebuild`'s `--pull`
   refreshes it; `--no-cache` alone would keep the locally cached base image
 - `apt` or `pip` packages need fresh versions


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1610

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 2m 19s | 60.3K | 39 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 1m 47s | 21.7K | 9 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 1m 22s | 32.1K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 1m 50s | 41.5K | 27 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 35s | 30.3K | 18 | gpt-5.6-luna |

**Total:** 5 runs · 8m 54s · 185.9K tokens · 107 tool calls · 7 failed (7%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1610
Closes #1610