### PR TITLE
feat(#1614): ask-user: /qna list ids do not match /qna get after rotation (list/get index mismatch)

### DIFF
--- a/.pi/extensions/ask-user/index.ts
+++ b/.pi/extensions/ask-user/index.ts
@@ -14,6 +14,7 @@
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { QuestionParams, QnaReadParams } from "./types.ts";
+import type { QnaEntry, QnaListedEntry } from "./types.ts";
 import {
 	migrateIfCsvExists,
 	listQnaEntries,
@@ -32,19 +33,16 @@ function truncate(s: string, maxLen: number): string {
 	return s.slice(0, maxLen - 1) + "…";
 }
 
-function formatTable(
-	entries: Array<{ datetime: string; question: string; answer: string }>,
-): string {
+function formatTable(entries: QnaListedEntry[]): string {
 	const rows: string[] = [];
 	rows.push("| # | Datetime | Question | Answer |");
 	rows.push("|---|---|---|---|");
-	for (let i = 0; i < entries.length; i++) {
-		const e = entries[i]!;
-		const id = i + 1;
+	for (const e of entries) {
 		const q = truncate(e.question, 60).replace(/\|/g, "\\|").replace(/\n/g, " ");
 		const a = truncate(e.answer, 40).replace(/\|/g, "\\|").replace(/\n/g, " ");
 		const dt = truncate(e.datetime, 24);
-		rows.push(`| ${id} | ${dt} | ${q} | ${a} |`);
+		// Render the absolute id the storage layer tagged — never renumber.
+		rows.push(`| ${e.id} | ${dt} | ${q} | ${a} |`);
 	}
 	return rows.join("\n");
 }
@@ -142,9 +140,9 @@ export default function askUser(pi: ExtensionAPI): void {
 					limit = parseInt(limitMatch[1]!, 10);
 				}
 
-				let entries: Array<{ datetime: string; question: string; answer: string }>;
+				let result: { entries: QnaListedEntry[]; total: number };
 				try {
-					entries = await listQnaEntries(projectDir, limit);
+					result = await listQnaEntries(projectDir, limit);
 				} catch (err) {
 					pi.sendUserMessage?.(`Error reading Q&A history: ${(err as Error).message}`, {
 						deliverAs: "followUp",
@@ -152,13 +150,16 @@ export default function askUser(pi: ExtensionAPI): void {
 					return;
 				}
 
-				if (entries.length === 0) {
+				if (result.entries.length === 0) {
 					pi.sendUserMessage?.("No Q&A history yet.", { deliverAs: "followUp" });
 					return;
 				}
 
-				const table = formatTable(entries);
-				pi.sendUserMessage?.(table, { deliverAs: "followUp" });
+				const table = formatTable(result.entries);
+				const first = result.entries[0]!.id;
+				const last = result.entries[result.entries.length - 1]!.id;
+				const footer = `Showing #${first}–#${last} of ${result.total}`;
+				pi.sendUserMessage?.([table, "", footer].join("\n"), { deliverAs: "followUp" });
 				return;
 			}
 
@@ -215,7 +216,7 @@ export default function askUser(pi: ExtensionAPI): void {
 					return;
 				}
 
-				let entries: Array<{ datetime: string; question: string; answer: string }>;
+				let entries: QnaListedEntry[];
 				try {
 					entries = await queryQnaEntries(projectDir, subargs);
 				} catch (err) {
@@ -247,9 +248,10 @@ export default function askUser(pi: ExtensionAPI): void {
 		},
 	});
 
-	function successResult<T extends { datetime: string; question: string; answer: string }>(
+	function successResult<T extends QnaEntry>(
 		entries: T[],
 		count: number,
+		total?: number,
 	): {
 		content: Array<{ type: "text"; text: string }>;
 		details: Record<string, unknown>;
@@ -261,11 +263,17 @@ export default function askUser(pi: ExtensionAPI): void {
 					text: JSON.stringify({
 						entries,
 						count,
+						...(total !== undefined ? { total } : {}),
 						...(entries.length === 0 ? { message: "No Q&A history yet" } : {}),
 					}),
 				},
 			],
-			details: { format: "qna-result-v1", entries, count },
+			details: {
+				format: "qna-result-v1",
+				entries,
+				count,
+				...(total !== undefined ? { total } : {}),
+			},
 		};
 	}
 
@@ -330,8 +338,8 @@ export default function askUser(pi: ExtensionAPI): void {
 
 			try {
 				if (action === "list") {
-					const entries = await listQnaEntries(projectDir, limit);
-					return successResult(entries, entries.length);
+					const { entries, total } = await listQnaEntries(projectDir, limit);
+					return successResult(entries, entries.length, total);
 				}
 
 				if (action === "get") {

--- a/.pi/extensions/ask-user/index.ts
+++ b/.pi/extensions/ask-user/index.ts
@@ -282,12 +282,13 @@ export default function askUser(pi: ExtensionAPI): void {
 		name: "ask_user_read",
 		label: "Read Q&A History",
 		description:
-			"Read past Q&A entries from the ask-user log. Supports list, get, and query actions. Returns structured JSON with entries array and count.",
-		promptSnippet: "Read Q&A history entries",
+			"Read past Q&A entries from the ask-user log. Supports list, get, and query actions. Every returned entry carries an absolute id (its position in the full history); list responses also include total (full history size). Always call get with the entries[].id value returned by list or query.",
+		promptSnippet: "Read Q&A history entries by absolute id",
 		promptGuidelines: [
-			"Use action:'list' to get recent entries (optionally with limit parameter).",
-			"Use action:'get' with id parameter to get a single entry by 1-based line number.",
-			"Use action:'query' with text parameter to search question and answer fields (case-insensitive).",
+			"Use action:'list' to get the most recent entries (optional limit, default 20). Each returned entry includes an absolute id — call get with exactly that entries[].id value.",
+			"Use action:'get' with the id of an entry as returned by list or query (an absolute id in the full history). Never derive ids by counting rows or array positions: when the log has more than 20 entries, list returns only the most recent slice, so positional numbers 1..N do not resolve to the entries shown.",
+			"Use action:'query' with text parameter to search question and answer fields (case-insensitive). Query results also carry absolute ids and are get-able the same way.",
+			"total in list responses is the full history size — entries may be a truncated subset (the most recent limit entries) when the log is longer than the limit.",
 		],
 		parameters: QnaReadParams,
 		async execute(

--- a/.pi/extensions/ask-user/jsonl-logger.ts
+++ b/.pi/extensions/ask-user/jsonl-logger.ts
@@ -9,7 +9,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import type { QnaEntry } from "./types.ts";
+import type { QnaEntry, QnaListedEntry } from "./types.ts";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -341,22 +341,41 @@ export async function getQnaEntry(
 /**
  * List the last N Q&A entries.
  * Default limit is 20.
+ *
+ * Each returned entry carries its absolute 1-based id (position in the full
+ * merged history), so `getQnaEntry(projectDir, entry.id)` always fetches the
+ * same entry the list displays — even when the log has more entries than the
+ * limit and only the tail is returned. `total` is the full history size.
  */
-export async function listQnaEntries(projectDir: string, limit: number = 20): Promise<QnaEntry[]> {
+export async function listQnaEntries(
+	projectDir: string,
+	limit: number = 20,
+): Promise<{ entries: QnaListedEntry[]; total: number }> {
 	const entries = await readQnaEntries(projectDir);
-	return entries.slice(-limit);
+	const total = entries.length;
+	// start and id math share one source, so the slice offset and the
+	// absolute ids can never disagree (start = total - limit + 1 for ids)
+	const start = Math.max(0, total - limit);
+	const listed = entries.slice(start).map((e, i) => ({ ...e, id: start + i + 1 }));
+	return { entries: listed, total };
 }
 
 /**
  * Search Q&A entries by text (case-insensitive) in question AND answer fields.
+ * Matched entries carry their absolute 1-based id, so results are `get`-able.
  */
-export async function queryQnaEntries(projectDir: string, text: string): Promise<QnaEntry[]> {
+export async function queryQnaEntries(
+	projectDir: string,
+	text: string,
+): Promise<QnaListedEntry[]> {
 	const entries = await readQnaEntries(projectDir);
 	const lowerText = text.toLowerCase();
-	return entries.filter(
-		(e) =>
-			e.question.toLowerCase().includes(lowerText) || e.answer.toLowerCase().includes(lowerText),
-	);
+	return entries
+		.map((e, i) => ({ ...e, id: i + 1 }))
+		.filter(
+			(e) =>
+				e.question.toLowerCase().includes(lowerText) || e.answer.toLowerCase().includes(lowerText),
+		);
 }
 
 // ---------------------------------------------------------------------------

--- a/.pi/extensions/ask-user/jsonl-logger.ts
+++ b/.pi/extensions/ask-user/jsonl-logger.ts
@@ -353,9 +353,14 @@ export async function listQnaEntries(
 ): Promise<{ entries: QnaListedEntry[]; total: number }> {
 	const entries = await readQnaEntries(projectDir);
 	const total = entries.length;
+	// Normalize limit to a non-negative integer BEFORE both slicing and id
+	// assignment: Array.prototype.slice truncates its index toward zero, so
+	// a fractional limit (e.g. 1.5) would slice at index 1 but compute ids
+	// 2.5/3.5 — ids nobody can `get`. Clamp negatives to 0 (empty list).
+	const normalized = Number.isFinite(limit) ? Math.max(0, Math.trunc(limit)) : 0;
 	// start and id math share one source, so the slice offset and the
 	// absolute ids can never disagree (start = total - limit + 1 for ids)
-	const start = Math.max(0, total - limit);
+	const start = Math.max(0, total - normalized);
 	const listed = entries.slice(start).map((e, i) => ({ ...e, id: start + i + 1 }));
 	return { entries: listed, total };
 }

--- a/.pi/extensions/ask-user/test/ask-user.test.mts
+++ b/.pi/extensions/ask-user/test/ask-user.test.mts
@@ -649,6 +649,21 @@ describe("list/search absolute ids (issue #1614)", () => {
 		assert.strictEqual(entries[0]!.id, 30);
 	});
 
+	it("fractional limit → truncated integer, ids integral and get-able", async () => {
+		await appendN(30);
+		// 1.5 must behave exactly like 1 (slice truncates its index toward
+		// zero, so ids must come from the same integer). The bug produced
+		// fractional ids (29.5/30.5) that no get could resolve.
+		const { entries, total } = await listQnaEntries(tmpDir, 1.5);
+		assert.strictEqual(total, 30);
+		assert.strictEqual(entries.length, 1, "trunc(1.5) = 1 entry, not 2");
+		assert.ok(Number.isInteger(entries[0]!.id), "id must be an integer");
+		assert.strictEqual(entries[0]!.id, 30);
+		const fetched = await getQnaEntry(tmpDir, entries[0]!.id);
+		assert.ok(fetched !== null && fetched !== undefined);
+		assert.deepStrictEqual(fetched, stripId(entries[0]!));
+	});
+
 	it("limit=0 → empty entries, total N", async () => {
 		await appendN(30);
 		const { entries, total } = await listQnaEntries(tmpDir, 0);

--- a/.pi/extensions/ask-user/test/ask-user.test.mts
+++ b/.pi/extensions/ask-user/test/ask-user.test.mts
@@ -524,27 +524,40 @@ describe("getQnaEntry / listQnaEntries / queryQnaEntries (real I/O)", () => {
 	});
 
 	it("listQnaEntries returns last N entries", async () => {
-		const entries = await listQnaEntries(tmpDir, 3);
+		const { entries, total } = await listQnaEntries(tmpDir, 3);
 		assert.strictEqual(entries.length, 3);
+		assert.strictEqual(total, 5);
 		assert.strictEqual(entries[0]!.question, "What is your favorite color?");
 		assert.strictEqual(entries[2]!.question, "How JSONL works?");
+		// Absolute ids: last 3 of 5 → 3, 4, 5
+		assert.deepStrictEqual(
+			entries.map((e) => e.id),
+			[3, 4, 5],
+		);
 	});
 
 	it("listQnaEntries defaults to 20", async () => {
-		const entries = await listQnaEntries(tmpDir);
+		const { entries, total } = await listQnaEntries(tmpDir);
 		assert.strictEqual(entries.length, 5, "Should return all when less than limit");
+		assert.strictEqual(total, 5);
+		assert.deepStrictEqual(
+			entries.map((e) => e.id),
+			[1, 2, 3, 4, 5],
+		);
 	});
 
 	it("queryQnaEntries searches question field", async () => {
 		const entries = await queryQnaEntries(tmpDir, "semicolons");
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0]!.question, "Explain semicolons in CSV");
+		assert.strictEqual(entries[0]!.id, 4);
 	});
 
 	it("queryQnaEntries searches answer field", async () => {
 		const entries = await queryQnaEntries(tmpDir, "Grail");
 		assert.strictEqual(entries.length, 1);
 		assert.strictEqual(entries[0]!.answer, "To seek the Holy Grail");
+		assert.strictEqual(entries[0]!.id, 2);
 	});
 
 	it("queryQnaEntries is case-insensitive", async () => {
@@ -555,6 +568,158 @@ describe("getQnaEntry / listQnaEntries / queryQnaEntries (real I/O)", () => {
 	it("queryQnaEntries returns empty for no match", async () => {
 		const entries = await queryQnaEntries(tmpDir, "zzz_nonexistent");
 		assert.strictEqual(entries.length, 0);
+	});
+});
+
+// ============================================================================
+// Integration tests: absolute ids on list/search (issue #1614)
+// ============================================================================
+
+describe("list/search absolute ids (issue #1614)", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-user-abs-id-test-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Append N entries, each "Entry i" / "Answer i". */
+	async function appendN(n: number): Promise<void> {
+		for (let i = 1; i <= n; i++) {
+			const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+			await appendQnaEntry(tmpDir, ts, `Entry ${i}`, `Answer ${i}`);
+		}
+	}
+
+	/** Strip the absolute id to compare against plain QnaEntry. */
+	function stripId(e: { datetime: string; question: string; answer: string; id: number }): QnaEntry {
+		return { datetime: e.datetime, question: e.question, answer: e.answer };
+	}
+
+	it("total < limit → all entries with ids 1..N and total N", async () => {
+		await appendN(3);
+		const { entries, total } = await listQnaEntries(tmpDir, 20);
+		assert.strictEqual(total, 3);
+		assert.strictEqual(entries.length, 3);
+		assert.deepStrictEqual(
+			entries.map((e) => e.id),
+			[1, 2, 3],
+		);
+	});
+
+	it("total == limit → ids 1..N", async () => {
+		await appendN(5);
+		const { entries, total } = await listQnaEntries(tmpDir, 5);
+		assert.strictEqual(total, 5);
+		assert.deepStrictEqual(
+			entries.map((e) => e.id),
+			[1, 2, 3, 4, 5],
+		);
+	});
+
+	it("30 entries, limit 20 → first row id 11, last row id 30, total 30", async () => {
+		await appendN(30);
+		const { entries, total } = await listQnaEntries(tmpDir, 20);
+		assert.strictEqual(total, 30);
+		assert.strictEqual(entries.length, 20);
+		// start = total - limit, id = start + i + 1 → 11..30. A naive baseIndex
+		// of 10 (total - limit, without +1) must fail this assertion.
+		assert.strictEqual(entries[0]!.id, 11);
+		assert.strictEqual(entries[entries.length - 1]!.id, 30);
+	});
+
+	it("roundtrip: every row in a truncated list is fetchable via getQnaEntry(id)", async () => {
+		await appendN(30);
+		const { entries } = await listQnaEntries(tmpDir, 20);
+		for (const row of entries) {
+			const fetched = await getQnaEntry(tmpDir, row.id);
+			assert.ok(fetched !== null && fetched !== undefined, `id ${row.id} should resolve`);
+			assert.deepStrictEqual(fetched, stripId(row));
+		}
+	});
+
+	it("limit=1 → single entry with id = total", async () => {
+		await appendN(30);
+		const { entries, total } = await listQnaEntries(tmpDir, 1);
+		assert.strictEqual(total, 30);
+		assert.strictEqual(entries.length, 1);
+		assert.strictEqual(entries[0]!.id, 30);
+	});
+
+	it("limit=0 → empty entries, total N", async () => {
+		await appendN(30);
+		const { entries, total } = await listQnaEntries(tmpDir, 0);
+		assert.deepStrictEqual(entries, []);
+		assert.strictEqual(total, 30);
+	});
+
+	it("empty log → entries [], total 0", async () => {
+		const { entries, total } = await listQnaEntries(tmpDir, 20);
+		assert.deepStrictEqual(entries, []);
+		assert.strictEqual(total, 0);
+	});
+
+	it("query: matches at positions 5 and 27 carry ids [5, 27] and roundtrip", async () => {
+		for (let i = 1; i <= 30; i++) {
+			const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+			const marker = i === 5 || i === 27 ? "quintessential " : "";
+			await appendQnaEntry(tmpDir, ts, `${marker}Entry ${i}`, `Answer ${i}`);
+		}
+
+		const results = await queryQnaEntries(tmpDir, "quintessential");
+		assert.strictEqual(results.length, 2);
+		assert.deepStrictEqual(
+			results.map((e) => e.id),
+			[5, 27],
+		);
+		for (const row of results) {
+			const fetched = await getQnaEntry(tmpDir, row.id);
+			assert.ok(fetched !== null && fetched !== undefined);
+			assert.deepStrictEqual(fetched, stripId(row));
+		}
+	});
+
+	it("rotation: 105 entries → list ids 86..105, get(86) = first listed row, total 105", async () => {
+		await appendN(105); // forces rotateQnaFile at 100
+		const { entries, total } = await listQnaEntries(tmpDir, 20);
+		assert.strictEqual(total, 105);
+		assert.strictEqual(entries.length, 20);
+		assert.strictEqual(entries[0]!.id, 86);
+		assert.strictEqual(entries[entries.length - 1]!.id, 105);
+		const fetched = await getQnaEntry(tmpDir, 86);
+		assert.ok(fetched !== null && fetched !== undefined);
+		assert.deepStrictEqual(fetched, stripId(entries[0]!));
+	});
+
+	it("corrupted line mid-file → ids count parsed entries only and roundtrip", async () => {
+		// Write valid + corrupted + valid directly (ids count parsed entries only)
+		const jsonlPath = path.join(tmpDir, ".pi", "context", "qna.jsonl");
+		await fs.promises.mkdir(path.dirname(jsonlPath), { recursive: true });
+		const valid1 = '{"datetime":"2026-05-15T19:00:00.000Z","question":"Q1","answer":"A1"}\n';
+		const corrupted = "not-json\n";
+		const valid2 = '{"datetime":"2026-05-15T20:00:00.000Z","question":"Q2","answer":"A2"}\n';
+		await fs.promises.writeFile(jsonlPath, valid1 + corrupted + valid2, "utf-8");
+
+		const origWarn = console.warn;
+		console.warn = () => {};
+		try {
+			const { entries, total } = await listQnaEntries(tmpDir, 20);
+			assert.strictEqual(total, 2);
+			assert.deepStrictEqual(
+				entries.map((e) => e.id),
+				[1, 2],
+			);
+			for (const row of entries) {
+				const fetched = await getQnaEntry(tmpDir, row.id);
+				assert.ok(fetched !== null && fetched !== undefined);
+				assert.deepStrictEqual(fetched, stripId(row));
+			}
+		} finally {
+			console.warn = origWarn;
+		}
 	});
 });
 
@@ -1021,8 +1186,9 @@ describe("Empty/missing JSONL file edge cases", () => {
 	});
 
 	it("listQnaEntries returns empty for missing file", async () => {
-		const entries = await listQnaEntries(tmpDir);
+		const { entries, total } = await listQnaEntries(tmpDir);
 		assert.deepStrictEqual(entries, []);
+		assert.strictEqual(total, 0);
 	});
 
 	it("getQnaEntry returns undefined for missing file", async () => {
@@ -1061,8 +1227,9 @@ describe("Empty JSONL file edge cases", () => {
 	});
 
 	it("listQnaEntries returns empty for empty file", async () => {
-		const entries = await listQnaEntries(tmpDir);
+		const { entries, total } = await listQnaEntries(tmpDir);
 		assert.deepStrictEqual(entries, []);
+		assert.strictEqual(total, 0);
 	});
 
 	it("getQnaEntry returns undefined for empty file", async () => {
@@ -1083,6 +1250,7 @@ interface ContentResult {
 function successResult<T extends { datetime: string; question: string; answer: string }>(
 	entries: T[],
 	count: number,
+	total?: number,
 ): ContentResult {
 	return {
 		content: [
@@ -1091,11 +1259,12 @@ function successResult<T extends { datetime: string; question: string; answer: s
 				text: JSON.stringify({
 					entries,
 					count,
+					...(total !== undefined ? { total } : {}),
 					...(entries.length === 0 ? { message: "No Q&A history yet" } : {}),
 				}),
 			},
 		],
-		details: { entries, count },
+		details: { entries, count, ...(total !== undefined ? { total } : {}) },
 	};
 }
 
@@ -1117,6 +1286,28 @@ describe("successResult (ask_user_read success envelope)", () => {
 
 		assert.strictEqual(result.details.count, 2);
 		assert.strictEqual((result.details.entries as Array<unknown>).length, 2);
+	});
+
+	it("includes total field when provided (list action)", () => {
+		const entries = [
+			{ id: 11, datetime: "2026-05-15T19:00:00.000Z", question: "Q1", answer: "A1" },
+			{ id: 12, datetime: "2026-05-15T20:00:00.000Z", question: "Q2", answer: "A2" },
+		];
+		const result = successResult(entries, entries.length, 35);
+
+		const parsed = JSON.parse(result.content[0]!.text);
+		assert.strictEqual(parsed.count, 2);
+		assert.strictEqual(parsed.total, 35, "Payload should carry total history size");
+		assert.strictEqual(parsed.entries[0]!.id, 11, "Entries keep their absolute ids");
+		assert.strictEqual(result.details.total, 35, "Details should carry total too");
+	});
+
+	it("omits total field when not provided (get/query action)", () => {
+		const entry = { datetime: "2026-05-15T19:00:00.000Z", question: "Q1", answer: "A1" };
+		const result = successResult([entry], 1);
+		const parsed = JSON.parse(result.content[0]!.text);
+		assert.ok(!("total" in parsed), "No total for get/query payloads");
+		assert.ok(!("total" in result.details), "No total in details for get/query");
 	});
 
 	it("returns message field when entries array is empty", () => {

--- a/.pi/extensions/ask-user/test/trust-gating.test.mts
+++ b/.pi/extensions/ask-user/test/trust-gating.test.mts
@@ -957,3 +957,39 @@ describe("list/get absolute ids (issue #1614)", () => {
 		}
 	});
 });
+
+// ============================================================================
+// Tests: ask_user_read registration guidance (issue #1614 audit)
+// ============================================================================
+
+// Locks the tool description/guidelines that tell consumers to use the
+// absolute entries[].id for get — never array positions (1..N over a
+// truncated slice). If the guidance regresses to "recent entries / 1-based
+// line number", agents recreate the wrong historical lookup this issue fixes.
+describe("ask_user_read registration guidance (issue #1614)", () => {
+	it("description and guidelines require entries[].id usage and explain total", () => {
+		const { mockPi, tools } = makeMockPi();
+		askUser(mockPi as any);
+
+		const tool = tools["ask_user_read"];
+		assert.ok(tool, "ask_user_read tool must be registered");
+		const guidance = [tool.description, tool.promptSnippet, ...tool.promptGuidelines].join("\n");
+
+		assert.ok(
+			guidance.includes("entries[].id"),
+			"guidance must require consumers to use each returned entries[].id",
+		);
+		assert.ok(
+			guidance.includes("total"),
+			"guidance must explain the total field (full history size)",
+		);
+		assert.ok(
+			/array position|counting rows|1\.\.N/.test(guidance),
+			"guidance must warn against deriving ids from array positions",
+		);
+		assert.ok(
+			!guidance.includes("1-based line number"),
+			"guidance must not describe ids as generic 1-based line numbers",
+		);
+	});
+});

--- a/.pi/extensions/ask-user/test/trust-gating.test.mts
+++ b/.pi/extensions/ask-user/test/trust-gating.test.mts
@@ -828,6 +828,37 @@ describe("list/get absolute ids (issue #1614)", () => {
 		assert.strictEqual(result.details.total, 25);
 	});
 
+	it("ask_user_read fractional limit → integer ids, list-then-get roundtrip", async () => {
+		await appendN(30);
+		const { tools, ctx } = await makeFixture();
+
+		// QnaReadParams.limit is Type.Number, so a fractional value reaches
+		// listQnaEntries; it must be truncated to an integer so payload ids
+		// are integral and resolve through get.
+		const listResult: any = await tools["ask_user_read"].execute(
+			"call1",
+			{ action: "list", limit: 1.5 },
+			null,
+			null,
+			ctx,
+		);
+		const listed = JSON.parse(listResult.content[0]!.text);
+		assert.strictEqual(listed.count, 1, "trunc(1.5) = 1 entry");
+		assert.ok(Number.isInteger(listed.entries[0]!.id), "payload id must be an integer");
+		assert.strictEqual(listed.entries[0]!.id, 30);
+
+		const getResult: any = await tools["ask_user_read"].execute(
+			"call2",
+			{ action: "get", id: listed.entries[0]!.id },
+			null,
+			null,
+			ctx,
+		);
+		const got = JSON.parse(getResult.content[0]!.text);
+		assert.strictEqual(got.entries[0]!.question, "Entry 30");
+		assert.strictEqual(got.entries[0]!.answer, "Answer 30");
+	});
+
 	it("ask_user_read query payload: matched entries carry absolute ids", async () => {
 		await appendN(26, (i) => (i === 5 || i === 20 ? "needle " : ""));
 		const { tools, ctx } = await makeFixture();

--- a/.pi/extensions/ask-user/test/trust-gating.test.mts
+++ b/.pi/extensions/ask-user/test/trust-gating.test.mts
@@ -192,9 +192,16 @@ describe("ask_user_read trust gating", () => {
 		const parsed = JSON.parse(result.content[0]!.text);
 		assert.strictEqual(parsed.count, 2);
 		assert.strictEqual(parsed.entries.length, 2);
+		assert.strictEqual(parsed.total, 2, "list payload must carry total history size");
+		assert.deepStrictEqual(
+			parsed.entries.map((e: any) => e.id),
+			[1, 2],
+			"list payload entries must carry absolute ids",
+		);
 
 		assert.strictEqual(result.details.format, "qna-result-v1");
 		assert.strictEqual(result.details.count, 2);
+		assert.strictEqual(result.details.total, 2);
 		assert.ok(!result.details.untrusted, "untrusted flag should not be present when trusted");
 	});
 
@@ -680,5 +687,242 @@ describe("jsonl-logger defensive trust parameter", () => {
 
 	it("appendQnaEntry still validates even when trusted=false", async () => {
 		await assert.rejects(() => appendQnaEntry(tmpDir, "bad-date", "Q1", "A1", false), /Datetime/);
+	});
+});
+
+// ============================================================================
+// Tests: list/get absolute ids across /qna and ask_user_read (issue #1614)
+// ============================================================================
+
+describe("list/get absolute ids (issue #1614)", () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-user-abs-adapter-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	/** Append N entries; optional marker prefix for specific positions. */
+	async function appendN(n: number, marker?: (i: number) => string): Promise<void> {
+		for (let i = 1; i <= n; i++) {
+			const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+			await appendQnaEntry(tmpDir, ts, `${marker ? marker(i) : ""}Entry ${i}`, `Answer ${i}`);
+		}
+	}
+
+	async function makeFixture(): Promise<{
+		commands: Record<string, any>;
+		messages: Array<{ msg: string; opts?: any }>;
+		tools: Record<string, any>;
+		ctx: any;
+	}> {
+		const { mockPi, commands, messages, tools } = makeMockPi();
+		askUser(mockPi as any);
+		const ctx = {
+			sessionManager: { getCwd: () => tmpDir },
+			isProjectTrusted: async () => true,
+		};
+		return { commands, messages, tools, ctx };
+	}
+
+	it("/qna list with 30 entries renders absolute ids + total footer", async () => {
+		await appendN(30);
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("list", ctx);
+
+		const msg = messages[0]!.msg;
+		assert.ok(
+			msg.includes("| 11 | 2026-01-01T00:00:11.000Z | Entry 11 | Answer 11 |"),
+			"row 1 should be labeled with absolute id 11",
+		);
+		assert.ok(
+			msg.includes("| 30 | 2026-01-01T00:00:30.000Z | Entry 30 | Answer 30 |"),
+			"last row should be labeled with absolute id 30",
+		);
+		assert.ok(msg.includes("Showing #11–#30 of 30"), "footer must show sliced range and total");
+	});
+
+	it("/qna list with fewer entries than limit → ids 1..N and full footer", async () => {
+		await appendN(3);
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("list", ctx);
+
+		const msg = messages[0]!.msg;
+		assert.ok(msg.includes("| 1 | 2026-01-01T00:00:01.000Z | Entry 1 | Answer 1 |"));
+		assert.ok(msg.includes("| 3 | 2026-01-01T00:00:03.000Z | Entry 3 | Answer 3 |"));
+		assert.ok(msg.includes("Showing #1–#3 of 3"), "footer always rendered when list succeeds");
+	});
+
+	it("/qna list empty log → no history message, no table, no footer", async () => {
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("list", ctx);
+
+		assert.strictEqual(messages[0]!.msg, "No Q&A history yet.");
+		assert.ok(!messages[0]!.msg.includes("Showing #"), "no footer for empty log");
+	});
+
+	it("/qna search rows carry absolute match ids and roundtrip through get", async () => {
+		await appendN(26, (i) => (i === 5 || i === 20 ? "needle " : ""));
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("search needle", ctx);
+
+		const msg = messages[0]!.msg;
+		assert.ok(msg.includes("| 5 | 2026-01-01T00:00:05.000Z | needle Entry 5 | Answer 5 |"));
+		assert.ok(msg.includes("| 20 | 2026-01-01T00:00:20.000Z | needle Entry 20 | Answer 20 |"));
+
+		// Displayed id roundtrips through get (shared root cause with list)
+		messages.length = 0;
+		await commands["qna"].handler("get 5", ctx);
+		assert.ok(messages[0]!.msg.includes("needle Entry 5"), "get returns the search-row question");
+		assert.ok(messages[0]!.msg.includes("Answer 5"), "get returns the search-row answer");
+	});
+
+	it("regression: --limit parse (custom honored, invalid falls back to 20)", async () => {
+		await appendN(30);
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("list --limit 5", ctx);
+		assert.ok(
+			messages[0]!.msg.includes("Showing #26–#30 of 30"),
+			"custom limit 5 should show last 5 entries",
+		);
+
+		messages.length = 0;
+		await commands["qna"].handler("list --limit abc", ctx);
+		assert.ok(
+			messages[0]!.msg.includes("Showing #11–#30 of 30"),
+			"invalid limit falls back to default 20",
+		);
+	});
+
+	it("ask_user_read list payload: per-entry ids, count and total (truncated)", async () => {
+		await appendN(25);
+		const { tools, ctx } = await makeFixture();
+
+		const result: any = await tools["ask_user_read"].execute(
+			"call1",
+			{ action: "list", limit: 20 },
+			null,
+			null,
+			ctx,
+		);
+
+		const parsed = JSON.parse(result.content[0]!.text);
+		assert.strictEqual(parsed.count, 20);
+		assert.strictEqual(parsed.total, 25, "payload carries full history size");
+		assert.deepStrictEqual(
+			parsed.entries.map((e: any) => e.id),
+			Array.from({ length: 20 }, (_, i) => i + 6),
+			"ids are absolute (6..25 for last 20 of 25)",
+		);
+		for (const e of parsed.entries) {
+			assert.ok(typeof e.id === "number" && e.datetime && e.question && e.answer);
+		}
+		assert.strictEqual(result.details.total, 25);
+	});
+
+	it("ask_user_read query payload: matched entries carry absolute ids", async () => {
+		await appendN(26, (i) => (i === 5 || i === 20 ? "needle " : ""));
+		const { tools, ctx } = await makeFixture();
+
+		const result: any = await tools["ask_user_read"].execute(
+			"call1",
+			{ action: "query", text: "needle" },
+			null,
+			null,
+			ctx,
+		);
+
+		const parsed = JSON.parse(result.content[0]!.text);
+		assert.strictEqual(parsed.count, 2, "count == number of matches");
+		assert.deepStrictEqual(
+			parsed.entries.map((e: any) => e.id),
+			[5, 20],
+			"query results keep absolute ids",
+		);
+	});
+
+	it("ask_user_read get payload unchanged; list-then-get roundtrip with payload ids", async () => {
+		await appendN(30);
+		const { tools, ctx } = await makeFixture();
+
+		const listResult: any = await tools["ask_user_read"].execute(
+			"call1",
+			{ action: "list", limit: 5 },
+			null,
+			null,
+			ctx,
+		);
+		const listed = JSON.parse(listResult.content[0]!.text);
+		assert.strictEqual(listed.entries.length, 5);
+		const firstId: number = listed.entries[0]!.id;
+		assert.strictEqual(firstId, 26, "first of last 5 of 30");
+
+		const getResult: any = await tools["ask_user_read"].execute(
+			"call2",
+			{ action: "get", id: firstId },
+			null,
+			null,
+			ctx,
+		);
+		const got = JSON.parse(getResult.content[0]!.text);
+		assert.strictEqual(got.count, 1);
+		assert.strictEqual(got.entries[0]!.datetime, "2026-01-01T00:00:26.000Z");
+		assert.strictEqual(got.entries[0]!.question, "Entry 26");
+		assert.strictEqual(got.entries[0]!.answer, "Answer 26");
+		assert.ok(!("id" in got.entries[0]), "get payload entry shape has no id (unchanged)");
+	});
+
+	it("human journey: displayed row id → /qna get returns same question/answer", async () => {
+		await appendN(30);
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("list", ctx);
+		assert.ok(
+			messages[0]!.msg.includes("| 11 | 2026-01-01T00:00:11.000Z | Entry 11 | Answer 11 |"),
+		);
+
+		messages.length = 0;
+		await commands["qna"].handler("get 11", ctx);
+		assert.ok(messages[0]!.msg.includes("Entry 11"), "get shows the row-11 question");
+		assert.ok(messages[0]!.msg.includes("Answer 11"), "get shows the row-11 answer");
+	});
+
+	it("regression: get 0 → usage; get 999 → not found; context-dir-as-file → error surfaced", async () => {
+		await appendN(5);
+		const { commands, messages, ctx } = await makeFixture();
+
+		await commands["qna"].handler("get 0", ctx);
+		assert.ok(messages[0]!.msg.includes("positive number"), "id < 1 shows usage");
+
+		messages.length = 0;
+		await commands["qna"].handler("get 999", ctx);
+		assert.strictEqual(messages[0]!.msg, "Entry #999 not found.");
+
+		// .pi/context replaced by a regular file → list error surfaces
+		messages.length = 0;
+		const fileDir = fs.mkdtempSync(path.join(os.tmpdir(), "ask-user-abs-file-"));
+		try {
+			await fs.promises.mkdir(path.join(fileDir, ".pi"), { recursive: true });
+			await fs.promises.writeFile(path.join(fileDir, ".pi", "context"), "not a dir", "utf-8");
+			const fileCtx = {
+				sessionManager: { getCwd: () => fileDir },
+				isProjectTrusted: async () => true,
+			};
+			await commands["qna"].handler("list", fileCtx);
+			assert.ok(
+				messages[0]!.msg.startsWith("Error reading Q&A history"),
+				`list error surfaced, got: ${messages[0]!.msg}`,
+			);
+		} finally {
+			fs.rmSync(fileDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/.pi/extensions/ask-user/types.ts
+++ b/.pi/extensions/ask-user/types.ts
@@ -40,6 +40,15 @@ export interface QnaEntry {
 }
 
 /**
+ * A Q&A entry tagged with its absolute 1-based id — its position in the
+ * full merged history (archives + active file). `getQnaEntry` consumes the
+ * same numbering, so list/search rows are always `get`-able.
+ */
+export interface QnaListedEntry extends QnaEntry {
+	id: number;
+}
+
+/**
  * Schema for the ask_user_read tool parameters.
  * Uses TypeBox for runtime validation.
  */

--- a/.pi/extensions/ask-user/types.ts
+++ b/.pi/extensions/ask-user/types.ts
@@ -64,7 +64,8 @@ export const QnaReadParams = Type.Object({
 	),
 	id: Type.Optional(
 		Type.Number({
-			description: "1-based line number of the entry (used with get action)",
+			description:
+				"Absolute id of the entry to fetch — the id value that list and query return with each entry. Do not count rows or array positions: they do not match absolute ids when the list is truncated.",
 		}),
 	),
 	text: Type.Optional(


### PR DESCRIPTION
## ✅ Pipeline Complete — Issue #1614

| Agent | Status | Duration | Tokens | Tools | Model |
|-------|--------|----------|--------|-------|-------|
| architect | ✓ SUCCESS | 4m 5s | 31.0K | 9 | deepseek-v4-flash |
| test-designer | ✓ SUCCESS | 3m 42s | 42.2K | 10 | deepseek-v4-flash |
| developer | ✗ FAILED | 30m 0s | 87.0K | 43 | deepseek-v4-flash |
| developer | ✓ SUCCESS (after retry) | 11m 46s | 37.4K | 25 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 13s | 83.3K | 40 | gpt-5.6-luna |
| developer | ✓ SUCCESS | 3m 57s | 42.2K | 24 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 2m 33s | 129.0K | 31 | gpt-5.6-luna |
| developer | ✓ SUCCESS | 2m 35s | 39.7K | 21 | deepseek-v4-flash |
| auditor | ✓ SUCCESS | 1m 58s | 59.4K | 20 | gpt-5.6-luna |

**Total:** 9 runs · 62m 49s · 551.3K tokens · 223 tool calls · 17 failed (8%)
**Issue:** https://github.com/SchneiderDaniel/cheasee-pi/issues/1614
Closes #1614