### PR TITLE
feat(#1616): lsp-auditor: extension-less files get last character as extension (Makefile → ext 'e')

### DIFF
--- a/.pi/extensions/lsp-auditor/file-discovery.ts
+++ b/.pi/extensions/lsp-auditor/file-discovery.ts
@@ -54,8 +54,10 @@ export function groupFilesByServer(
 	for (const file of files) {
 		const ext = fileExtension(file);
 		let found = false;
+		// An empty extension (extension-less file) never matches — a mapping
+		// configured with extensions: [""] must not capture Makefile-like files.
 		for (const mapping of mappings) {
-			if (mapping.extensions.includes(ext)) {
+			if (ext !== "" && mapping.extensions.includes(ext)) {
 				const list = serverFiles.get(mapping) || [];
 				list.push(file);
 				serverFiles.set(mapping, list);

--- a/.pi/extensions/lsp-auditor/file-discovery.ts
+++ b/.pi/extensions/lsp-auditor/file-discovery.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ServerMapping } from "./types.ts";
+import { fileExtension } from "./lib/file-ext.ts";
 
 // ─── Git Diff Parsing ────────────────────────────────────────────────
 
@@ -51,7 +52,7 @@ export function groupFilesByServer(
 	const unsupported: string[] = [];
 
 	for (const file of files) {
-		const ext = file.slice(file.lastIndexOf(".")).toLowerCase();
+		const ext = fileExtension(file);
 		let found = false;
 		for (const mapping of mappings) {
 			if (mapping.extensions.includes(ext)) {

--- a/.pi/extensions/lsp-auditor/lib/file-ext.ts
+++ b/.pi/extensions/lsp-auditor/lib/file-ext.ts
@@ -1,0 +1,18 @@
+/**
+ * File extension helper for LSP Auditor.
+ *
+ * Pure string logic — zero I/O. Single owner of the "no extension → ''"
+ * decision, so callers can never re-derive extensions and regress to
+ * slice(-1) behavior (Makefile must not yield "e").
+ */
+
+import { extname } from "node:path";
+
+/**
+ * Lowercased extension of a file path, including the leading dot.
+ * Files without an extension ("Makefile", ".gitignore") yield "".
+ * Matches node:path.extname semantics exactly (e.g. "file." → ".").
+ */
+export function fileExtension(file: string): string {
+	return extname(file).toLowerCase();
+}

--- a/.pi/extensions/lsp-auditor/lsp-client/audit-one.ts
+++ b/.pi/extensions/lsp-auditor/lsp-client/audit-one.ts
@@ -16,6 +16,7 @@ import { resolve as resolvePath } from "node:path";
 import type { MessageConnection } from "vscode-jsonrpc";
 import type { LspRuntime, LspDiagnostic } from "../types.ts";
 import type { LspDiagnosticData } from "../lib/lsp-types.ts";
+import { fileExtension } from "../lib/file-ext.ts";
 import { isLspPublishDiagnosticsParams, isLspDiagnosticData } from "../lib/lsp-types.ts";
 
 // ─── Pure Helpers ────────────────────────────────────────────────────
@@ -37,6 +38,8 @@ export function languageIdForExtension(ext: string): string {
 			return "rust";
 		case ".go":
 			return "go";
+		case "":
+			return "";
 		default:
 			return ext.slice(1);
 	}
@@ -83,7 +86,11 @@ export async function openFileForAudit(
 	}
 
 	const content = await rt.readFile(fullPath, "utf-8");
-	const langId = languageIdForExtension(file.slice(file.lastIndexOf(".")).toLowerCase());
+	const langId = languageIdForExtension(fileExtension(file));
+	if (langId === "") {
+		errors.push(`Cannot determine language for file: ${file}`);
+		return;
+	}
 	const uri = `file://${fullPath}`;
 
 	// Send didOpen — awaited to prevent unhandled promise rejection.

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
@@ -20,6 +20,7 @@ import {
 } from "../formatting.ts";
 import { buildServerMappings } from "../server-mappings.ts";
 import { extractModifiedFiles, groupFilesByServer } from "../file-discovery.ts";
+import { fileExtension } from "../lib/file-ext.ts";
 import { countRetryAttempts, shouldRetry, MAX_RETRIES } from "../retry.ts";
 import { mergeAuditResults, mapSessionEntriesToRetryEntries, checkProjectTrust } from "../run-pre-audit.ts";
 import { formatForMode } from "../output-adapter.ts";
@@ -405,6 +406,78 @@ describe("shouldRetry", () => {
 	it("3 attempts → false", () => assert.strictEqual(shouldRetry(3), false));
 	it("negative → treated as 0 → true", () => assert.strictEqual(shouldRetry(-1), true));
 	it("NaN → treated as 0 → true", () => assert.strictEqual(shouldRetry(NaN), true));
+});
+
+describe("fileExtension", () => {
+	it("no-dot file → '' (bug case: must NOT yield last character)", () => {
+		assert.strictEqual(fileExtension("Makefile"), "");
+		assert.strictEqual(fileExtension("Dockerfile"), "");
+		assert.strictEqual(fileExtension("README"), "");
+		assert.strictEqual(fileExtension("changelog"), "");
+	});
+
+	it("case normalization → lowercased extension", () => {
+		assert.strictEqual(fileExtension("a.TS"), ".ts");
+	});
+
+	it("dotfile → '' (path.extname convention)", () => {
+		assert.strictEqual(fileExtension(".gitignore"), "");
+	});
+
+	it("matches path.extname edge cases exactly", () => {
+		assert.strictEqual(fileExtension("file."), ".");
+		assert.strictEqual(fileExtension(""), "");
+	});
+
+	it("dotted dirs/names → extension of last segment", () => {
+		assert.strictEqual(fileExtension("dir.with.dot/file.ts"), ".ts");
+		assert.strictEqual(fileExtension("a.b.ts"), ".ts");
+	});
+
+	it("normal path unchanged", () => {
+		assert.strictEqual(fileExtension("a.ts"), ".ts");
+	});
+});
+
+describe("groupFilesByServer no-dot regression", () => {
+	const mappings: ServerMapping[] = [
+		{ extensions: [".ts"], command: "ts-ls", args: ["--stdio"], severityThreshold: "warning" },
+		{
+			extensions: [".py"],
+			command: "pyright-langserver",
+			args: ["--stdio"],
+			severityThreshold: "warning",
+		},
+	];
+
+	it("extension-less file → unsupported, no server group (repro step 2)", () => {
+		const { serverFiles, errors } = groupFilesByServer(["Makefile"], mappings);
+		assert.strictEqual(serverFiles.size, 0);
+		assert.strictEqual(errors.length, 1);
+		assert.ok(errors[0]!.includes("Makefile"));
+	});
+
+	it("extension-less file NOT spuriously matched to single-char extension mapping", () => {
+		const withE: ServerMapping[] = [
+			{ extensions: ["e"], command: "e-ls", args: [], severityThreshold: "warning" },
+		];
+		const { serverFiles, errors } = groupFilesByServer(["Makefile"], withE);
+		assert.strictEqual(serverFiles.size, 0, "Makefile must not match extension 'e'");
+		assert.ok(errors[0]!.includes("Makefile"));
+	});
+
+	it("extension-less mixed with supported files → only supported grouped", () => {
+		const { serverFiles, errors } = groupFilesByServer(["Makefile", "a.ts", "b.py"], mappings);
+		const allFiles = [...serverFiles.values()].flat();
+		assert.deepStrictEqual(allFiles.sort(), ["a.ts", "b.py"]);
+		assert.ok(errors[0]!.includes("Makefile"));
+	});
+
+	it("dotfile → unsupported bucket, never matched", () => {
+		const { serverFiles, errors } = groupFilesByServer([".gitignore"], mappings);
+		assert.strictEqual(serverFiles.size, 0);
+		assert.ok(errors[0]!.includes(".gitignore"));
+	});
 });
 
 describe("groupFilesByServer", () => {

--- a/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-auditor.test.mts
@@ -466,6 +466,15 @@ describe("groupFilesByServer no-dot regression", () => {
 		assert.ok(errors[0]!.includes("Makefile"));
 	});
 
+	it("empty-extension mapping [''] must not capture extension-less files", () => {
+		const withEmpty: ServerMapping[] = [
+			{ extensions: [""], command: "empty-ls", args: [], severityThreshold: "warning" },
+		];
+		const { serverFiles, errors } = groupFilesByServer(["Makefile"], withEmpty);
+		assert.strictEqual(serverFiles.size, 0, "Makefile must not match extensions: ['']");
+		assert.ok(errors[0]!.includes("Makefile"));
+	});
+
 	it("extension-less mixed with supported files → only supported grouped", () => {
 		const { serverFiles, errors } = groupFilesByServer(["Makefile", "a.ts", "b.py"], mappings);
 		const allFiles = [...serverFiles.values()].flat();

--- a/.pi/extensions/lsp-auditor/test/lsp-client-split.test.mts
+++ b/.pi/extensions/lsp-auditor/test/lsp-client-split.test.mts
@@ -22,6 +22,7 @@ import {
 	languageIdForExtension,
 	lspSeverityToLabel,
 	createDiagnosticsCollector,
+	openFileForAudit,
 } from "../lsp-client/audit-one.ts";
 import { FILE_TIMEOUT_MS, DIAG_WAIT_TIMEOUT_MS } from "../lsp-client/audit-group.ts";
 
@@ -227,6 +228,10 @@ describe("audit-one.ts — pure helpers", () => {
 		assert.strictEqual(languageIdForExtension(".txt"), "txt");
 	});
 
+	it("languageIdForExtension('') → '' (explicit fail-closed contract)", () => {
+		assert.strictEqual(languageIdForExtension(""), "");
+	});
+
 	it("lspSeverityToLabel maps severity numbers", () => {
 		assert.strictEqual(lspSeverityToLabel(1), "Error");
 		assert.strictEqual(lspSeverityToLabel(2), "Warning");
@@ -234,6 +239,41 @@ describe("audit-one.ts — pure helpers", () => {
 		assert.strictEqual(lspSeverityToLabel(4), "Hint");
 		assert.strictEqual(lspSeverityToLabel(0), "Information");
 		assert.strictEqual(lspSeverityToLabel(5), "Information");
+	});
+});
+
+describe("audit-one.ts — openFileForAudit fail-closed (extension-less file)", () => {
+	it("extension-less file → no didOpen, no openedUris entry, error recorded", async () => {
+		const rt = createMockRuntime();
+		const connection = createDefaultMockConnection() as any;
+		const openedUris = new Set<string>();
+		const errors: string[] = [];
+
+		await openFileForAudit(rt, connection, "Makefile", "/worktree", openedUris, errors);
+
+		const didOpenCalls = connection.sendNotification.mock.calls.filter(
+			(c: any) => c.arguments[0] === "textDocument/didOpen",
+		);
+		assert.strictEqual(didOpenCalls.length, 0, "no didOpen sent for extension-less file");
+		assert.strictEqual(openedUris.size, 0);
+		assert.ok(errors.some((e) => e.includes("Makefile")), "per-file error recorded");
+	});
+
+	it("control: src/a.ts still sends didOpen with languageId 'typescript'", async () => {
+		const rt = createMockRuntime();
+		const connection = createDefaultMockConnection() as any;
+		const openedUris = new Set<string>();
+		const errors: string[] = [];
+
+		await openFileForAudit(rt, connection, "src/a.ts", "/worktree", openedUris, errors);
+
+		const didOpenCall = connection.sendNotification.mock.calls.find(
+			(c: any) => c.arguments[0] === "textDocument/didOpen",
+		);
+		assert.ok(didOpenCall, "didOpen should have been sent");
+		assert.strictEqual(didOpenCall.arguments[1].textDocument.languageId, "typescript");
+		assert.strictEqual(openedUris.size, 1);
+		assert.strictEqual(errors.length, 0);
 	});
 });
 


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1616

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✓ SUCCESS | 20m 10s | 74.0K | 35 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 13m 39s | 23.3K | 11 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 4m 23s | 32.0K | 14 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 10m 22s | 43.7K | 33 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 6m 28s | 74.3K | 26 | gpt-5.6-luna |
| developer | ✓ SUCCESS | 4m 42s | 33.0K | 13 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 7m 16s | 128.9K | 19 | gpt-5.6-luna |

**Total:** 7 runs · 66m 59s · 409.2K tokens · 151 tool calls · 9 failed (6%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1616
Closes #1616