### PR TITLE
feat(#1615): format-on-save: ESLint fallback uses removed useEslintrc option — config-error fallback dead on eslint >= 9

### DIFF
--- a/.pi/extensions/format-on-save/eslint-adapter.mts
+++ b/.pi/extensions/format-on-save/eslint-adapter.mts
@@ -22,6 +22,15 @@ import type { Linter } from "./ports.mts";
 
 const SUPPORTED_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx"] as const;
 
+/**
+ * Files glob for the fallback's minimal flat config.
+ * Mirrors SUPPORTED_EXTENSIONS plus common JS/TS variants so the
+ * no-config fallback actually matches the linted file. Without a
+ * files-matching object, flat config reports "File ignored because no
+ * matching configuration was supplied" instead of linting.
+ */
+const FALLBACK_FILES = "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}";
+
 // ─── ESLint Result Types ──────────────────────────────────────────────
 
 /** A single message from ESLint result. */
@@ -193,14 +202,72 @@ export class EslintLinter implements Linter {
 
 	/**
 	 * Create a fallback ESLint instance with no project config.
+	 *
+	 * ESLint v9+ is flat-config-only: `useEslintrc` was removed and the
+	 * constructor throws "Invalid Options" on it, so "no project config"
+	 * must be expressed as `overrideConfigFile: true` (skip config-file
+	 * lookup) plus a minimal files-matching `overrideConfig`. v8 (EOL
+	 * 2024-10-05) and below keep the legacy eslintrc-era option.
 	 */
 	private async createFallbackESLint(): Promise<ESLintInstance> {
 		const { ESLint } = await import("eslint");
-		const instance = new ESLint({
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			useEslintrc: false,
-		} as any) as unknown as ESLintInstance;
+		const version = String((ESLint as unknown as { version?: string }).version ?? "");
+		const config = await this.buildFallbackConfig();
+		const options = this.buildFallbackOptions(version, config);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const instance = new ESLint(options as any) as unknown as ESLintInstance;
 		return instance;
+	}
+
+	/**
+	 * Fallback constructor options for the installed ESLint major.
+	 * Flat config (>= 9): skip config-file lookup and apply the minimal
+	 * `overrideConfig`. Legacy eslintrc (<= 8): `--no-eslintrc` equivalent.
+	 */
+	private buildFallbackOptions(version: string, config: unknown[]): unknown {
+		const major = Number(version.split(".")[0]);
+		return major >= 9
+			? { overrideConfigFile: true, overrideConfig: config }
+			: { useEslintrc: false };
+	}
+
+	/**
+	 * Minimal flat config for the fallback: modern ECMAScript parsing for
+	 * all supported extensions, plus the typescript-eslint parser when the
+	 * package happens to be installed (throws nothing otherwise — espree's
+	 * TS parse failures surface as messages, not throws).
+	 */
+	private async buildFallbackConfig(): Promise<unknown[]> {
+		const config: unknown[] = [
+			{
+				files: [FALLBACK_FILES],
+				languageOptions: { ecmaVersion: "latest", sourceType: "module" },
+			},
+		];
+		const tsParser = await this.resolveTsParser();
+		if (tsParser) {
+			config.push({
+				files: ["**/*.{ts,mts,cts,tsx}"],
+				languageOptions: { parser: tsParser },
+			});
+		}
+		return config;
+	}
+
+	/**
+	 * Resolve the typescript-eslint parser when installed, else null.
+	 * The parser is optional: without it the fallback still lints `.ts`
+	 * files (espree reports fatal parse diagnostics instead of throwing).
+	 */
+	private async resolveTsParser(): Promise<unknown> {
+		try {
+			// @ts-expect-error — typescript-eslint is an optional peer; the
+			// package is only resolved at runtime when the project has it
+			const mod = await import("typescript-eslint");
+			return (mod as { parser?: unknown }).parser ?? null;
+		} catch {
+			return null;
+		}
 	}
 
 	/**
@@ -245,9 +312,11 @@ export class EslintLinter implements Linter {
 	 *   2. Keyword matching — fallback for legacy eslintrc error formats
 	 */
 	private isConfigError(err: unknown): boolean {
-		// Tier 1: precise name check for ESLint v9+ flat config ConfigError
+		// Tier 1: precise name checks — ConfigError for ESLint v9+ flat
+		// config; SyntaxError for syntax-broken config files (throws while
+		// loading, while linted-source parse failures come back as messages)
 		const name = (err as { name?: string } | null)?.name;
-		if (name === "ConfigError") {
+		if (name === "ConfigError" || name === "SyntaxError") {
 			return true;
 		}
 		// Tier 2: keyword fallback for legacy eslintrc error formats

--- a/.pi/extensions/format-on-save/eslint-adapter.mts
+++ b/.pi/extensions/format-on-save/eslint-adapter.mts
@@ -296,12 +296,29 @@ export class EslintLinter implements Linter {
 	 * Extract a human-readable message from an unknown error value.
 	 * Handles Error instances, plain objects with a `message` property, and
 	 * any other value via String().
+	 *
+	 * Preserves the error name (e.g. "SyntaxError: Unexpected end of input")
+	 * so config-error detection by name still works on the user-visible
+	 * error string — a bare message like "Unexpected end of input" would
+	 * otherwise lose the "SyntaxError" marker the handler keys on.
 	 */
 	private getErrorMessage(err: unknown): string {
-		if (err instanceof Error) return err.message;
-		const msg = (err as { message?: unknown } | null)?.message;
-		if (typeof msg === "string") return msg;
-		return String(err);
+		let message: string;
+		if (err instanceof Error) {
+			message = err.message;
+		} else {
+			const msg = (err as { message?: unknown } | null)?.message;
+			if (typeof msg === "string") {
+				message = msg;
+			} else {
+				return String(err);
+			}
+		}
+		const name = (err as { name?: unknown } | null)?.name;
+		if (typeof name === "string" && name.length > 0 && name !== "Error") {
+			return `${name}: ${message}`;
+		}
+		return message;
 	}
 
 	/**

--- a/.pi/extensions/format-on-save/index.ts
+++ b/.pi/extensions/format-on-save/index.ts
@@ -149,6 +149,7 @@ async function handleFormat(
 function isConfigErrorMessage(message: string): boolean {
 	return (
 		message.includes("ConfigError") ||
+		message.includes("SyntaxError") ||
 		message.includes("Failed to load") ||
 		message.includes("Could not find") ||
 		message.includes("eslint.config") ||

--- a/.pi/extensions/format-on-save/test/format-on-save.test.mts
+++ b/.pi/extensions/format-on-save/test/format-on-save.test.mts
@@ -2504,4 +2504,40 @@ describe("handler — [config error] prefix for SyntaxError config errors", () =
 			cleanup();
 		}
 	});
+
+	it("real adapter result (broken config SyntaxError) through handler → [config error] prefix", async () => {
+		// Integration: real EslintLinter + real eslint on a broken
+		// eslint.config.mjs fixture; the resulting LintResult.error flows
+		// through the handler, which must classify it as a config error
+		// (relies on getErrorMessage preserving the "SyntaxError" name).
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const { dir, jsFile, cleanup } = createBrokenConfigFixture();
+		const linter = new EslintLinter(); // real eslint + real fs
+		const { consoleErrorCalls, cleanup: handlerCleanup } = await runHandlerWithMocks(
+			{ canHandle: () => false, format: async () => ({ formatted: false }) } as Formatter,
+			linter,
+			{ input: { path: jsFile } },
+			{ mode: "tui" },
+		);
+		try {
+			assert.ok(dir, "fixture dir exists");
+			const match = consoleErrorCalls.find((c) => c.includes("lint error"));
+			assert.ok(match, "should have lint error log");
+			assert.ok(
+				match!.includes("SyntaxError"),
+				"preserved error name must reach the handler message",
+			);
+			assert.ok(
+				match!.includes("[config error]"),
+				"real broken-config result must be prefixed as a config error",
+			);
+			assert.ok(
+				!match!.includes("Invalid Options") && !match!.includes("useEslintrc"),
+				"removed-option constructor error must never surface",
+			);
+		} finally {
+			handlerCleanup();
+			cleanup();
+		}
+	});
 });

--- a/.pi/extensions/format-on-save/test/format-on-save.test.mts
+++ b/.pi/extensions/format-on-save/test/format-on-save.test.mts
@@ -9,7 +9,7 @@
  */
 
 import assert from "node:assert";
-import { describe, it, mock } from "node:test";
+import { describe, it } from "node:test";
 
 import { registerHandler } from "../index.ts";
 import { formatEslintDiagnostics } from "../eslint.mts";
@@ -2221,5 +2221,287 @@ describe("EslintLinter — singleton promise", () => {
 		const result2 = await l.lint("/path/file.ts");
 		assert.ok(result2.error);
 		assert.strictEqual(factoryCallCount, 1, "factory must still be called exactly once");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// ESLint fallback — flat config (useEslintrc removed in v9)
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * Fixture dir with a syntax-broken eslint.config.mjs plus clean .js/.ts
+ * sources. Non-dot-prefixed (flat config ignores dot-directories).
+ */
+function createBrokenConfigFixture(): {
+	dir: string;
+	jsFile: string;
+	tsFile: string;
+	cleanup: () => void;
+} {
+	const dir = mkdtempSync(join(tmpdir(), "fos-eslint-fallback-"));
+	writeFileSync(join(dir, "eslint.config.mjs"), "export default [");
+	const jsFile = join(dir, "a.js");
+	writeFileSync(jsFile, "const x = 1;\n");
+	const tsFile = join(dir, "a.ts");
+	writeFileSync(tsFile, "const x: number = 1;\n");
+	return { dir, jsFile, tsFile, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/** Run fn with cwd set to dir; restoration guaranteed even on throw. */
+async function withCwd(dir: string, fn: () => Promise<unknown>): Promise<unknown> {
+	const oldCwd = process.cwd();
+	process.chdir(dir);
+	try {
+		return await fn();
+	} finally {
+		process.chdir(oldCwd);
+	}
+}
+
+describe("EslintLinter — flat-config fallback (useEslintrc removed)", () => {
+	// ── Phase 1: fallback constructor works on flat config ───────────
+
+	it("createFallbackESLint constructs without throwing on the installed eslint (dead-constructor regression)", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const l = new EslintLinter();
+		// REAL eslint via the private method — must not mock createFallbackESLint
+		const instance = await (l as any).createFallbackESLint();
+		assert.ok(instance, "fallback instance should construct on flat config");
+		assert.ok(!String((l as any).buildFallbackOptions("10.8.0", [])).includes("useEslintrc"));
+	});
+
+	it("lint() falls back on a broken config for .js — real config SyntaxError, never Invalid Options", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const { dir, jsFile, cleanup } = createBrokenConfigFixture();
+		try {
+			const l = new EslintLinter(); // default factory — real eslint
+			const result = (await withCwd(dir, () => l.lint(jsFile))) as Awaited<ReturnType<typeof l.lint>>;
+			assert.ok(result.error, "should surface the original config error");
+			assert.ok(
+				result.error!.includes("Unexpected end of input"),
+				"error should carry the original SyntaxError text",
+			);
+			assert.ok(
+				!result.error!.includes("Invalid Options") && !result.error!.includes("useEslintrc"),
+				"must never surface the removed-option constructor error",
+			);
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("lint() completes on a broken config for .ts — fallback ran, config error preserved", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const { dir, tsFile, cleanup } = createBrokenConfigFixture();
+		try {
+			const l = new EslintLinter();
+			const result = (await withCwd(dir, () => l.lint(tsFile))) as Awaited<ReturnType<typeof l.lint>>;
+			assert.ok(result.error, "config error preserved");
+			assert.ok(result.error!.includes("Unexpected end of input"));
+			assert.ok(
+				!result.error!.includes("Invalid Options") && !result.error!.includes("useEslintrc"),
+				"must never surface the removed-option constructor error",
+			);
+			// espree cannot parse TS — parse failure may surface as mapped
+			// diagnostics; the key assertion is the fallback ran (no throw)
+			assert.ok(Array.isArray(result.diagnostics));
+		} finally {
+			cleanup();
+		}
+	});
+
+	it("fallback constructor options: flat config on 9+, legacy useEslintrc on v8", async () => {
+		// eslint 8 (EOL 2024-10-05) is not installable here; the exact
+		// option objects for both branches are asserted via the pure
+		// buildFallbackOptions gate below, and the flat branch is proven
+		// against the real installed eslint by the constructor regression
+		// test (passing useEslintrc on v9+ would throw "Invalid Options").
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const l = new EslintLinter();
+		const cfg: unknown[] = [{ files: ["**/*.js"] }];
+
+		// Flat branch (major >= 9): skip config lookup + non-empty config
+		const flat = (l as any).buildFallbackOptions("10.8.0", cfg) as {
+			overrideConfigFile?: boolean;
+			overrideConfig?: unknown[];
+			useEslintrc?: unknown;
+		};
+		assert.ok(!("useEslintrc" in flat), "must not pass the removed useEslintrc option");
+		assert.strictEqual(flat.overrideConfigFile, true, "must skip config-file lookup");
+		assert.ok(
+			Array.isArray(flat.overrideConfig) && flat.overrideConfig.length > 0,
+			"must carry a non-empty minimal config",
+		);
+
+		// Legacy branch (major < 9): eslintrc-era option
+		assert.deepStrictEqual((l as any).buildFallbackOptions("8.57.0", cfg), {
+			useEslintrc: false,
+		});
+	});
+
+	it("fallback options gate on the ESLint major: v8 legacy, v9/v10 flat", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const l = new EslintLinter();
+		const cfg: unknown[] = [{ files: ["**/*.js"] }];
+		assert.deepStrictEqual((l as any).buildFallbackOptions("8.57.0", cfg), {
+			useEslintrc: false,
+		});
+		assert.deepStrictEqual((l as any).buildFallbackOptions("9.0.0", cfg), {
+			overrideConfigFile: true,
+			overrideConfig: cfg,
+		});
+		assert.deepStrictEqual((l as any).buildFallbackOptions("10.8.0", cfg), {
+			overrideConfigFile: true,
+			overrideConfig: cfg,
+		});
+	});
+
+	// ── Phase 2: config-error detection — SyntaxError tier ───────────
+
+	it("isConfigError returns true for SyntaxError (syntax-broken config file)", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const l = new EslintLinter();
+		assert.strictEqual(
+			(l as any).isConfigError({ name: "SyntaxError", message: "Unexpected end of input" }),
+			true,
+		);
+	});
+
+	it("isConfigError still classifies ConfigError/legacy keywords and rejects non-config errors", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const l = new EslintLinter();
+		assert.strictEqual((l as any).isConfigError({ name: "ConfigError", message: "bad" }), true);
+		assert.strictEqual(
+			(l as any).isConfigError({ name: "Error", message: "Failed to load config" }),
+			true,
+		);
+		assert.strictEqual(
+			(l as any).isConfigError({ name: "TypeError", message: "Cannot read properties of undefined" }),
+			false,
+		);
+	});
+
+	// ── Phase 3: fallback config shape ───────────────────────────────
+
+	it("buildFallbackConfig returns a non-empty files-matching config covering all supported extensions", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const l = new EslintLinter();
+		const config = (await (l as any).buildFallbackConfig()) as Array<{
+			files?: string[];
+			languageOptions?: { ecmaVersion?: string; sourceType?: string };
+		}>;
+		assert.ok(Array.isArray(config) && config.length > 0, "config must not be []");
+		const files = config[0]!.files;
+		assert.ok(files && files.length > 0, "first object must carry a files glob");
+		for (const ext of [".ts", ".tsx", ".js", ".jsx"]) {
+			assert.ok(
+				files[0]!.includes(ext.slice(1)),
+				`files glob should cover ${ext}: ${files[0]}`,
+			);
+		}
+		assert.deepStrictEqual(config[0]!.languageOptions, {
+			ecmaVersion: "latest",
+			sourceType: "module",
+		});
+	});
+
+	it("buildFallbackConfig wires the TS parser when resolvable; stays non-empty without it", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+
+		// Unresolvable branch — typescript-eslint is not installed here
+		const l = new EslintLinter();
+		const noParser = (await (l as any).buildFallbackConfig()) as Array<{
+			files?: string[];
+			languageOptions?: { parser?: unknown };
+		}>;
+		assert.strictEqual(noParser.length, 1, "no parser entry without typescript-eslint");
+		assert.ok(noParser[0]!.files && noParser[0]!.files!.length > 0, "still a non-empty config");
+
+		// Resolvable branch — override the resolver to simulate installation
+		const l2 = new EslintLinter();
+		(l2 as any).resolveTsParser = async () => ({ meta: { name: "typescript-eslint/parser" } });
+		const withParser = (await (l2 as any).buildFallbackConfig()) as Array<{
+			files?: string[];
+			languageOptions?: { parser?: unknown };
+		}>;
+		assert.strictEqual(withParser.length, 2, "parser entry appended");
+		const tsEntry = withParser[1]!;
+		assert.ok(tsEntry.files![0]!.includes("ts"), "parser entry targets ts/tsx");
+		assert.ok(tsEntry.languageOptions?.parser, "parser wired into the config");
+	});
+
+	it("fallback lints a syntactically broken source file — parse diagnostic with ruleId null", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const dir = mkdtempSync(join(tmpdir(), "fos-eslint-fallback-"));
+		writeFileSync(join(dir, "eslint.config.mjs"), "export default [");
+		const brokenFile = join(dir, "broken.js");
+		writeFileSync(brokenFile, "const x = ;\n");
+		try {
+			const l = new EslintLinter();
+			const result = (await withCwd(dir, () => l.lint(brokenFile))) as Awaited<
+				ReturnType<typeof l.lint>
+			>;
+			assert.ok(result.error, "config error preserved alongside fallback diagnostics");
+			assert.ok(result.error!.includes("Unexpected end of input"));
+			assert.strictEqual(result.diagnostics.length, 1, "fallback should lint, not return empty");
+			assert.strictEqual(result.diagnostics[0]!.ruleId, null);
+			assert.ok(result.diagnostics[0]!.message.includes("Parsing error"));
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	// ── Phase 4: enrichment with empty fallback results ──────────────
+
+	it("lint with config error and empty fallback results returns empty diagnostics with enriched error", async () => {
+		const { EslintLinter } = await import("../eslint-adapter.mts");
+		const mockESLint = async () => ({
+			lintText: async () => {
+				throw { name: "ConfigError", message: "bad config" };
+			},
+		});
+		const mockFallback = async () => ({
+			lintText: async () => [],
+		});
+
+		const l = new EslintLinter(mockESLint as any);
+		(l as any).readFile = async () => "const x = 1;\n";
+		(l as any).createFallbackESLint = mockFallback;
+
+		const result = await l.lint("/path/file.ts");
+		assert.strictEqual(result.diagnostics.length, 0);
+		assert.strictEqual(result.fixesApplied, false);
+		assert.ok(result.error && result.error.includes("bad config"), "original error enriched");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════
+// Phase 5: Handler — [config error] prefix for SyntaxError config errors
+// ═══════════════════════════════════════════════════════════════════════
+
+describe("handler — [config error] prefix for SyntaxError config errors", () => {
+	it("SyntaxError config message in lint result → console.error includes [config error]", async () => {
+		const linter: Linter = {
+			canHandle: () => true,
+			lint: async () => ({
+				diagnostics: [],
+				fixesApplied: false,
+				error: "SyntaxError: Unexpected end of input",
+			}),
+		};
+
+		const { consoleErrorCalls, cleanup } = await runHandlerWithMocks(
+			{ canHandle: () => true, format: async () => ({ formatted: false }) } as Formatter,
+			linter,
+			{},
+			{ mode: "tui" },
+		);
+		try {
+			const match = consoleErrorCalls.find((c) => c.includes("lint error"));
+			assert.ok(match, "should have lint error log");
+			assert.ok(match!.includes("[config error]"), "SyntaxError config message must be prefixed");
+		} finally {
+			cleanup();
+		}
 	});
 });


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1615

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| researcher | ✗ FAILED | 30m 0s | 66.0K | 11 | deepseek-v4-flash |
| researcher | ✓ SUCCESS (after retry) | 15m 50s | 82.1K | 19 | deepseek-v4-flash |
| architect | ✓ SUCCESS | 8m 5s | 32.7K | 17 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 9m 36s | 31.4K | 18 | deepseek-v4-flash |
| developer | ✓ SUCCESS | 27m 54s | 74.2K | 53 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 3m 38s | 109.7K | 25 | gpt-5.6-luna |
| developer | ✓ SUCCESS | 3m 25s | 41.0K | 19 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 12s | 59.3K | 20 | gpt-5.6-luna |

**Total:** 8 runs · 100m 40s · 496.4K tokens · 182 tool calls · 14 failed (8%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1615
Closes #1615